### PR TITLE
REDCap Pipelines fix

### DIFF
--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/RedcapPipeline.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/RedcapPipeline.java
@@ -52,8 +52,9 @@ public class RedcapPipeline {
     {
         Options gnuOptions = new Options();
         gnuOptions.addOption("h", "help", false, "shows this help document and quits.")
-            .addOption("p", "redcap_project", true, "Redcap Project Name")
-            .addOption("d", "directory", true, "Output directory");
+            .addOption("p", "redcap_project", true, "Redcap Project stable ID")
+            .addOption("d", "directory", true, "Output directory")
+            .addOption("m", "merge-datasources", false, "Flag for merging datasources for given stable ID");
 
         return gnuOptions;
     }
@@ -65,7 +66,7 @@ public class RedcapPipeline {
         System.exit(exitStatus);
     }
 
-    private static void launchJob(String[] args, String project, String directory) throws Exception
+    private static void launchJob(String[] args, String project, String directory, boolean mergeClinicalDataSources) throws Exception
     {
         SpringApplication app = new SpringApplication(RedcapPipeline.class);      
         ConfigurableApplicationContext ctx = app.run(args);
@@ -73,10 +74,11 @@ public class RedcapPipeline {
         JobParameters jobParameters = new JobParametersBuilder()
                 .addString("redcap_project", project)
                 .addString("directory", directory)
-                    .toJobParameters();  
+                .addString("mergeClinicalDataSources", String.valueOf(mergeClinicalDataSources))
+                .toJobParameters();
              
-            Job redcapJob= ctx.getBean(BatchConfiguration.REDCAP_JOB, Job.class);       
-            JobExecution jobExecution = jobLauncher.run(redcapJob, jobParameters);                
+        Job redcapJob= ctx.getBean(BatchConfiguration.REDCAP_JOB, Job.class);
+        JobExecution jobExecution = jobLauncher.run(redcapJob, jobParameters);    
 
     }
     
@@ -90,6 +92,6 @@ public class RedcapPipeline {
             !commandLine.hasOption("redcap_project")) {
             help(gnuOptions, 0);
         }
-        launchJob(args, commandLine.getOptionValue("redcap_project"), commandLine.getOptionValue("directory"));
+        launchJob(args, commandLine.getOptionValue("redcap_project"), commandLine.getOptionValue("directory"), commandLine.hasOption("m"));
     }    
 }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataStepListener.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataStepListener.java
@@ -32,6 +32,6 @@ public class ClinicalDataStepListener implements StepExecutionListener {
         if (clinicalDataSource.hasMoreTimelineData()) {
             return new ExitStatus("TIMELINE");
         }
-        return new ExitStatus("FINISHED");
+        return ExitStatus.COMPLETED;
     }
 }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalPatientDataProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalPatientDataProcessor.java
@@ -32,7 +32,7 @@
 package org.mskcc.cmo.ks.redcap.pipeline;
 
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.batch.item.ItemProcessor;
 
@@ -45,22 +45,20 @@ public class ClinicalPatientDataProcessor implements ItemProcessor<ClinicalDataC
     @Value("#{stepExecutionContext['patientHeader']}")
     private Map<String, List<String>> total_header;
     
-    private final Logger log = Logger.getLogger(ClinicalPatientDataProcessor.class);
-    
     @Override
     public ClinicalDataComposite process(ClinicalDataComposite composite) throws Exception {        
-        String to_write = "";
+        List<String> record = new ArrayList();
         List<String> header = total_header.get("header");
         
-        to_write += composite.getData().get("PATIENT_ID") + "\t";
+        record.add(composite.getData().get("PATIENT_ID"));
         
         for(String column : header) {
             if (!column.equals("PATIENT_ID")) {
-                to_write += composite.getData().get(column) + "\t";
+                record.add(composite.getData().getOrDefault(column, ""));
             }            
         }                        
         
-        composite.setPatientResult(to_write);        
+        composite.setPatientResult(StringUtils.join(record, "\t"));
         return composite;
     }       
 }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalSampleDataProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalSampleDataProcessor.java
@@ -32,7 +32,7 @@
 package org.mskcc.cmo.ks.redcap.pipeline;
 
 import java.util.*;
-import org.apache.log4j.Logger;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -44,25 +44,24 @@ public class ClinicalSampleDataProcessor implements ItemProcessor<Map<String, St
     
     @Value("#{stepExecutionContext['sampleHeader']}")
     private Map<String, List<String>> total_header;
-    
-    private final Logger log = Logger.getLogger(ClinicalSampleDataProcessor.class);
-    
+        
     @Override
     public ClinicalDataComposite process(Map<String, String> i) throws Exception {
         ClinicalDataComposite composite = new ClinicalDataComposite(i);
-        String to_write = "";
+        List<String> record = new ArrayList();
         List<String> header = total_header.get("header");
         
         // get the sample and patient ids first before processing the other columns
-        to_write= i.get("SAMPLE_ID") + "\t" + i.get("PATIENT_ID") + "\t";                      
+        record.add(i.get("SAMPLE_ID"));
+        record.add(i.get("PATIENT_ID"));       
         
         for(String column : header) {
             if(!column.equals("SAMPLE_ID")) {
-                to_write += i.get(column) + "\t";
+                record.add(i.getOrDefault(column, ""));
             }
         }        
         
-        composite.setSampleResult(to_write);        
+        composite.setSampleResult(StringUtils.join(record, "\t"));
         return composite;
     }       
 }


### PR DESCRIPTION
Processors were adding extra tabs at the end of a line, creating more fields in a file than there are headers.

Pipeline would write a patient and/or sample clinical file even when there isn't any corresponding data for the given file. Now if a REDCap project doesn't have one or the other, the corresponding clinical file will not be generated anymore.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>