### PR TITLE
CVR pipeline updates, enable fetching for ARCHER

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataReader.java
@@ -120,7 +120,18 @@ public class CVRFusionDataReader implements ItemStreamReader<CVRFusionRecord> {
             String sampleId = result.getMetaData().getDmpSampleId();
             List<CVRSvVariant> variants = result.getSvVariants();
             for (CVRSvVariant variant : variants) {
-                CVRFusionRecord record = new CVRFusionRecord(variant, sampleId, false);
+
+                CVRFusionRecord record = null; // = new CVRFusionRecord(variant, sampleId, false);
+                try {
+                    record = new CVRFusionRecord(variant, sampleId, false);
+                }
+                catch (NullPointerException e) {
+                    // log error if both variant gene sites are not null
+                    if (variant.getSite1_Gene() != null && variant.getSite2_Gene() != null) {
+                        log.error("Error creating fusion record for sample, gene1-gene2 event: " + sampleId + ", " + variant.getSite1_Gene() + "-" + variant.getSite2_Gene());
+                    }
+                    continue;
+                }
                 String fusion = record.getHugo_Symbol() + "|" +record.getTumor_Sample_Barcode() + "|" + record.getFusion();
                 CVRFusionRecord recordReversed = new CVRFusionRecord(variant, sampleId, true);
                 if (!fusionsSeen.contains(fusion)) {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelReader.java
@@ -117,7 +117,10 @@ public class CVRGenePanelReader implements ItemStreamReader<CVRGenePanelRecord> 
             CVRGenePanelRecord record = new CVRGenePanelRecord(result.getMetaData());
             genePanelRecords.add(record);
         }
-        setGenePanelHeader(ec, genePanelRecords.get(0));
+        // only try setting header if gene panel records list is not empty
+        if (!genePanelRecords.isEmpty()) {
+            setGenePanelHeader(ec, genePanelRecords.get(0));
+        }        
     }
 
     @Override

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRFusionRecord.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRFusionRecord.java
@@ -63,15 +63,15 @@ public class CVRFusionRecord {
         this.dnaSupport = "yes";
         this.rnaSupport = "unknown";
         this.method = "NA";
-        if (variant.getEvent_Info().contains("in frame")) {
+        if (variant.getEvent_Info() != null && variant.getEvent_Info().contains("in frame")) {
             this.frame = "in frame";
-        } else if (variant.getEvent_Info().contains("out of frame")) {
+        } else if (variant.getEvent_Info() != null && variant.getEvent_Info().contains("out of frame")) {
             this.frame = "out of frame";
         } else {
             this.frame = "unknown";
         }
         this.comments = variant.getAnnotation() + " " + variant.getComments();
-        this.comments = this.comments.replace("\r\n", "").replace("\r", "").replace("\n", "").replace("\t", "");
+        this.comments = this.comments.replaceAll("[\\t\\n\\r]+"," ");
     }
 
     public String getHugo_Symbol() {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRMergedResult.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRMergedResult.java
@@ -138,7 +138,7 @@ public class CVRMergedResult {
     */
     @JsonProperty("cnv-intragenic-variants")
     public List<CVRCnvIntragenicVariant> getCnvIntragenicVariants() {
-        return cnvIntragenicVariants;
+        return cnvIntragenicVariants != null ? cnvIntragenicVariants : new ArrayList();
     }
 
     /**
@@ -158,7 +158,7 @@ public class CVRMergedResult {
     */
     @JsonProperty("cnv-variants")
     public List<CVRCnvVariant> getCnvVariants() {
-        return cnvVariants;
+        return cnvVariants != null ? cnvVariants : new ArrayList();
     }
 
     /**
@@ -218,7 +218,7 @@ public class CVRMergedResult {
     */
     @JsonProperty("snp-indel-exonic")
     public List<CVRSnp> getSnpIndelExonic() {
-        return snpIndelExonic;
+        return snpIndelExonic != null ? snpIndelExonic : new ArrayList();
     }
 
     /**
@@ -238,7 +238,7 @@ public class CVRMergedResult {
     */
     @JsonProperty("snp-indel-exonic-np")
     public List<CVRSnp> getSnpIndelExonicNp() {
-        return snpIndelExonicNp;
+        return snpIndelExonicNp != null ? snpIndelExonicNp : new ArrayList();
     }
 
     /**
@@ -258,7 +258,7 @@ public class CVRMergedResult {
     */
     @JsonProperty("snp-indel-silent")
     public List<CVRSnp> getSnpIndelSilent() {
-        return snpIndelSilent;
+        return snpIndelSilent != null ? snpIndelSilent : new ArrayList();
     }
 
     /**
@@ -278,7 +278,7 @@ public class CVRMergedResult {
     */
     @JsonProperty("snp-indel-silent-np")
     public List<CVRSnp> getSnpIndelSilentNp() {
-        return snpIndelSilentNp;
+        return snpIndelSilentNp != null ? snpIndelSilentNp : new ArrayList();
     }
 
     /**
@@ -298,7 +298,7 @@ public class CVRMergedResult {
     */
     @JsonProperty("sv-variants")
     public List<CVRSvVariant> getSvVariants() {
-        return svVariants;
+        return svVariants != null ? svVariants : new ArrayList();
     }
 
     /**

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRSvVariant.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRSvVariant.java
@@ -76,7 +76,12 @@ import javax.annotation.Generated;
     "sv_variant_id",
     "tumor_read_count",
     "tumor_variant_count",
-    "variant_status_name"
+    "variant_status_name",
+    "gene1",
+    "gene2",
+    "exon1",
+    "exon2",
+    "sample_comment"
 })
 public class CVRSvVariant {
     @JsonProperty("annotation")
@@ -133,6 +138,16 @@ public class CVRSvVariant {
     private String tumorVariantCount;
     @JsonProperty("variant_status_name")
     private String variantStatusName;
+    @JsonProperty("gene1")
+    private String gene1;
+    @JsonProperty("gene2")
+    private String gene2;
+    @JsonProperty("exon1")
+    private String exon1;
+    @JsonProperty("exon2")
+    private String exon2;
+    @JsonProperty("sample_comment")
+    private String sampleComment;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
@@ -250,7 +265,7 @@ public class CVRSvVariant {
     */
     @JsonProperty("comments")
     public String getComments() {
-        return comments;
+        return comments != null ? comments : sampleComment;
     }
 
     /**
@@ -470,7 +485,7 @@ public class CVRSvVariant {
     */
     @JsonProperty("site1_gene")
     public String getSite1_Gene() {
-        return site1Gene;
+        return site1Gene != null ? site1Gene : gene1;
     }
 
     /**
@@ -550,7 +565,7 @@ public class CVRSvVariant {
     */
     @JsonProperty("site2_gene")
     public String getSite2_Gene() {
-        return site2Gene;
+        return site2Gene != null ? site2Gene : gene2;
     }
 
     /**
@@ -751,5 +766,75 @@ public class CVRSvVariant {
     @JsonAnySetter
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
+    }
+
+    /**
+     * @return the gene1
+     */
+    public String getGene1() {
+        return gene1;
+    }
+
+    /**
+     * @param gene1 the gene1 to set
+     */
+    public void setGene1(String gene1) {
+        this.gene1 = gene1;
+    }
+
+    /**
+     * @return the gene2
+     */
+    public String getGene2() {
+        return gene2;
+    }
+
+    /**
+     * @param gene2 the gene2 to set
+     */
+    public void setGene2(String gene2) {
+        this.gene2 = gene2;
+    }
+
+    /**
+     * @return the exon1
+     */
+    public String getExon1() {
+        return exon1;
+    }
+
+    /**
+     * @param exon1 the exon1 to set
+     */
+    public void setExon1(String exon1) {
+        this.exon1 = exon1;
+    }
+
+    /**
+     * @return the exon2
+     */
+    public String getExon2() {
+        return exon2;
+    }
+
+    /**
+     * @param exon2 the exon2 to set
+     */
+    public void setExon2(String exon2) {
+        this.exon2 = exon2;
+    }
+
+    /**
+     * @return the sampleComment
+     */
+    public String getSampleComment() {
+        return sampleComment;
+    }
+
+    /**
+     * @param sampleComment the sampleComment to set
+     */
+    public void setSampleComment(String sampleComment) {
+        this.sampleComment = sampleComment;
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/variants/CVRVariantsProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/variants/CVRVariantsProcessor.java
@@ -112,7 +112,7 @@ public class CVRVariantsProcessor implements ItemProcessor<CVRVariants, String> 
         } catch (org.springframework.web.client.RestClientException e) {
             String message = "Error getting seg data for sample: " + sampleId;
             log.warn(message);
-            return null;
+            return new CVRSegData();
         }
         return responseEntity.getBody();
     }


### PR DESCRIPTION
Fixed bugs in CVR pipeline that arose because ARCHER cvr_data.json structure is slightly different for structural variants data.

Enabled fetching for ARCHER data in the import-dmp-impact.sh script

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>