### PR TITLE
Add where condition looking at sample suffix based on studyid

### DIFF
--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/DarwinPipeline.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/DarwinPipeline.java
@@ -46,9 +46,9 @@ import org.apache.log4j.Logger;
  */
 @SpringBootApplication
 public class DarwinPipeline {
-    
+
     private static Logger log = Logger.getLogger(DarwinPipeline.class);
-    
+
     private static Options getOptions(String[] args){
         Options gnuOptions = new Options();
         gnuOptions.addOption("h", "help", false, "shows this help document and quits.")
@@ -56,20 +56,19 @@ public class DarwinPipeline {
         .addOption("s", "study", true, "Cancer Study ID");
         return gnuOptions;
     }
-    
+
     private static void help(Options gnuOptions, int exitStatus){
         HelpFormatter helpFormatter = new HelpFormatter();
         helpFormatter.printHelp("Darwin Pipeline", gnuOptions);
         System.exit(exitStatus);
     }
-    
-    
+
     private static void launchJob(String[] args, String outputDirectory, String studyID) throws Exception{
         SpringApplication app = new SpringApplication(DarwinPipeline.class);
 
         ConfigurableApplicationContext ctx = app.run(args);
         JobLauncher jobLauncher = ctx.getBean(JobLauncher.class);
-       
+
         Job job;
         JobParameters jobParameters = new JobParametersBuilder()
                 .addString("outputDirectory", outputDirectory)
@@ -81,9 +80,9 @@ public class DarwinPipeline {
                 break;
             case "skcm_mskcc_2015_chant":
                 job = ctx.getBean(BatchConfiguration.SKCM_MSKCC_2015_CHANT_JOB, Job.class);
-				break;
+                break;
             default:
-                job = null;
+                job = ctx.getBean(BatchConfiguration.MSK_JOB, Job.class);
                 break;
         }
         if (job!=null){
@@ -92,11 +91,11 @@ public class DarwinPipeline {
         else{
             log.fatal("Failed to start DarwinPipeline");
         }
-        
+
         log.info("Shutting down DarwinPipeline");
         ctx.close();
     }
-    
+
     public static void main(String[] args) throws Exception{
         Options gnuOptions = DarwinPipeline.getOptions(args);
         CommandLineParser parser = new GnuParser();
@@ -106,10 +105,7 @@ public class DarwinPipeline {
             !commandLine.hasOption("study")){
             help(gnuOptions, 0);
         }
-        
+
         launchJob(args, commandLine.getOptionValue("directory"), commandLine.getOptionValue("study"));
     }
-            
-        
-    
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/DarwinConfiguration.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/DarwinConfiguration.java
@@ -35,11 +35,11 @@ import com.ibm.db2.jcc.DB2SimpleDataSource;
 import com.querydsl.sql.SQLQueryFactory;
 import com.querydsl.sql.DB2Templates;
 import java.sql.SQLException;
+import java.util.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 /**
  *
  * @author jake
@@ -47,35 +47,33 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 @Configuration
 @PropertySource("classpath:application.properties")
 public class DarwinConfiguration {
-    
+
     @Value("${darwin.username}")
     private String username;
-        
+
     @Value("${darwin.password}")
     private String password;
-    
+
     @Value("${darwin.server}")
     private String server;
-    
+
     @Value("${darwin.port}")
     private Integer port;
-    
+
     @Value("${darwin.database}")
     private String database;
-    
+
     @Value("${darwin.schema}")
     private String schema;
-    
-        
+
+
     @Bean
     public SQLQueryFactory darwinQueryFactory() throws SQLException{
         DB2Templates templates = new DB2Templates();
         com.querydsl.sql.Configuration config = new com.querydsl.sql.Configuration(templates);
-        return new SQLQueryFactory(config, darwinDataSource()); 
+        return new SQLQueryFactory(config, darwinDataSource());
     }
-    
-    
-    
+
     public DB2SimpleDataSource darwinDataSource(){
         DB2SimpleDataSource dataSource = new DB2SimpleDataSource();
         dataSource.setPortNumber(port);
@@ -86,6 +84,15 @@ public class DarwinConfiguration {
         dataSource.setServerName(server);
         dataSource.setDriverType(4);
         return dataSource;
-    }    
-    
+    }
+
+    @Bean(name="studyIdRegexMap")    
+    public Map<String, String> studyIdRegexMap() {
+        Map<String, String> studyIdRegexMap = new HashMap<>();
+        studyIdRegexMap.put("mskimpact", "%-IM%");
+        studyIdRegexMap.put("mskimpact_heme", "%-IH%");
+        studyIdRegexMap.put("mskarcher", "%-AR%");
+        studyIdRegexMap.put("raindance", "%-TS%");
+        return studyIdRegexMap;
+    }
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPathologyDmp.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPathologyDmp.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016-2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.model;
+
+/**
+ *
+ * @author heinsz
+ */
+public class MskimpactPathologyDmp {
+    private String ptIdPathDmp;
+    private String rptIdPathDmp;
+    private String dmpIdPathDmp;
+    private String sampleIdPathDmp;
+
+    public MskimpactPathologyDmp() {}
+
+    public String getPT_ID_PATH_DMP() {
+        return ptIdPathDmp;
+    }
+
+    public void setPT_ID_PATH_DMP(String ptIdPathDmp) {
+        this.ptIdPathDmp = ptIdPathDmp;
+    }
+
+    public String getRPT_ID_PATH_DMP() {
+        return rptIdPathDmp;
+    }
+
+    public void setRPT_ID_PATH_DMP(String rptIdPathDmp) {
+        this.rptIdPathDmp = rptIdPathDmp;
+    }
+
+    public String getDMP_ID_PATH_DMP() {
+        return dmpIdPathDmp;
+    }
+
+    public void setDMP_ID_PATH_DMP(String dmpIdPathDmp) {
+        this.dmpIdPathDmp = dmpIdPathDmp;
+    }
+
+    public String getSAMPLE_ID_PATH_DMP() {
+        return sampleIdPathDmp;
+    }
+
+    public void setSAMPLE_ID_PATH_DMP(String sampleIdPathDmp) {
+        this.sampleIdPathDmp = sampleIdPathDmp;
+    }
+}

--- a/darwin/src/main/resources/application.properties.EXAMPLE
+++ b/darwin/src/main/resources/application.properties.EXAMPLE
@@ -15,6 +15,7 @@ darwin.password=
 darwin.chunk_size=10
 darwin.demographics_view=DEMOGRAPHICS_V
 darwin.latest_activity_view=LATEST_ACTIVITY_V
+darwin.pathology_dmp_view=PATHOLOGY_DMP_V
 darwin.skcm_mskcc_2015_chant.staging_path_current_view=MEL_STAGING_PATH_CURR_V
 darwin.skcm_mskcc_2015_chant.general_view=MEL_GENERAL_V
 darwin.skcm_mskcc_2015_chant.primary_view=MEL_PRIMARY_V


### PR DESCRIPTION
We need to now split the data we get back from darwin demographics by panel assay. To do this, we need to join on another table `DVCBIO.PATHOLOGY_DMP_V` and filter on the `SAMPLE_ID_PATH_DMP` column.

The logic used for filtering is done with an sql `like` predicate in our select. This is the mapping of study id to the like predicate:
"mskimpact", "%-IM%"
"mskimpact_heme", "%-IH%"
"mskarcher", "%-AR%"
"raindance", "%-TS%"

I also did some code cleanup (replace tabs with spaces, removed trailing whitespace) on the files I touched.

@n1zea144 @angelicaochoa 