### PR TITLE
Email util to send error messages when failures occur

### DIFF
--- a/cvr/pom.xml
+++ b/cvr/pom.xml
@@ -41,6 +41,16 @@
       <artifactId>annotator</artifactId>
       <version>0.1.0</version>
     </dependency>
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>mail</artifactId>
+      <version>1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
@@ -64,6 +64,7 @@ public class BatchConfiguration {
     public static final String GML_JOB = "gmlJob";
     public static final String GML_JSON_JOB = "gmlJsonJob";
     public static final String CONSUME_SAMPLES_JOB = "consumeSamplesJob";
+    public static final String EMAIL_UTIL= "EmailUtil";
 
     @Autowired
     public JobBuilderFactory jobBuilderFactory;

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/EmailUtil.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/EmailUtil.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.cbioportal.cmo.pipelines.cvr;
+import java.util.*;
+import java.util.Properties;
+import javax.mail.*;
+import javax.mail.internet.*;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+/**
+ *
+ * @author heinsz
+ */
+@Configuration
+public class EmailUtil {
+
+    @Value("${email.server}")
+    private  String server;
+    @Value("${email.sender}")
+    private  String sender;
+    @Value("${email.subject}")
+    private  String subject;
+    @Value("${email.recipient}")
+    private  String recipient;
+
+    private Session session;
+    private Properties properties;
+
+    @Bean
+    public EmailUtil EmailUtil() {
+        return new EmailUtil();
+    }
+
+    public EmailUtil() {
+        properties = System.getProperties();
+        session = Session.getDefaultInstance(properties);
+    }
+
+    public  void sendErrorEmail(List<Throwable> exceptions, String parameters) {
+        try {
+            properties.setProperty("mail.smtp.host", server);
+            MimeMessage message = new MimeMessage(session);
+            message.setFrom(new InternetAddress(sender));
+            message.addRecipient(Message.RecipientType.TO, new InternetAddress(recipient));
+            message.setSubject(subject);
+            String body = "An error occured while running the CVR Pipeline with job parameters " + parameters + ".\n\n";
+            List<String> messages = new ArrayList<>();
+            for (Throwable exception : exceptions) {
+                messages.add(ExceptionUtils.getFullStackTrace(exception));
+            }
+            body += StringUtils.join(messages, "\n\n");
+            message.setText(body);
+            Transport.send(message);
+        }
+        catch (MessagingException mex) {
+            mex.printStackTrace();
+        }
+    }
+}

--- a/cvr/src/main/resources/application.properties.EXAMPLE
+++ b/cvr/src/main/resources/application.properties.EXAMPLE
@@ -24,3 +24,9 @@ dmp.tokens.consume_gml_sample=gml_cbio_consume_sample
 genomenexus.base_url=
 genomenexus.hgvs=variant_annotation/hgvs/
 genomenexus.isoform_override=variant_annotation/isoform_override/
+
+# email properties
+email.server=localhost
+email.sender=
+email.recipient=
+email.subject=Failure in CVR Pipeline


### PR DESCRIPTION
- Exit status of 1 on failures
- Email sent with stack trace, email parameters set in properties file.

Example of email:

Subject: Failure in CVR Pipeline
Body:
An error occured while running the CVR Pipeline with job parameters {stagingDirectory=/data/zack/cbio-portal-data/msk-impact/hemepact/, studyId=hemepact, sessionId=34055fbc0372ff91f3ad43333fa7fc5edeaf3853, skipSeg=false}.

org.springframework.batch.item.ItemStreamException: org.springframework.batch.item.file.FlatFileParseException: Parsing error at line: 3 in resource=[file [/data/zack/cbio-portal-data/msk-impact/hemepact/data_mutations_extended.txt]], input=[BCL2	0	MSKCC	GRCh37	18	60985883	60985883	+	Missense_Mutation	SNP	C	C	G			P-0017076-T01-IH3									Unknown	SOMATIC				MSK-IMPACT			1054	251	1365	0	ENST00000333681.4:c.17G>C	p.Arg6Thr	p.R6T	ENST00000333681		6	aGa/aCa	0	NEWRECORD]
	at org.cbioportal.cmo.pipelines.cvr.mutation.CVRMutationDataReader.open(CVRMutationDataReader.java:164)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:317)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:190)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157)
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.doProceed(DelegatingIntroductionInterceptor.java:133)
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.invoke(DelegatingIntroductionInterceptor.java:121)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:207)
	at com.sun.proxy.$Proxy44.open(Unknown Source)
	at org.springframework.batch.item.support.CompositeItemStream.open(CompositeItemStream.java:96)
	at org.springframework.batch.core.step.tasklet.TaskletStep.open(TaskletStep.java:310)
	at org.springframework.batch.core.step.AbstractStep.execute(AbstractStep.java:197)
	at org.springframework.batch.core.job.SimpleStepHandler.handleStep(SimpleStepHandler.java:148)
	at org.springframework.batch.core.job.AbstractJob.handleStep(AbstractJob.java:392)
	at org.springframework.batch.core.job.SimpleJob.doExecute(SimpleJob.java:135)
	at org.springframework.batch.core.job.AbstractJob.execute(AbstractJob.java:306)
	at org.springframework.batch.core.launch.support.SimpleJobLauncher$1.run(SimpleJobLauncher.java:135)
	at org.springframework.core.task.SyncTaskExecutor.execute(SyncTaskExecutor.java:50)
	at org.springframework.batch.core.launch.support.SimpleJobLauncher.run(SimpleJobLauncher.java:128)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:317)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:190)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157)
	at org.springframework.batch.core.configuration.annotation.SimpleBatchConfiguration$PassthruAdvice.invoke(SimpleBatchConfiguration.java:127)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:207)
	at com.sun.proxy.$Proxy41.run(Unknown Source)
	at org.cbioportal.cmo.pipelines.CVRPipeline.launchCvrPipelineJob(CVRPipeline.java:106)
	at org.cbioportal.cmo.pipelines.CVRPipeline.main(CVRPipeline.java:155)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:53)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.springframework.batch.item.file.FlatFileParseException: Parsing error at line: 3 in resource=[file [/data/zack/cbio-portal-data/msk-impact/hemepact/data_mutations_extended.txt]], input=[BCL2	0	MSKCC	GRCh37	18	60985883	60985883	+	Missense_Mutation	SNP	C	C	G			P-0017076-T01-IH3									Unknown	SOMATIC				MSK-IMPACT			1054	251	1365	0	ENST00000333681.4:c.17G>C	p.Arg6Thr	p.R6T	ENST00000333681		6	aGa/aCa	0	NEWRECORD]
	at org.springframework.batch.item.file.FlatFileItemReader.doRead(FlatFileItemReader.java:183)
	at org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader.read(AbstractItemCountingItemStreamItemReader.java:88)
	at org.cbioportal.cmo.pipelines.cvr.mutation.CVRMutationDataReader.open(CVRMutationDataReader.java:144)
	... 41 more
Caused by: org.springframework.batch.item.file.transform.IncorrectTokenCountException: Incorrect number of tokens found in record: expected 44 actual 45
	at org.springframework.batch.item.file.transform.AbstractLineTokenizer.tokenize(AbstractLineTokenizer.java:125)
	at org.springframework.batch.item.file.mapping.DefaultLineMapper.mapLine(DefaultLineMapper.java:43)
	at org.springframework.batch.item.file.FlatFileItemReader.doRead(FlatFileItemReader.java:180)
	... 43 more

@angelicaochoa @sheridancbio 