### PR TITLE
Implement usage of namespace project

### DIFF
--- a/redcap/pom.xml
+++ b/redcap/pom.xml
@@ -12,10 +12,8 @@
     <version>0.1.0</version>
   </parent>
   <packaging>pom</packaging>
-
   <modules>
     <module>redcap_source</module> 
     <module>redcap_pipeline</module> 
   </modules>
-    
 </project>

--- a/redcap/redcap_pipeline/src/main/resources/application.properties.EXAMPLE
+++ b/redcap/redcap_pipeline/src/main/resources/application.properties.EXAMPLE
@@ -3,4 +3,6 @@ redcap_url=
 mapping_token=
 # The name of the project that contains the metadata about the clinical attributes in redcap
 metadata_project=
+# The name of the project that contains the namespace mapping of external column headers to normalized
+namespace_project=
 chunk=10

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/models/RedcapToken.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/models/RedcapToken.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "study_id",    
     "api_token",
     "stable_id",
-    "id_mapping_complete"
+    "my_first_instrument_complete"
 })
 public class RedcapToken {
 
@@ -31,8 +31,8 @@ public class RedcapToken {
     private String apiToken;
     @JsonProperty("stable_id")
     private String stableId;
-    @JsonProperty("id_mapping_complete")
-    private String idMappingComplete;
+    @JsonProperty("my_first_instrument_complete")
+    private String myFirstInstrumentComplete;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
@@ -45,17 +45,16 @@ public class RedcapToken {
 
     /**
     * 
-    * @param recordId
     * @param studyId
     * @param apiToken
     * @param stableId
-    * @param idMappingComplete
+    * @param myFirstInstrumentComplete
     */
-    public RedcapToken(String studyId, String apiToken, String stableId, String idMappingComplete) {
+    public RedcapToken(String studyId, String apiToken, String stableId, String myFirstInstrumentComplete) {
         this.studyId = studyId;
         this.apiToken = apiToken;
         this.stableId = stableId;
-        this.idMappingComplete = idMappingComplete;
+        this.myFirstInstrumentComplete = myFirstInstrumentComplete;
     }
     
     /**
@@ -90,7 +89,7 @@ public class RedcapToken {
 
     /**
     * 
-    * @param token
+    * @param apiToken
     * The api_token
     */
     @JsonProperty("api_token")
@@ -121,21 +120,21 @@ public class RedcapToken {
     /**
     * 
     * @return
-    * The idMappingComplete
+    * The myFirstInstrumentComplete
     */
-    @JsonProperty("id_mapping_complete")
-    public String getIdMappingComplete() {
-        return idMappingComplete;
+    @JsonProperty("my_first_instrument_complete")
+    public String getMyFirstInstrumentComplete() {
+        return myFirstInstrumentComplete;
     }
 
     /**
     * 
-    * @param idMappingComplete
-    * The id_mapping_complete
+    * @param myFirstInstrumentComplete
+    * The my_first_instrument_complete
     */
-    @JsonProperty("id_mapping_complete")
-    public void setIdMappingComplete(String idMappingComplete) {
-        this.idMappingComplete = idMappingComplete;
+    @JsonProperty("my_first_instrument_complete")
+    public void setMyFirstInstrumentComplete(String myFirstInstrumentComplete) {
+        this.myFirstInstrumentComplete = myFirstInstrumentComplete;
     }
 
     @JsonAnyGetter


### PR DESCRIPTION
- Use the namespace dictionary in redcap to map external columns names to our normalized ones.
- Cleaned up how the uri variables are created.

Reviewers:
@n1zea144, @angelicaochoa  