### PR TITLE
Use sample id from primary, add metastat view

### DIFF
--- a/darwin/pom.xml
+++ b/darwin/pom.xml
@@ -88,9 +88,13 @@
             <artifactId>db2jcc4</artifactId>
             <version>4.19.26</version>
         </dependency>
+    <dependency>
+	  <groupId>com.fasterxml.jackson.core</groupId>
+	  <artifactId>jackson-databind</artifactId>
+	</dependency>
         <dependency>
             <groupId>org.mskcc.cmo.ks.redcap.source</groupId>
-            <artifactId>data_source</artifactId>
+            <artifactId>redcap_source</artifactId>
             <version>0.1.0</version>
         </dependency>
     </dependencies>

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantClinicalCompositeRecord.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantClinicalCompositeRecord.java
@@ -1,0 +1,46 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.mskcc.cmo.ks.darwin.pipeline.model;
+
+/**
+ *
+ * @author heinsz
+ */
+public class Skcm_mskcc_2015_chantClinicalCompositeRecord {
+    
+    private Skcm_mskcc_2015_chantClinicalRecord record;
+    private String sampleRecord;
+    private String patientRecord;
+    
+    public Skcm_mskcc_2015_chantClinicalCompositeRecord() {}
+    public Skcm_mskcc_2015_chantClinicalCompositeRecord(Skcm_mskcc_2015_chantClinicalRecord record) {
+        this.record = record;
+    }
+    
+    public Skcm_mskcc_2015_chantClinicalRecord getRecord() {
+        return this.record;
+    }
+    
+    public void setRecord(Skcm_mskcc_2015_chantClinicalRecord record) {
+        this.record = record;
+    }
+    
+    public String getSampleRecord() {
+        return sampleRecord;
+    }
+    
+    public void setSampleRecord(String sampleRecord) {
+        this.sampleRecord = sampleRecord;
+    }
+    
+    public String getPatientRecord() {
+        return patientRecord;
+    }
+    
+    public void setPatientRecord(String patientRecord) {
+        this.patientRecord = patientRecord;
+    }
+}

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantClinicalRecord.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantClinicalRecord.java
@@ -112,6 +112,10 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     private String meliTumorType;
     private String meliPrimarySite;
     private String meliMetSite;
+    private String melmsPtid;
+    private String melmsSiteTypeDesc;
+    private String melmsSiteDesc;
+    private String melmsSiteYear;
     
     
     private Map<String, Object> additionalProperties;    
@@ -184,7 +188,11 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
             String meliProcedureYear,
             String meliTumorType,
             String meliPrimarySite,
-            String meliMetSite) {
+            String meliMetSite,
+            String melmsPtid,
+            String melmsSiteTypeDesc,
+            String melmsSiteDesc,
+            String melmsSiteYear) {
 this.melspcPtid = StringUtils.isNotEmpty(melspcPtid) ? melspcPtid : "NA";
 this.melspcStageYear = StringUtils.isNotEmpty(melspcStageYear) ? melspcStageYear : "NA";
 this.melspcStgGrpName = StringUtils.isNotEmpty(melspcStgGrpName) ? melspcStgGrpName : "NA";
@@ -252,14 +260,15 @@ this.meliProcedureYear = StringUtils.isNotEmpty(meliProcedureYear) ? meliProcedu
 this.meliTumorType = StringUtils.isNotEmpty(meliTumorType) ? meliTumorType : "NA";
 this.meliPrimarySite = StringUtils.isNotEmpty(meliPrimarySite) ? meliPrimarySite : "NA";
 this.meliMetSite = StringUtils.isNotEmpty(meliMetSite) ? meliMetSite : "NA";
+this.melmsPtid = StringUtils.isNotEmpty(melmsPtid) ? melmsPtid : "NA";
+this.melmsSiteTypeDesc = StringUtils.isNotEmpty(melmsSiteTypeDesc) ? melmsSiteTypeDesc : "NA";
+this.melmsSiteDesc = StringUtils.isNotEmpty(melmsSiteDesc) ? melmsSiteDesc : "NA";
+this.melmsSiteYear = StringUtils.isNotEmpty(melmsSiteYear) ? melmsSiteYear : "NA";
     }
     
     public String getPATIENT_ID() {
         if (patientId != null) {
             return patientId;
-        }
-        else if (!meliPtid.equals("NA")) {
-            return meliPtid;
         }
         else if (!melspcPtid.equals("NA")) {
             return melspcPtid;
@@ -267,8 +276,11 @@ this.meliMetSite = StringUtils.isNotEmpty(meliMetSite) ? meliMetSite : "NA";
         else if (!melgPtid.equals("NA")) {
             return melgPtid;
         }        
-        else {
+        else if (!melpPtid.equals("NA")) {
             return melpPtid;
+        }
+        else {
+            return melmsPtid;
         }
     }
     
@@ -277,9 +289,15 @@ this.meliMetSite = StringUtils.isNotEmpty(meliMetSite) ? meliMetSite : "NA";
     }
     
     public String getSAMPLE_ID() {
-        if (patientId != null) {
-            return patientId;
+        if (sampleId != null) {
+            return sampleId;
         }
+        else if (!meliDmpSampleId.equals("NA")) {
+            return meliDmpSampleId;
+        }        
+        else if (!melpPrimSeq.equals("NA")) {
+            return melpPtid + "_" + melpPrimSeq;
+        }        
         else if (!melspcPtid.equals("NA")) {
             return melspcPtid;
         }
@@ -287,7 +305,7 @@ this.meliMetSite = StringUtils.isNotEmpty(meliMetSite) ? meliMetSite : "NA";
             return melgPtid;
         }
         else {
-            return melpPtid;
+            return melmsPtid;
         }
     }
     
@@ -831,6 +849,38 @@ this.meliMetSite = StringUtils.isNotEmpty(meliMetSite) ? meliMetSite : "NA";
         this.meliMetSite = meliMetSite;
     }
     
+    public String getMELMS_PTID() {
+        return melmsPtid;
+    }
+    
+    public void setMELMS_PTID(String melmsPtid) {
+        this.melmsPtid = melmsPtid;
+    }
+    
+    public String getMELMS_SITE_TYPE_DESC() {
+        return melmsSiteTypeDesc;
+    }
+    
+    public void setMELMS_SITE_TYPE_DESC(String melmsSiteTypeDesc) {
+        this.melmsSiteTypeDesc = melmsSiteTypeDesc;
+    }
+    
+    public String getMELMS_SITE_DESC() {
+        return melmsSiteDesc;
+    }
+    
+    public void setMELMS_SITE_DESC(String melmsSiteDesc) {
+        this.melmsSiteDesc = melmsSiteDesc;
+    }
+
+    public String getMELMS_SITE_YEAR() {
+        return melmsSiteYear;
+    }
+    
+    public void setMELMS_SITE_YEAR(String melmsSiteYear) {
+        this.melmsSiteYear = melmsSiteYear;
+    }    
+    
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
@@ -901,7 +951,21 @@ this.meliMetSite = StringUtils.isNotEmpty(meliMetSite) ? meliMetSite : "NA";
         fieldNames.add("MELI_TUMOR_TYPE");
         fieldNames.add("MELI_PRIMARY_SITE");
         fieldNames.add("MELI_MET_SITE");
+        fieldNames.add("MELMS_SITE_TYPE_DESC");
+        fieldNames.add("MELMS_SITE_DESC");
+        fieldNames.add("MELMS_SITE_YEAR");
 
+        return fieldNames;
+    }
+    
+    public List<String> getAllVariables() {
+        List<String> fieldNames = getFieldNames();
+        fieldNames.add("MELSPC_PTID");
+        fieldNames.add("MELP_PTID");
+        fieldNames.add("MELG_PTID");
+        fieldNames.add("MELI_PTID");
+        fieldNames.add("MELMS_PTID");
+        
         return fieldNames;
     }
     

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalPatientProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalPatientProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.skcm_mskcc_2015_chantclinical;
+
+import org.mskcc.cmo.ks.darwin.pipeline.model.*;
+
+import java.util.*;
+import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
+import org.mskcc.cmo.ks.redcap.source.MetadataManager;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ *
+ * @author heinsz
+ */
+public class Skcm_mskcc_2015_chantClinicalPatientProcessor implements ItemProcessor<Skcm_mskcc_2015_chantClinicalCompositeRecord, Skcm_mskcc_2015_chantClinicalCompositeRecord> {
+    @Autowired
+    public MetadataManager metadataManager;
+    @Autowired
+     public ClinicalDataSource clinicalDataSource;    
+    @Override
+    public Skcm_mskcc_2015_chantClinicalCompositeRecord process(final Skcm_mskcc_2015_chantClinicalCompositeRecord melanomaClinicalCompositeRecord) throws Exception{
+        Skcm_mskcc_2015_chantClinicalRecord melanomaClinicalRecord = melanomaClinicalCompositeRecord.getRecord();
+        List<String> header =  melanomaClinicalRecord.getFieldNames();
+        Map<String, List<String>> fullHeader = metadataManager.getFullHeader(header);
+        
+        List<String> record = new ArrayList<>();
+        for (String field : melanomaClinicalRecord.getFieldNames()) {
+            String value = melanomaClinicalRecord.getClass().getMethod("get" + field).invoke(melanomaClinicalRecord).toString();
+            Set<String> uniqueValues = new HashSet(Arrays.asList(value.split("\\|")));            
+            List<String> values = Arrays.asList(value.split("\\|"));
+            if (fullHeader.get("attribute_types").get(header.indexOf(field)).equals("PATIENT")) { 
+                if (uniqueValues.size() == 1) {
+                    record.add(values.get(0));
+                }
+                else {
+                    record.add(value);
+                 }
+            }
+        }
+        melanomaClinicalCompositeRecord.setPatientRecord(StringUtils.join(record, "\t"));
+        return melanomaClinicalCompositeRecord;
+    }
+}

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalPatientWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalPatientWriter.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.skcm_mskcc_2015_chantclinical;
+
+import org.mskcc.cmo.ks.darwin.pipeline.model.*;
+import org.mskcc.cmo.ks.redcap.source.MetadataManager;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.core.io.*;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.io.*;
+import java.util.*;
+import java.nio.file.Paths;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ *
+ * @author heinsz
+ */
+public class Skcm_mskcc_2015_chantClinicalPatientWriter implements ItemStreamWriter<Skcm_mskcc_2015_chantClinicalCompositeRecord> {
+    
+    @Value("#{jobParameters[outputDirectory]}")
+    private String outputDirectory;    
+    
+    @Value("${darwin.skcm_mskcc_2015_chant_clinical_patient_filename}")
+    private String filename;    
+    
+    @Autowired
+    public MetadataManager metadataManager;
+    
+    private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
+    private String stagingFile;    
+    
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        PassThroughLineAggregator aggr = new PassThroughLineAggregator();
+        flatFileItemWriter.setLineAggregator(aggr);
+        flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback(){
+            @Override
+            public void writeHeader(Writer writer) throws IOException {
+                List<String> header = new Skcm_mskcc_2015_chantClinicalRecord().getFieldNames();
+                Map<String, List<String>> fullHeader = metadataManager.getFullHeader(header);
+                writer.write("#" + getMetaLine(fullHeader.get("display_names"), fullHeader).replace("\n", "") + "\n");
+                writer.write("#" + getMetaLine(fullHeader.get("descriptions"), fullHeader).replace("\n", "") + "\n");
+                writer.write("#" + getMetaLine(fullHeader.get("datatypes"), fullHeader).replace("\n", "") + "\n");
+                writer.write("#" + getMetaLine(fullHeader.get("priorities"), fullHeader).replace("\n", "") + "\n");
+                writer.write( getMetaLine(fullHeader.get("header"), fullHeader).replace("\n", "") + "\n");
+            }
+        });
+        stagingFile = Paths.get(outputDirectory).resolve(filename).toString();
+        flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
+        flatFileItemWriter.open(executionContext);
+    }
+    
+    @Override
+    public void update(ExecutionContext executionContext) throws ItemStreamException {}
+    
+    @Override
+    public void close() throws ItemStreamException {
+        flatFileItemWriter.close();
+    }
+    
+    @Override
+    public void write(List<? extends Skcm_mskcc_2015_chantClinicalCompositeRecord> items) throws Exception {
+        List<String> writeList = new ArrayList<>();
+        for (Skcm_mskcc_2015_chantClinicalCompositeRecord result : items) {
+            String patientLine = result.getPatientRecord();
+            writeList.add(patientLine.replace("\n", ""));
+        }
+        
+        flatFileItemWriter.write(writeList);
+    }
+    
+    private String getMetaLine(List<String> metaData, Map<String, List<String>> header) {
+        List<String> attributeTypes = header.get("attribute_types");
+        List<String> metaDataToWrite = new ArrayList<>();
+        for (int i = 0; i < metaData.size(); i++) {
+            if (attributeTypes.get(i).equals("PATIENT")) {
+                metaDataToWrite.add(metaData.get(i));
+            }
+        }
+        
+        return StringUtils.join(metaDataToWrite, "\t");        
+    }
+    
+}

--- a/darwin/src/main/resources/application.properties.EXAMPLE
+++ b/darwin/src/main/resources/application.properties.EXAMPLE
@@ -15,10 +15,12 @@ darwin.password=
 darwin.chunk_size=10
 darwin.demographics_view=DEMOGRAPHICS_V
 darwin.latest_activity_view=LATEST_ACTIVITY_V
-darwin.skcm_mskcc_2015_chant_staging_path_current=MEL_STAGING_PATH_CURR_V
-darwin.skcm_mskcc_2015_chant_general=MEL_GENERAL_V
-darwin.skcm_mskcc_2015_chant_primary=MEL_PRIMARY_V
-darwin.skcm_mskcc_2015_chant_systemic_tx=MEL_SYSTEMIC_TX_V
+darwin.skcm_mskcc_2015_chant.staging_path_current_view=MEL_STAGING_PATH_CURR_V
+darwin.skcm_mskcc_2015_chant.general_view=MEL_GENERAL_V
+darwin.skcm_mskcc_2015_chant.primary_view=MEL_PRIMARY_V
+darwin.skcm_mskcc_2015_chant.impact_view=MEL_IMPACT_V
+darwin.skcm_mskcc_2015_chant.metastat_sites_view=MEL_METASTAT_SITES_V
+darwin.skcm_mskcc_2015_chant.systemic_tx=MEL_SYSTEMIC_TX_V
 darwin.demographics_filename=data_clinical_supp_darwin_demographics.txt
 darwin.skcm_mskcc_2015_chant_clinical_filename=data_clinical_supp_darwin_skcm_mskcc_2015_chant.txt
 darwin.skcm_mskcc_2015_chant_timeline_filename=data_timeline_skcm_mskcc_2015_chant_txt
@@ -35,5 +37,6 @@ darwin.clinical_filename=data_clinical_supp_caisis_gbm.txt
 
 # For redcap metadata clinical attributes header generation
 metadata_project=
+namespace_project=
 
 #NOTE: runs with two settings, -d </path/to/output_directory> -s [Cancer Study ID (mskimpact for default)]


### PR DESCRIPTION
- Adding view DVCBIO.MEL_METASTAT_SITES_V
- Use sample id from IMPACT view and use primary key in the primary view correctly.
- Composite processing for sample and patient clinical data.
- Bugfix to pom to fix intermittent failure to interact with redcap