### PR TITLE
Generalize import temporary study

### DIFF
--- a/import-scripts/import-dmp-impact-data.sh
+++ b/import-scripts/import-dmp-impact-data.sh
@@ -26,8 +26,7 @@ $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,add
 echo "cleaning all clinical & timeline data files - replacing carriage returns with newlines..."
 files=$(ls $MSK_IMPACT_DATA_HOME/data_clinical*)
 files="$files $(ls $MSK_IMPACT_DATA_HOME/data_timeline*)"
-for file in $files
-do
+for file in $files; do
 	tmp_file="$file.tmp"
 	tr '\r' '\n' < $file > $tmp_file
 	mv $tmp_file $file
@@ -54,25 +53,21 @@ $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,add
 cd $MSK_HEMEPACT_DATA_HOME;$HG_BINARY commit -m "Latest MSK-IMPACT Dataset: Darwin heme"
 
 DB_VERSION_FAIL=0
-IMPORT_STATUS=0
-IMPORT_FAIL=0
-VALIDATION_FAIL=0
-DELETE_FAIL=0
-RENAME_BACKUP_FAIL=0
-RENAME_FAIL=0
-GROUPS_FAIL=0
-SUCCESS=0
+IMPORT_STATUS_IMPACT=0
+IMPORT_STATUS_HEME=0
+IMPORT_STATUS_RAINDANCE=0
+IMPORT_STATUS_MIXEDPACT=0
+#IMPORT_STATUS_ARCHER=0
 MERGE_FAIL=0
-MIXEDPACT_IMPORT_FAIL=0
+IMPORT_FAIL_MIXEDPACT=0
 
 # fetch new/updated IMPACT samples using CVR Web service   (must come after mercurial fetching) 
 echo "fetching samples from CVR Web service  ..."
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -d $MSK_IMPACT_DATA_HOME -i mskimpact
-if [ $? -gt 0 ]
-then
+if [ $? -gt 0 ]; then
 	echo "CVR fetch failed!"
 	cd $MSK_IMPACT_DATA_HOME;$HG_BINARY revert --all --no-backup;rm *.orig
-	IMPORT_STATUS=1
+	IMPORT_STATUS_IMPACT=1
 else
 	echo "committing cvr data"
 	cd $MSK_IMPACT_DATA_HOME;$HG_BINARY commit -m "Latest MSK-IMPACT Dataset: CVR"
@@ -81,11 +76,10 @@ fi
 # fetch new/updated IMPACT germline samples using CVR Web service   (must come after normal cvr fetching) 
 echo "fetching CVR GML data ..."
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -d $MSK_IMPACT_DATA_HOME -g -i mskimpact
-if [ $? -gt 0 ]
-then
+if [ $? -gt 0 ]; then
 	echo "CVR Germline fetch failed!"
 	cd $MSK_IMPACT_DATA_HOME;$HG_BINARY revert --all --no-backup;rm *.orig
-	IMPORT_STATUS=1
+	IMPORT_STATUS_IMPACT=1
 else
 	echo "committing CVR germline data"
 	cd $MSK_IMPACT_DATA_HOME;$HG_BINARY commit -m "Latest MSK-IMPACT Dataset: CVR Germline"
@@ -93,11 +87,11 @@ fi
 
 # fetch new/updated raindance samples using CVR Web service (must come after mercurial fetching). The -s flag skips segment data fetching
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -d $MSK_RAINDANCE_DATA_HOME -s -i mskraindance
-if [ $? -gt 0 ]
-then
+if [ $? -gt 0 ]; then
 	echo "CVR raindance fetch failed!"
 	echo "This will not affect importing of mskimpact"
 	cd $MSK_RAINDANCE_DATA_HOME;$HG_BINARY revert --all --no-backup;rm *.orig
+	IMPORT_STATUS_RAINDANCE=1
 else
 	# raindance does not provide copy number or fusions data.
 	echo "removing unused files"
@@ -107,11 +101,11 @@ fi
 
 echo "fetching CVR heme data ..."
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -d $MSK_HEMEPACT_DATA_HOME -i mskimpact_heme
-if [ $? -gt 0 ]
-then
+if [ $? -gt 0 ]; then
       echo "CVR heme fetch failed!"
       echo "This will not affect importing of mskimpact"
       cd $MSK_HEMEPACT_DATA_HOME;$HG_BINARY revert --all --no-backup;rm *.orig
+      IMPORT_STATUS_HEME=1
 else
       cd $MSK_HEMEPACT_DATA_HOME;$HG_BINARY commit -m "Latest heme dataset"
 fi
@@ -143,97 +137,72 @@ cd $MSK_IMPACT_DATA_HOME;$HG_BINARY add;$HG_BINARY commit -m "Latest MSK-IMPACT 
 # check database version before importing anything
 echo "Checking if database version is compatible"
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --check-db-version
-if [ $? -gt 0 ]
-then
+if [ $? -gt 0 ]; then
     echo "Database version expected by portal does not match version in database!"
     DB_VERSION_FAIL=1
-    IMPORT_STATUS=1
+    IMPORT_STATUS_IMPACT=1
 fi    
 
-if [ $DB_VERSION_FAIL -eq 0 ]
-then 
+if [ $DB_VERSION_FAIL -eq 0 ]; then 
     # import into portal database
     echo "importing cancer type updates into msk portal database..."
     $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --import-types-of-cancer
 fi
 
+# Temp study importer arguments
+# (1): cancer study id [ mskimpact | mskimpact_heme | mskraindance | mskarcher | mixedpact ]
+# (2): temp study id [ temporary_mskimpact | temporary_mskimpact_heme | temporary_mskraindance | temporary_mskarcher | temporary_mixedpact ]
+# (3): backup study id [ yesterday_mskimpact | yesterday_mskimpact_heme | yesterday_mskraindance | yesterday_mskarcher | yesterday_mixedpact ]
+# (4): portal name [ mskimpact-portal | mskheme-portal | mskraindance-portal | mskarcher-portal | mixedpact-portal ]
+# (5): study path [ $MSK_IMPACT_DATA_HOME | $MSK_HEMEPACT_DATA_HOME | $MSK_RAINDANCE_DATA_HOME | $MSK_ARCHER_DATA_HOME | $MSK_MIXEDPACT_DATA_HOME ]
+# (6): notification file [ $mskimpact_notification_file | $mskheme_notification_file | $mskraindance_notification_file | $mixedpact_notification_file ]
+# (7): tmp directory
+# (8): email list
+# (9): importer jar
 
-## use flag to import under temporary id
-
-if [ $IMPORT_STATUS -eq 0 ]
-then
-	echo "Importing temporary mskimpact..."
-	$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --update-study-data --portal mskimpact-portal --notification-file "$mskimpact_notification_file" --temporary-id temporary_mskimpact
-	if [ -f "$tmp/num_studies_updated.txt" ]
-	then
-		num_studies_updated=`cat $tmp/num_studies_updated.txt`
-	else
-		num_studies_updated=0
-	fi
-	if [ "$num_studies_updated" -ne 1 ]
-	then
-		echo "Failed to import mskimpact!"
-		IMPORT_FAIL=1
-	else
-		# validate
-		echo "validating..."
-		$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --validate-temp-study --temp-study-id temporary_mskimpact --original-study-id mskimpact
-		if [ $? -gt 0 ]
-		then
-			echo "Failed to validate - deleting temp study"
-			$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --delete-cancer-study --cancer-study-ids temporary_mskimpact
-			VALIDATION_FAIL=1
-		else
-			echo "Successful validation - renaming mskimpact and temp studies"
-			$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --delete-cancer-study --cancer-study-ids yesterday_mskimpact
-			if [ $? -gt 0 ]
-			then
-				echo "Failed to delete cancer study yesterday_mskimpact!"
-				DELETE_FAIL=1
-			else
-				echo "Renaming mksimpact to yesterday_mskimpact"
-				$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --rename-cancer-study --new-study-id yesterday_mskimpact --original-study-id mskimpact
-				if [ $? -gt 0 ]
-				then
-					echo "Failed to rename old mskimpact study to yesterday!"
-					RENAME_BACKUP_FAIL=1
-				else
-					echo "Updating groups of yesterday_mskimpact to KSBACKUP"
-					$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --update-groups --cancer-study-ids yesterday_mskimpact --groups "KSBACKUP"
-					if [ $? -gt 0 ]
-					then
-						echo "Failed to change groups!"
-						GROUPS_FAIL=1
-					fi
-					echo "renaming temporary_mskimpact to mskimpact"
-					$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --rename-cancer-study --new-study-id mskimpact --original-study-id temporary_mskimpact
-					SUCCESS=1
-					if [ $? -gt 0 ]
-					then
-						echo "Failed to rename temp study to mskimpact!"
-						RENAME_FAIL=1
-					else
-						echo "Consuming samples from cvr"
-						$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -c $MSK_IMPACT_DATA_HOME/cvr_data.json
-					fi
-				fi
-			fi
-		fi
-	fi
-
+## TEMP STUDY IMPORT: MSKIMPACT
+if [ $IMPORT_STATUS_IMPACT -eq 0 ]; then
+	bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskimpact" --temp-study-id="temporary_mskimpact" --backup-study-id="yesterday_mskimpact" --portal-name="mskimpact-portal" --study-path="$MSK_IMPACT_DATA_HOME" --notification-file="$mskimpact_notification_file" --tmp-directory="$tmp" --email-list="$email_list" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar"
 else
-    if [ $DB_VERSION_FAIL -gt 0 ]
-    then
-        echo "Not importing - database version is not compatible"
+    if [ $DB_VERSION_FAIL -gt 0 ]; then
+        echo "Not importing mskimpact - database version is not compatible"
     else
-    	echo "Not importing - something went wrong with a fetch"
+    	echo "Not importing mskimpact - something went wrong with a fetch"
     fi
 fi
 
-echo "Importing mskimpact heme..."
-$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --update-study-data --portal mskheme-portal --notification-file "$mskheme_notification_file"
-#echo "Importing mskimpact raindance..."
-#$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --update-study-data --portal mskraindance-portal --notification-file "$mskraindance_notification_file"
+## TEMP STUDY IMPORT: MSKIMPACT_HEME
+if [ $IMPORT_STATUS_HEME -eq 0 ]; then
+	bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskimpact_heme" --temp-study-id="temporary_mskimpact_heme" --backup-study-id="yesterday_mskimpact_heme" --portal-name="mskheme-portal" --study-path="$MSK_HEMEPACT_DATA_HOME" --notification-file="$mskheme_notification_file" --tmp-directory="$tmp" --email-list="$email_list" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar"
+else
+    if [ $DB_VERSION_FAIL -gt 0 ]; then
+        echo "Not importing mskimpact_heme - database version is not compatible"
+    else
+    	echo "Not importing mskimpact_heme - something went wrong with a fetch"
+    fi
+fi
+
+## TEMP STUDY IMPORT: MSKRAINDANCE
+if [ $IMPORT_STATUS_RAINDANCE -eq 0 ]; then
+	bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskraindance" --temp-study-id="temporary_mskraindance" --backup-study-id="yesterday_mskraindance" --portal-name="mskraindance-portal" --study-path="$MSK_RAINDANCE_DATA_HOME" --notification-file="$mskraindance_notification_file" --tmp-directory="$tmp" --email-list="$email_list" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar"
+else
+    if [ $DB_VERSION_FAIL -gt 0 ]; then
+        echo "Not importing mskraindance - database version is not compatible"
+    else
+    	echo "Not importing mskraindance - something went wrong with a fetch"
+    fi
+fi
+
+## TEMP STUDY IMPORT: MSKARCHER
+# if [ $IMPORT_STATUS_ARCHER -eq 0 ]; then
+# 	bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskarcher" --temp-study-id="temporary_mskarcher" --backup-study-id="yesterday_mskarcher" --portal-name="mskarcher-portal" --study-path="$MSK_ARCHER_DATA_HOME" --notification-file="$mskarcher_notification_file" --tmp-directory="$tmp" --email-list="$email_list" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar"
+# else
+#     if [ $DB_VERSION_FAIL -gt 0 ]; then
+#         echo "Not importing mskarcher - database version is not compatible"
+#     else
+#     	echo "Not importing mskarcher - something went wrong with a fetch"
+#     fi
+# fi
 
 
 ## MSK-IMPACT, HEMEPACT, and RAINDANCE merge
@@ -299,17 +268,17 @@ fi
 # update MIXEDPACT in portal only if merge and case list updates were succesful
 if [ $MERGE_FAIL -eq 0 ]; then
     echo "Importing MIXEDPACT study..."
-	$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --update-study-data --portal mixedpact-portal --notification-file "$mixedpact_notification_file" 
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mixedpact" --temp-study-id="temporary_mixedpact" --backup-study-id="yesterday_mixedpact" --portal-name="mixedpact-portal" --study-path="$MSK_MIXEDPACT_DATA_HOME" --notification-file="$mixedpact_notification_file" --tmp-directory="$tmp" --email-list="$email_list" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar"
     if [ $? -gt 0 ]; then 
-        echo "MIXEDPACT import failed!"
-        MIXEDPACT_IMPORT_FAIL=1
+        IMPORT_FAIL_MIXEDPACT=1
     fi
 else
-    MIXEDPACT_IMPORT_FAIL=1
+	echo "Something went wrong with merging clinical studies."
+    IMPORT_FAIL_MIXEDPACT=1
 fi
 
 # commit or revert changes for MIXEDPACT
-if [ $MIXEDPACT_IMPORT_FAIL -gt 0 ]; then
+if [ $IMPORT_FAIL_MIXEDPACT -gt 0 ]; then
     echo "MIXEDPACT merge and/or updates failed! Reverting data to last commit."
     cd $MSK_MIXEDPACT_DATA_HOME;$HG_BINARY revert --all --no-backup;
     rm $MSK_MIXEDPACT_DATA_HOME/*.orig
@@ -321,8 +290,7 @@ fi
 ## END MSK-IMPACT, HEMEPACT, and RAINDANCE merge
 
 # redeploy war
-if [ $num_studies_updated -gt 0 ]
-then
+if [ $num_studies_updated -gt 0 ]; then
 	echo "'$num_studies_updated' studies have been updated, requesting redeployment of msk portal war..."
 	ssh -i $HOME/.ssh/id_rsa_tomcat_restarts_key cbioportal_importer@dashi.cbio.mskcc.org touch /srv/data/portal-cron/msk-tomcat-restart
 	ssh -i $HOME/.ssh/id_rsa_tomcat_restarts_key cbioportal_importer@dashi2.cbio.mskcc.org touch /srv/data/portal-cron/msk-tomcat-restart
@@ -339,75 +307,22 @@ cd $MSK_IMPACT_DATA_HOME;$HG_BINARY push
 
 EMAIL_BODY="The MSKIMPACT database version is incompatible. Imports will be skipped until database is updated."
 # send email if db version isn't compatible
-if [ $DB_VERSION_FAIL -gt 0 ]
-then
+if [ $DB_VERSION_FAIL -gt 0 ]; then
     echo -e "Sending email $EMAIL_BODY"
     echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Update Failure: DB version is incompatible" $email_list
 fi
 
 EMAIL_BODY="The MSKIMPACT study failed fetch. The original study will remain on the portal."
 # send email if fetch fails
-if [ $IMPORT_FAIL -gt 0 ]
-then
+if [ $IMPORT_STATUS_IMPACT -gt 0 ]; then
 	echo -e "Sending email $EMAIL_BODY"
 	echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Fetch Failure: Import" $email_list
-fi
-
-EMAIL_BODY="The MSKIMPACT study failed import. The original study will remain on the portal."
-# send email if import fails
-if [ $IMPORT_FAIL -gt 0 ]
-then
-	echo -e "Sending email $EMAIL_BODY"
-	echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Update Failure: Import" $email_list
-fi
-
-EMAIL_BODY="The MSKIMPACT study failed to pass the validation step in import process. The original study will remain on the portal."
-# send email if validation fails
-if [ $VALIDATION_FAIL -gt 0 ]
-then
-	echo -e "Sending email $EMAIL_BODY"
-	echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Update Failure: Validation" $email_list
-fi
-
-EMAIL_BODY="The yesterday_mskimpact study failed to delete. MSKIMPACT study did not finish updating."
-if [ $DELETE_FAIL -gt 0 ]
-then
-	echo -e "Sending email $EMAIL_BODY"
-	echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Update Failure: Deletion" $email_list
-fi
-
-
-EMAIL_BODY="Failed to backup mskimpact to yesterday_mskimpact via renaming. MSKIMPACT study did not finish updating."
-if [ $RENAME_BACKUP_FAIL -gt 0 ]
-then
-	echo -e "Sending email $EMAIL_BODY"
-	echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Update Failure: Renaming backup" $email_list
-fi
-
-EMAIL_BODY="Failed to rename temp study temporary_mskimpact to mskimpact. MSKIMPACT study did not finish updating."
-if [ $RENAME_FAIL -gt 0 ]
-then
-	echo -e "Sending email $EMAIL_BODY"
-	echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Update Failure: CRITICAL!! Renaming" $email_list
-fi
-
-EMAIL_BODY="Failed to update groups for backup study."
-if [ $GROUPS_FAIL -gt 0 ]
-then
-	echo -e "Sending email $EMAIL_BODY"
-	echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Update Failure: Groups update" $email_list
 fi
 
 EMAIL_BODY="Failed to merge MSK-IMPACT and HEMEPACT data. Merged study will not be updated."
 if [ $MERGE_FAIL -gt 0 ]; then
     echo -e "Sending email $EMAIL_BODY"
     echo -e "$EMAIL_BODY" |  mail -s "MIXEDPACT Merge Failure: Study will not be updated." $email_list
-fi
-
-EMAIL_BODY="Failed to import MIXEDPACT study."
-if [ $MIXEDPACT_IMPORT_FAIL -gt 0 ]; then
-    echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "MIXEDPACT Import Failure: Study will not be updated." $email_list
 fi
 
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --send-update-notification --portal mskimpact-portal --notification-file "$mskimpact_notification_file"

--- a/import-scripts/import-temp-study.sh
+++ b/import-scripts/import-temp-study.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+
+# temp sudy import arguments
+# (1): cancer study id [ mskimpact | mskimpact_heme | mskraindance | mskarcher | mixedpact ]
+# (2): temp study id [ temporary_mskimpact | temporary_mskimpact_heme | temporary_mskraindance | temporary_mskarcher | temporary_mixedpact ]
+# (3): backup study id [ yesterday_mskimpact | yesterday_mskimpact_heme | yesterday_mskraindance | yesterday_mskarcher | yesterday_mixedpact ]
+# (4): portal name [ mskimpact-portal | mskheme-portal | mskraindance-portal | mskarcher-portal | mixedpact-portal ]
+# (5): study path [ $MSK_IMPACT_DATA_HOME | $MSK_HEMEPACT_DATA_HOME | $MSK_RAINDANCE_DATA_HOME | $MSK_ARCHER_DATA_HOME | $MSK_MIXEDPACT_DATA_HOME ]
+# (6): notification file [ $mskimpact_notification_file | $mskheme_notification_file | $mskraindance_notification_file | $mixedpact_notification_file ]
+# (7): tmp directory
+# (8): email list
+# (9): importer jar
+
+# Non-zero exit code status indication
+# There are several flags that are checked during the execution of the temporary study import. If any flags are non-zero at the end 
+# of execution then an email is sent out to the email list provided for each non-zero flag and the script exits with a non-zero status.
+# Flags:
+# 	IMPORT_FAIL			if non-zero indicates that the study failed to import under a temporary id
+# 	VALIDATION_FAIL		if non-zero indicates that the temporary study failed validation against the original study
+# 	DELETE_FAIL			if non-zero indicates that the backup study failed to delete 
+# 	RENAME_BACKUP_FAIL	if non-zero indicates that the original study failed to rename to the backup study id 
+# 	RENAME_FAIL 		if non-zero indicates that the temporary study failed to rename to the original study id 
+
+function usage {
+	echo "import-temp-study.sh"
+	echo -e "\t-i | --study-id              cancer study identifier"
+	echo -e "\t-t | --temp-study-id         temp study identifier"
+	echo -e "\t-b | --backup-study-id       backup study identifier"
+	echo -e "\t-p | --portal-name           portal name"
+	echo -e "\t-s | --study-path            study path"
+	echo -e "\t-n | --notification-file     notification file"
+	echo -e "\t-d | --tmp-directory         tmp directory"
+	echo -e "\t-e | --email-list            email list"
+	echo -e "\t-j | --importer-jar          importer jar"
+}
+
+for i in "$@"; do
+case $i in
+    -i=*|--study-id=*)
+    CANCER_STUDY_IDENTIFIER="${i#*=}"
+    echo "study id=$CANCER_STUDY_IDENTIFIER"
+    shift
+    ;;
+    -t=*|--temp-study-id=*)
+    TEMP_CANCER_STUDY_IDENTIFIER="${i#*=}"
+    echo "temp id=$TEMP_CANCER_STUDY_IDENTIFIER"
+    shift
+    ;;
+    -b=*|--backup-study-id=*)
+    BACKUP_CANCER_STUDY_IDENTIFIER="${i#*=}"
+    echo "backup id=$BACKUP_CANCER_STUDY_IDENTIFIER"
+    shift
+    ;;
+    -p=*|--portal-name=*)
+    PORTAL_NAME="${i#*=}"
+    echo "portal name=$PORTAL_NAME"
+    shift
+    ;;
+    -s=*|--study-path=*)
+    STUDY_PATH="${i#*=}"
+    echo "study path=$STUDY_PATH"
+    shift
+    ;;
+    -n=*|--notification-file=*)
+    NOTIFICATION_FILE="${i#*=}"
+    echo "notifcation file=$NOTIFICATION_FILE"
+    shift
+    ;;
+    -d=*|--tmp-directory=*)
+    TMP_DIRECTORY="${i#*=}"
+    echo "tmp dir=$TMP_DIRECTORY"
+    shift
+    ;;
+    -e=*|--email-list=*)
+    EMAIL_LIST="${i#*=}"
+    echo "email list=$EMAIL_LIST"
+    shift
+    ;;
+    -j=*|--importer-jar=*)
+    IMPORTER_JAR="${i#*=}"
+    echo "importer jar=$IMPORTER_JAR"
+    shift
+    ;;
+    *)
+    ;;
+esac
+done
+
+if [[ -z $CANCER_STUDY_IDENTIFIER || -z $TEMP_CANCER_STUDY_IDENTIFIER || -z $BACKUP_CANCER_STUDY_IDENTIFIER || -z $PORTAL_NAME || -z $STUDY_PATH || -z $NOTIFICATION_FILE || -z $TMP_DIRECTORY || -z $EMAIL_LIST || -z $IMPORTER_JAR ]]; then
+	usage
+	exit 1
+fi
+
+# variables for import temp study status
+IMPORT_FAIL=0
+VALIDATION_FAIL=0
+DELETE_FAIL=0
+RENAME_BACKUP_FAIL=0
+RENAME_FAIL=0
+GROUPS_FAIL=0
+
+# import study using temp id
+echo "Importing study '$CANCER_STUDY_IDENTIFIER' as temporary study '$TEMP_CANCER_STUDY_IDENTIFIER'"
+$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$TMP_DIRECTORY" -cp $IMPORTER_JAR org.mskcc.cbio.importer.Admin --update-study-data --portal "$PORTAL_NAME" --notification-file "$NOTIFICATION_FILE" --temporary-id "$TEMP_CANCER_STUDY_IDENTIFIER"
+
+# check number of studies updated before continuing
+if [ -f "$TMP_DIRECTORY/num_studies_updated.txt" ]; then 
+	num_studies_updated=`cat $TMP_DIRECTORY/num_studies_updated.txt`
+else
+	num_studies_updated=0
+fi
+
+if [ "$num_studies_updated" -ne 1 ]; then
+	echo "Failed to import study '$CANCER_STUDY_IDENTIFIER'"
+	IMPORT_FAIL=1
+else
+	# validate
+	echo "Validating import..."
+	$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$TMP_DIRECTORY" -cp $IMPORTER_JAR org.mskcc.cbio.importer.Admin --validate-temp-study --temp-study-id $TEMP_CANCER_STUDY_IDENTIFIER --original-study-id $CANCER_STUDY_IDENTIFIER
+	if [ $? -gt 0 ]; then
+		echo "Failed to validate - deleting temp study '$TEMP_CANCER_STUDY_IDENTIFIER'"
+		$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$TMP_DIRECTORY" -cp $IMPORTER_JAR org.mskcc.cbio.importer.Admin --delete-cancer-study --cancer-study-ids $TEMP_CANCER_STUDY_IDENTIFIER
+		VALIDATION_FAIL=1
+	else
+		echo "Successful validation - renaming '$CANCER_STUDY_IDENTIFIER' and temp study '$TEMP_CANCER_STUDY_IDENTIFIER'"
+		$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$TMP_DIRECTORY" -cp $IMPORTER_JAR org.mskcc.cbio.importer.Admin --delete-cancer-study --cancer-study-ids $BACKUP_CANCER_STUDY_IDENTIFIER
+		if [ $? -gt 0 ]; then
+			echo "Failed to delete backup study '$BACKUP_CANCER_STUDY_IDENTIFIER'!"
+			DELETE_FAIL=1
+		else
+			echo "Renaming '$CANCER_STUDY_IDENTIFIER' to '$BACKUP_CANCER_STUDY_IDENTIFIER'"
+			$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$TMP_DIRECTORY" -cp $IMPORTER_JAR org.mskcc.cbio.importer.Admin --rename-cancer-study --new-study-id $BACKUP_CANCER_STUDY_IDENTIFIER --original-study-id $CANCER_STUDY_IDENTIFIER
+			if [ $? -gt 0 ]; then
+				echo "Failed to rename existing '$CANCER_STUDY_IDENTIFIER' to backup study '$BACKUP_CANCER_STUDY_IDENTIFIER'!"
+				RENAME_BACKUP_FAIL=1
+			else
+				echo "Updating groups of study '$BACKUP_CANCER_STUDY_IDENTIFIER' to KSBACKUP"
+				$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$TMP_DIRECTORY" -cp $IMPORTER_JAR org.mskcc.cbio.importer.Admin --update-groups --cancer-study-ids $BACKUP_CANCER_STUDY_IDENTIFIER --groups "KSBACKUP"
+				if [ $? -gt 0 ]; then
+					echo "Failed to change groups for backup study '$BACKUP_CANCER_STUDY_IDENTIFIER!"
+					GROUPS_FAIL=1
+				fi
+				echo "Renaming temporary study '$TEMP_CANCER_STUDY_IDENTIFIER' to '$CANCER_STUDY_IDENTIFIER'"
+				$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$TMP_DIRECTORY" -cp $IMPORTER_JAR org.mskcc.cbio.importer.Admin --rename-cancer-study --new-study-id $CANCER_STUDY_IDENTIFIER --original-study-id $TEMP_CANCER_STUDY_IDENTIFIER
+				if [ $? -gt 0 ]; then
+					echo "Failed to rename temporary study '$TEMP_CANCER_STUDY_IDENTIFIER' to '$CANCER_STUDY_IDENTIFIER!"
+					RENAME_FAIL=1
+				else
+					# only consume samples if study is mskimpact
+					if [ $CANCER_STUDY_IDENTIFIER == "mskimpact" ]; then 
+						echo "Consuming mskimpact samples from cvr"
+						$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -c $MSK_IMPACT_DATA_HOME/cvr_data.json
+					fi
+				fi
+			fi
+		fi
+	fi
+fi
+
+### FAILURE EMAIL ###
+
+EMAIL_BODY="The $CANCER_STUDY_IDENTIFIER study failed import. The original study will remain on the portal."
+# send email if import fails
+if [ $IMPORT_FAIL -gt 0 ]
+then
+	echo -e "Sending email $EMAIL_BODY"
+	echo -e "$EMAIL_BODY" | mail -s "$CANCER_STUDY_IDENTIFIER Update Failure: Import" $EMAIL_LIST
+fi
+
+EMAIL_BODY="The $CANCER_STUDY_IDENTIFIER study failed to pass the validation step in import process. The original study will remain on the portal."
+# send email if validation fails
+if [ $VALIDATION_FAIL -gt 0 ]
+then
+	echo -e "Sending email $EMAIL_BODY"
+	echo -e "$EMAIL_BODY" | mail -s "$CANCER_STUDY_IDENTIFIER Update Failure: Validation" $EMAIL_LIST
+fi
+
+EMAIL_BODY="The $BACKUP_CANCER_STUDY_IDENTIFIER study failed to delete. $CANCER_STUDY_IDENTIFIER study did not finish updating."
+if [ $DELETE_FAIL -gt 0 ]
+then
+	echo -e "Sending email $EMAIL_BODY"
+	echo -e "$EMAIL_BODY" | mail -s "$CANCER_STUDY_IDENTIFIER Update Failure: Deletion" $EMAIL_LIST
+fi
+
+EMAIL_BODY="Failed to backup $CANCER_STUDY_IDENTIFIER to $BACKUP_CANCER_STUDY_IDENTIFIER via renaming. $CANCER_STUDY_IDENTIFIER study did not finish updating."
+if [ $RENAME_BACKUP_FAIL -gt 0 ]
+then
+	echo -e "Sending email $EMAIL_BODY"
+	echo -e "$EMAIL_BODY" | mail -s "$CANCER_STUDY_IDENTIFIER Update Failure: Renaming backup" $EMAIL_LIST
+fi
+
+EMAIL_BODY="Failed to rename temp study $TEMP_CANCER_STUDY_IDENTIFIER to $CANCER_STUDY_IDENTIFIER. $CANCER_STUDY_IDENTIFIER study did not finish updating."
+if [ $RENAME_FAIL -gt 0 ]
+then
+	echo -e "Sending email $EMAIL_BODY"
+	echo -e "$EMAIL_BODY" | mail -s "$CANCER_STUDY_IDENTIFIER Update Failure: CRITICAL!! Renaming" $EMAIL_LIST
+fi
+
+EMAIL_BODY="Failed to update groups for backup study $BACKUP_CANCER_STUDY_IDENTIFIER."
+if [ $GROUPS_FAIL -gt 0 ]
+then
+	echo -e "Sending email $EMAIL_BODY"
+	echo -e "$EMAIL_BODY" | mail -s "$CANCER_STUDY_IDENTIFIER Update Failure: Groups update" $EMAIL_LIST
+fi
+
+
+# determine if we need to exit with error code
+if [[ $IMPORT_FAIL -ne 0 || $VALIDATION_FAIL -ne 0 || $DELETE_FAIL -ne 0 || $RENAME_BACKUP_FAIL -ne 0 || $RENAME_FAIL -ne 0 || $GROUPS_FAIL -ne 0 ]]; then
+	echo "Update failed for study '$CANCER_STUDY_IDENTIFIER"
+	exit 1
+else
+	echo "Update successful for study '$CANCER_STUDY_IDENTIFIER'"
+fi


### PR DESCRIPTION
Generalized code for importing a study as a temp study, including logic for validating import, renaming study, etc.
Each of our clinical pipelines/studies will now import as a temp study.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>