### PR TITLE
Externalized Consume Samples Job

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/consume/ConsumeSampleReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/consume/ConsumeSampleReader.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.cmo.pipelines.cvr.consume;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.model.CVRData;
+import org.cbioportal.cmo.pipelines.cvr.model.CVRMergedResult;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.batch.item.NonTransientResourceException;
+import org.springframework.batch.item.ParseException;
+import org.springframework.batch.item.UnexpectedInputException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class ConsumeSampleReader implements ItemStreamReader<String> {
+
+    @Value("#{jobParameters[jsonFilename]}")
+    private String jsonFilename;
+    
+    @Autowired
+    public CVRUtilities cvrUtilities;
+    
+    private List<String> cvrSampleList = new ArrayList();
+    
+    Logger log = Logger.getLogger(ConsumeSampleReader.class);
+    
+    @Override
+    public void open(ExecutionContext ec) throws ItemStreamException {
+        CVRData cvrData = new CVRData();        
+        // load cvr data from cvr_data.json file
+        File cvrFile = new File(jsonFilename);
+        try {
+            cvrData = cvrUtilities.readJson(cvrFile);
+        } catch (IOException e) {
+            log.error("Error reading file: " + cvrFile.getName());
+            throw new ItemStreamException(e);
+        }
+        // add samples to list
+        List<String> sampleList = new ArrayList();
+        for (CVRMergedResult result : cvrData.getResults()) {
+            sampleList.add(result.getMetaData().getDmpSampleId());
+        }
+        this.cvrSampleList = sampleList;
+    }
+
+    @Override
+    public void update(ExecutionContext ec) throws ItemStreamException {}
+
+    @Override
+    public void close() throws ItemStreamException {}
+
+    @Override
+    public String read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
+        if (!cvrSampleList.isEmpty()) {
+            return cvrSampleList.remove(0);
+        }
+        return null;
+    }
+    
+}

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/consume/ConsumeSampleWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/consume/ConsumeSampleWriter.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.cmo.pipelines.cvr.consume;
+
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.model.CVRConsumeSample;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamWriter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class ConsumeSampleWriter implements ItemStreamWriter<String> {
+    
+    @Value("#{jobParameters[jsonFilename]}")
+    private String jsonFilename;
+    
+    @Value("${dmp.server_name}")
+    private String dmpServerName;
+    
+    @Value("${dmp.tokens.consume_sample}")
+    private String dmpConsumeSample;
+    
+    @Value("${dmp.tokens.consume_gml_sample}")
+    private String dmpConsumeGmlSample;
+    
+    @Value("#{jobParameters[sessionId]}")
+    private String sessionId;
+    
+    @Value("#{jobParameters[testingMode]}")
+    private boolean testingMode;
+    
+    @Autowired
+    public CVRUtilities cvrUtilities;
+    
+    private String dmpConsumeUrl;
+    
+    Logger log = Logger.getLogger(ConsumeSampleWriter.class);
+    
+    @Override
+    public void open(ExecutionContext ec) throws ItemStreamException {
+        // determine which dmp server url to use based on the file basename
+        this.dmpConsumeUrl = dmpServerName;
+        if (jsonFilename.contains(cvrUtilities.CVR_FILE)) {
+            this.dmpConsumeUrl += dmpConsumeSample;
+        }
+        else if (jsonFilename.contains(cvrUtilities.GML_FILE)) {
+            this.dmpConsumeUrl += dmpConsumeGmlSample;
+        }
+        this.dmpConsumeUrl += "/" + sessionId + "/";
+    }
+
+    @Override
+    public void update(ExecutionContext ec) throws ItemStreamException {}
+
+    @Override
+    public void close() throws ItemStreamException {}
+
+    @Override
+    public void write(List<? extends String> sampleIdList) throws Exception {
+        for (String sampleId : sampleIdList) {
+            if (testingMode) {
+                log.info("[TESTING MODE]: sample id will not be consumed: " + sampleId);
+            }
+            else {
+                consumeSample(sampleId);
+            }            
+        }
+    }
+    
+    private void consumeSample(String sampleId) {
+        HttpEntity requestEntity = getRequestEntity();
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<CVRConsumeSample> responseEntity;
+        try {
+            responseEntity = restTemplate.exchange(dmpConsumeUrl + sampleId, HttpMethod.GET, requestEntity, CVRConsumeSample.class);
+            if (responseEntity.getBody().getaffectedRows()==0) {
+                String message = "No consumption for sample " + sampleId;
+                log.warn(message);
+            }
+            if (responseEntity.getBody().getaffectedRows()>1) {
+                String message = "Multple samples consumed (" + responseEntity.getBody().getaffectedRows() + ") for sample " + sampleId;
+                log.warn(message);
+            }
+            if (responseEntity.getBody().getaffectedRows()==1) {
+                String message = "Sample "+ sampleId +" consumed succesfully";
+                log.info(message);
+            }
+        } catch (org.springframework.web.client.RestClientException e) {
+            log.error("Error consuming sample " + sampleId + "(" + e + ")");
+        }
+    }
+    
+    private HttpEntity getRequestEntity() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return new HttpEntity<Object>(headers);
+    }
+    
+}


### PR DESCRIPTION
* added Job, Step, Reader, and Writer for consuming samples given a CVR json filename
* removed the consumeSample() methods from `CVRVariantsProcessor` and `GMLVariantsProcessor`

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>