### PR TITLE
Link study id to DMP retrieve variants token

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/SessionConfiguration.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/SessionConfiguration.java
@@ -32,6 +32,7 @@
 
 package org.cbioportal.cmo.pipelines.cvr;
 
+import java.util.*;
 import org.apache.log4j.Logger;
 import org.cbioportal.cmo.pipelines.cvr.model.CVRSession;
 import org.springframework.beans.factory.annotation.Value;
@@ -70,6 +71,18 @@ public class SessionConfiguration {
 
     @Value("${dmp.tokens.create_gml_session}")
     private String gmlCreateSession;
+    
+    @Value("${dmp.tokens.retrieve_variants.impact}")
+    private String retrieveVariantsImpact;
+    
+    @Value("${dmp.tokens.retrieve_variants.rdts}")
+    private String retrieveVariantsRaindance;
+    
+    @Value("${dmp.tokens.retrieve_variants.heme}")
+    private String retrieveVariantsHeme;
+    
+    @Value("${dmp.tokens.retrieve_variants.archer}")
+    private String retrieveVariantsArcher;
 
     Logger log = Logger.getLogger(SessionConfiguration.class);
 
@@ -111,6 +124,21 @@ public class SessionConfiguration {
             log.error("Unable to secure connection");
             return "NA";
         }
+    }
+    
+    /**
+     * Maps a study id to it's dmp retrieve variants token.
+     * @return 
+     */
+    @Bean(name="retrieveVariantTokensMap")
+    public Map<String, String> retrieveVariantTokensMap() {
+        Map<String, String> map = new HashMap<>();
+        map.put("mskimpact", retrieveVariantsImpact);
+        map.put("raindance", retrieveVariantsRaindance);
+        map.put("hemepact", retrieveVariantsHeme);
+        map.put("mskarcher", retrieveVariantsArcher);
+        
+        return map;
     }
 
     private HttpEntity getRequestEntity() {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/variants/CVRVariantsReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/variants/CVRVariantsReader.java
@@ -33,6 +33,7 @@
 package org.cbioportal.cmo.pipelines.cvr.variants;
 
 import java.util.*;
+import javax.annotation.Resource;
 import org.cbioportal.cmo.pipelines.cvr.model.*;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -51,19 +52,23 @@ public class CVRVariantsReader implements ItemStreamReader<CVRVariants> {
 
     @Value("#{jobParameters[sessionId]}")
     private String sessionId;
+    
+    @Value("#{jobParameters[studyId]}")
+    private String studyId;
 
     @Value("${dmp.server_name}")
     private String dmpServerName;
-
-    @Value("${dmp.tokens.retrieve_variants}")
-    private String dmpRetreiveVariants;
+    
+    @Resource(name="retrieveVariantTokensMap")
+    private Map<String, String> retrieveVariantTokensMap;
 
     private List<CVRVariants> cvrVariants = new ArrayList<CVRVariants>();
 
     // Calls cbio_retrieve_variants against CVR web service
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
-        String dmpUrl = dmpServerName + dmpRetreiveVariants + "/" + sessionId + "/0";
+        // get retrieve variants token by study id
+        String dmpUrl = dmpServerName + retrieveVariantTokensMap.get(studyId) + "/" + sessionId + "/0";
         RestTemplate restTemplate = new RestTemplate();
         HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = getRequestEntity();
         ResponseEntity<CVRVariants> responseEntity = restTemplate.exchange(dmpUrl, HttpMethod.GET, requestEntity, CVRVariants.class);

--- a/cvr/src/main/resources/application.properties.EXAMPLE
+++ b/cvr/src/main/resources/application.properties.EXAMPLE
@@ -9,12 +9,14 @@ dmp.user_name=
 dmp.password=
 dmp.tokens.create_session=create_session
 dmp.tokens.create_gml_session=create_gml_session
-#select one of the following dmp.tokens.retrieve_variants lines:
-#dmp.tokens.retrieve_variants=cbio_retrieve_variants
-#dmp.tokens.retrieve_variants=cbio_rdts_retrieve_variants
-#dmp.tokens.retrieve_variants=cbio_retrieve_heme_variants
-#dmp.tokens.retrieve_variants=cbio_archer_retrieve_variants
+
+# dmp tokens for retrieving variants
+dmp.tokens.retrieve_variants.impact=cbio_retrieve_variants
+dmp.tokens.retrieve_variants.rdts=cbio_rdts_retrieve_variants
+dmp.tokens.retrieve_variants.heme=cbio_retrieve_heme_variants
+dmp.tokens.retrieve_variants.archer=cbio_archer_retrieve_variants
 dmp.tokens.retrieve_gml_variants=gml_cbio_retrieve_variants
+
 dmp.tokens.retrieve_segment_data=get_seg_data
 dmp.tokens.retrieve_gml_segment_data=gml_get_seg_data
 dmp.tokens.consume_sample=cbio_consume_sample


### PR DESCRIPTION
Study ID's are now linked to specific DMP tokens for retrieving variants. This is to avoid having to modify `application.properties` and re-build jars for each study we are retrieving data for.

**PLEASE NOTE:** This PR requires changes to `application.properties` !

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>