### PR TITLE
Import scripts updates

### DIFF
--- a/import-scripts/create_case_lists_by_cancer_type.py
+++ b/import-scripts/create_case_lists_by_cancer_type.py
@@ -48,8 +48,8 @@ def write_case_list_files(clinical_file_map, output_directory, study_id):
 		stable_id = study_id + '_' + cancer_type_no_spaces
 		case_list_name = 'Tumor Type: ' + cancer_type
 		case_list_description = 'All tumors with cancer type ' + cancer_type
-		case_list_ids = '\t'.join(ids)
-		case_list_file.write('cancer_study_identifier : ' + study_id + '\n' +
+		case_list_ids = '\t'.join(list(set(ids)))
+		case_list_file.write('cancer_study_identifier: ' + study_id + '\n' +
 								'stable_id: ' + stable_id + '\n' + 
 								'case_list_name: ' + case_list_name + '\n' + 
 								'case_list_description: ' + case_list_description + '\n' +
@@ -64,7 +64,7 @@ def create_case_lists(clinical_file_name, output_directory, study_id):
 # ---------------------------------------------------------------
 # displays usage of program
 def usage():
-	print >> OUTPUT_FILE, 'create_case_lists_by_cancer_type.py --clinical-file <path/to/clinical/file> --output-directory <path/to/output/directory> study-id <cancer_study_identifier>'
+	print >> OUTPUT_FILE, 'create_case_lists_by_cancer_type.py --clinical-file <path/to/clinical/file> --output-directory <path/to/output/directory> --study-id <cancer_study_identifier>'
 
 # ---------------------------------------------------------------
 # the main

--- a/import-scripts/expand-clinical-data.py
+++ b/import-scripts/expand-clinical-data.py
@@ -1,0 +1,99 @@
+import sys
+import optparse
+import csv
+import os
+
+ERROR_FILE = sys.stderr
+OUTPUT_FILE = sys.stdout
+
+SUPPLEMENTAL_SAMPLE_CLINICAL_DATA = {}
+FILTERED_SAMPLE_IDS = set()
+
+def expand_clinical_data_main(clinical_filename, fields):
+	""" Loads supplemental clinical data from data_clinical.txt and writes data to output directory. """
+	# add supp fields to header if not already exists
+	header = get_file_header(clinical_filename)
+	for supp_field in fields:
+		if not supp_field in header:
+			header.append(supp_field)
+
+	# load data from clinical_filename and write data to output directory
+	data_file = open(clinical_filename, 'rU')
+	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
+	output_data = ['\t'.join(header)]
+	for line in data_reader:
+		# update line with supplemental sample clinical data and format data as string for output file
+		line.update(SUPPLEMENTAL_SAMPLE_CLINICAL_DATA.get(line['SAMPLE_ID'].strip(), {}))
+		data = map(lambda v: line.get(v,''), header)
+		output_data.append('\t'.join(data))
+	data_file.close()	
+
+	# write data to output file
+	output_file = open(clinical_filename, 'w')
+	output_file.write('\n'.join(output_data))
+	output_file.close()
+	print >> OUTPUT_FILE, 'Updated clinical file `' + clinical_filename + '` with supp fields: ' + ', '.join(fields)
+
+def load_supplemental_clinical_data(supplemental_clinical_filename, supplemental_fields, study_id):
+	""" Loads supplemental clinical data from supplemental_clinical_filename into SUPPLEMENTAL_SAMPLE_CLINICAL_DATA. """
+	data_file = open(supplemental_clinical_filename, 'rU')
+	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
+	for line in data_reader:
+		if study_id == 'genie':
+			normalize_genie_sample_type(line)
+		SUPPLEMENTAL_SAMPLE_CLINICAL_DATA[line['SAMPLE_ID'].strip()] = dict({(k,v) for k,v in line.items() if k in supplemental_fields})
+	data_file.close()
+
+def normalize_genie_sample_type(data):
+	if data['SAMPLE_TYPE'].strip() == 'Metastasis':
+		data['SAMPLE_TYPE'] = '4'
+	elif data['SAMPLE_TYPE'].strip() == 'Primary':
+		data['SAMPLE_TYPE'] = '1'
+	return data
+
+
+def get_file_header(filename):
+	""" Returns the file header. """
+	data_file = open(filename, 'rU')
+	filedata = [x for x in data_file.readlines() if not x.startswith('#')]
+	header = map(str.strip, filedata[0].split('\t'))
+	data_file.close()
+	return header
+
+def usage():
+	print >> OUTPUT_FILE, "expand-clinical-data.py --study-id [study id] --clinical-file [path to clinical file] --clinical-supp-file [path to clinical supp file] --fields [comma-delimited list of fields to expand the clinical file]"
+	sys.exit(2)
+
+def main():
+	# get command line stuff
+	parser = optparse.OptionParser()
+	parser.add_option('-c', '--clinical-file', action = 'store', dest = 'clinfile')
+	parser.add_option('-s', '--clinical-supp-file', action = 'store', dest = 'clinsuppfile')
+	parser.add_option('-f', '--fields', action = 'store', dest = 'fields')
+	parser.add_option('-i', '--study-id', action = 'store', dest = 'studyid')
+
+	(options, args) = parser.parse_args()
+	clin_file = options.clinfile
+	clin_supp_file = options.clinsuppfile
+	fields = options.fields.split(',')
+	study_id = options.studyid
+
+	# check arguments
+	if not clin_file or not clin_supp_file or not fields or not study_id:
+		print >> ERROR_FILE, "Clinical file, clinical supp file, fields, and study id must be provided!"
+		usage()
+	if not os.path.exists(clin_file):
+		print >> ERROR_FILE, "No such file: " + clin_file
+		usage()
+	if not os.path.exists(clin_supp_file):
+		print >> ERROR_FILE, "No such file: " + clin_supp_file
+		usage()
+
+	# load supplemental data from the clinical supp file
+	load_supplemental_clinical_data(clin_supp_file, fields, study_id)
+	expand_clinical_data_main(clin_file, fields)
+
+
+
+if __name__ == '__main__':
+	main()

--- a/import-scripts/generate-clinical-subset.py
+++ b/import-scripts/generate-clinical-subset.py
@@ -1,0 +1,220 @@
+import sys
+import optparse
+import csv
+import os
+from datetime import datetime
+
+ERROR_FILE = sys.stderr
+OUTPUT_FILE = sys.stdout
+
+FILTERING_CRITERIA = {}
+SUPPLEMENTAL_SAMPLE_CLINICAL_DATA = {}
+FILTERED_SAMPLE_IDS = set()
+
+def filter_samples_by_clinical_attributes(clinical_filename):
+	""" Filters samples by clinical attribute and values. """
+	data_file = open(clinical_filename)
+	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
+	for line in data_reader:
+		if keep_sample(line):
+			FILTERED_SAMPLE_IDS.add(line['SAMPLE_ID'].strip())
+	data_file.close()
+
+def keep_sample(sample_data):
+	""" Returns true if at least one of the attribute values meets one of the filtering criteria. """
+	filtered_sample_data = dict({(k,v) for k,v in sample_data.items() if k in FILTERING_CRITERIA.keys()})
+	for k,v in filtered_sample_data.items():
+		if v.strip() in FILTERING_CRITERIA[k]:
+			return True
+	return False
+
+def update_data_with_sequencing_date(study_id, clinical_filename):
+	""" Updates clinical data with sequencing date. """
+	# add supp fields to header if not already exists
+	header = get_file_header(clinical_filename)
+	if not 'SEQ_DATE' in header:
+		header.append('SEQ_DATE')
+
+	# load data from clinical_filename and write data to output directory
+	data_file = open(clinical_filename, 'rU')
+	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
+	output_data = ['\t'.join(header)]
+	for line in data_reader:
+		if not line['SAMPLE_ID'].strip() in FILTERED_SAMPLE_IDS:			
+			continue
+		# update line with supplemental sample clinical data and format data as string for output file
+		line.update(SUPPLEMENTAL_SAMPLE_CLINICAL_DATA.get(line['SAMPLE_ID'].strip(), {}))
+		data = map(lambda v: line.get(v,''), header)
+		output_data.append('\t'.join(data))
+	data_file.close()	
+
+	# write data to output file
+	output_file = open(clinical_filename, 'w')
+	output_file.write('\n'.join(output_data))
+	output_file.close()
+	print >> OUTPUT_FILE, 'Input clinical data updated with sequencing date for study: ' + study_id
+
+def filter_samples_by_sequencing_date(clinical_supp_filename, sequencing_date_limit, anonymize_date):
+	""" Generates list of sample IDs from sequencing date file meeting the sequencing date limit criteria. """
+	seq_date_limit = datetime.strptime(sequencing_date_limit, '%Y/%m/%d %H:%M:%S')
+
+	data_file = open(clinical_supp_filename, 'rU')
+	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
+	for line in data_reader:
+		# figure out which column to use
+		if 'SeqDate' in line.keys():
+			seq_date_val = line['SeqDate']
+		else:
+			seq_date_val = line['SEQ_DATE']
+		raw_sample_seq_date = datetime.strptime(seq_date_val, '%Y-%m-%d %H:%M:%S')
+
+		# if sample sequencing date meets criteria then anonymize the sequencing date
+		if raw_sample_seq_date <= seq_date_limit:
+			sample_seq_date = ''
+			if anonymize_date:
+				# anonymize the sample seq date and add to supplemental sample clinical data
+				if raw_sample_seq_date.month <= 3:
+					sample_seq_date = 'Jan-' + str(raw_sample_seq_date.year)
+				elif raw_sample_seq_date.month > 3 and raw_sample_seq_date.month <= 6:
+					sample_seq_date = 'June-' + str(raw_sample_seq_date.year)
+				elif raw_sample_seq_date.month > 6 and raw_sample_seq_date.month <= 9:
+					sample_seq_date = 'July-' + str(raw_sample_seq_date.year)
+				else:
+					sample_seq_date = 'Oct-' + str(raw_sample_seq_date.year)
+			else:
+				sample_seq_date = raw_sample_seq_date.strftime('%Y/%m')
+
+			try:
+				sample_id = line['SAMPLE_ID'].strip()
+			except KeyError:
+				sample_id = line['DMP_ASSAY_ID'].strip()
+
+			SUPPLEMENTAL_SAMPLE_CLINICAL_DATA[sample_id] = {'SEQ_DATE':sample_seq_date}
+			FILTERED_SAMPLE_IDS.add(sample_id)
+	data_file.close()
+
+def generate_sample_subset_file(subset_filename):
+	""" Writes subset of sample ids to output directory. """
+	output_file = open(subset_filename, 'w')
+	output_file.write('\n'.join(list(FILTERED_SAMPLE_IDS)))
+	output_file.close()
+	print >> OUTPUT_FILE, 'Subset file written to: ' + subset_filename
+
+def is_valid_sequencing_date(sequencing_date_limit):
+	""" Determines whether provided sequencing date limit is in valid format. """
+	try:
+		seq_date_limit = datetime.strptime(sequencing_date_limit, '%Y/%m/%d')
+	except ValueError:
+			return False
+	return True
+
+def get_file_header(filename):
+	""" Returns the file header. """
+	data_file = open(filename, 'rU')
+	filedata = [x for x in data_file.readlines() if not x.startswith('#')]
+	header = map(str.strip, filedata[0].split('\t'))
+	data_file.close()
+	return header
+
+def is_valid_clin_header(clinical_filename, is_seq_date):
+	""" Determines whether one of the sequencing date columns is in supplemental clinical file. """
+	header = get_file_header(clinical_filename)
+	# if seq date filter then only SEQ_DATE or SeqDate need to be in file header, 
+	# otherwise we want to make sure all filtering criteria columns are in header
+	if is_seq_date:
+		for seq_date_col in ['SEQ_DATE', 'SeqDate']:
+			if seq_date_col in header:
+				return True
+		return False
+	else:
+		for column in FILTERING_CRITERIA.keys():
+			if not column in header:
+				return False
+		return True
+
+def parse_filter_criteria(filter_criteria):
+	attr_name = filter_criteria.split('=')[0]
+	attr_values = filter_criteria.split('=')[1].split(',')
+	if attr_name == 'SEQUENCING_DATE':
+		if len(attr_values) > 1:
+			print >> ERROR_FILE, "Only ONE sequencing date can be provided for filtering."
+			exit(2)
+		if not is_valid_sequencing_date(attr_values[0]):
+			print >> ERROR_FILE, 'Sequencing date must be in YYYY/MM/DD format'
+			sys.exit(2)
+		FILTERING_CRITERIA['SEQ_DATE'] = attr_values[0] + ' 23:59:59' # add max hr:min:sec for date
+	else:
+		# more than one attribute filter can be provided, parse all attributes and values
+		filter_criteria_parts = filter_criteria.split(';')
+		for fc in filter_criteria_parts:
+			attr_name = fc.split('=')[0]
+			attr_values = fc.split('=')[1].split(',')
+			FILTERING_CRITERIA[attr_name] = attr_values
+
+def usage():
+	print >> OUTPUT_FILE, "generate-clinical-subset.py --study-id [study id] --clinical-file [path to clinical file] --clinical-supp-file [path to clinical supp file] --filter-criteria [ATTR1=[VALUE1,VALUE2...];ATTR2=[VALUE1,VALUE2...]] --subset-filename [path to subset filename]"
+	sys.exit(2)
+
+def main():
+	# get command line stuff
+	parser = optparse.OptionParser()
+	parser.add_option('-i', '--study-id', action = 'store', dest = 'studyid')
+	parser.add_option('-c', '--clinical-file', action = 'store', dest = 'clinfile')
+	parser.add_option('-s', '--clinical-supp-file', action = 'store', dest = 'clinsuppfile')
+	parser.add_option('-f', '--filter-criteria', action = 'store', dest = 'filtercriteria')
+	parser.add_option('-a', '--anonymize-date', action = 'store', dest = 'anondate')
+	parser.add_option('-o', '--subset-filename', action = 'store', dest = 'subsetfile')
+
+	(options, args) = parser.parse_args()
+	study_id = options.studyid
+	clin_file = options.clinfile
+	clin_supp_file = options.clinsuppfile
+	filter_criteria = options.filtercriteria
+	anonymize_date = options.anondate
+	subset_filename = options.subsetfile
+
+	# study id, clinical file, and clinical supp file must be provided
+	if not study_id or not filter_criteria or not clin_file:
+		print >> ERROR_FILE, 'Study ID, filtering criteria and clinical file must be provided!'
+		usage()
+
+	# make sure that clinical file and supp file exist
+	if not os.path.exists(clin_file):
+		print >> ERROR_FILE, 'No such file: ' + clin_file
+		usage()
+	if clin_supp_file and not os.path.exists(clin_supp_file):
+		print >> ERROR_FILE, 'No such file: ' + clin_supp_file
+		usage()
+
+	# determine whether to anonymize date or not
+	if not anonymize_date or anonymize_date.lower() == 'false':
+		anonymize_date = False
+	else:
+		anonymize_date = True
+
+	# parse the filtering criteria
+	parse_filter_criteria(filter_criteria)
+	if 'SEQ_DATE' in FILTERING_CRITERIA.keys():
+		# if no supp file provided then check clin file for 
+		if not clin_supp_file and is_valid_clin_header(clin_file, True):
+			filter_samples_by_sequencing_date(clin_file, FILTERING_CRITERIA['SEQ_DATE'], anonymize_date)
+		elif clin_supp_file and is_valid_clin_header(clin_supp_file, True):
+			filter_samples_by_sequencing_date(clin_supp_file, FILTERING_CRITERIA['SEQ_DATE'], anonymize_date)
+			update_data_with_sequencing_date(study_id, clin_file)
+		else:
+			if clin_supp_file:
+				print >> ERROR_FILE, 'Clinical supp file must contain either `SEQ_DATE` or `SeqDate` in header!'
+			else:
+				print >> ERROR_FILE, 'Clinical file must contain either `SEQ_DATE` or `SeqDate` in header!'
+			exit(2)		
+	else:
+		if not clin_supp_file and is_valid_clin_header(clin_file, False):
+			filter_samples_by_clinical_attributes(clin_file)
+		elif clin_supp_file and is_valid_clin_header(clin_supp_file, False):
+			filter_samples_by_clinical_attributes(clin_supp_file)
+	# generate file with subset of ids		
+	generate_sample_subset_file(subset_filename)
+
+
+if __name__ == '__main__':
+	main()

--- a/import-scripts/subset-impact-data.sh
+++ b/import-scripts/subset-impact-data.sh
@@ -1,0 +1,67 @@
+# UTILITY FOR SUBSETTING IMPACT DATA
+
+# (1): study id
+# (2): output directory 
+# (3): mskimpact data directory 
+# (4): data filter criteria to subset IMPACT data with (either SEQUENCING_DATE or <ATTRIBUTE_NAME>=[ATTRIBUTE_VAL1,ATTRIBUTE_VAL2,...])
+# (5): output subset filename
+
+for i in "$@"; do
+case $i in
+    -i=*|--study-id=*)
+    STUDY_ID="${i#*=}"
+    shift # past argument=value
+    ;;
+    -o=*|--output-directory=*)
+    OUTPUT_DIRECTORY="${i#*=}"
+    shift # past argument=value
+    ;;
+    -m=*|--mskimpact-directory=*)
+    MSK_IMPACT_DATA_DIRECTORY="${i#*=}"
+    shift # past argument=value
+    ;;
+    -f=*|--filter-criteria=*)
+    FILTER_CRITERIA="${i#*=}"
+    shift # past argument=value
+    ;;
+    -s=*|--subset-filename=*)
+    SUBSET_FILENAME="${i#*=}"
+    shift # past argument=value
+    ;;
+    *)
+      # default option
+      echo "This option does not exist!  " "${i#*=}" 
+    ;;
+esac
+done
+echo "Input arguments: "
+echo "\tSTUDY_ID="$STUDY_ID
+echo "\tOUTPUT_DIRECTORY="$OUTPUT_DIRECTORY
+echo "\tMSK_IMPACT_DATA_DIRECTORY="$MSK_IMPACT_DATA_DIRECTORY
+echo "\tFILTER_CRITERIA="$FILTER_CRITERIA
+echo "\tSUBSET_FILENAME="$SUBSET_FILENAME
+
+if [ $STUDY_ID == "genie" ]; then
+	# once cvr pipeline captures SEQ_DATE, we can get rid of this if/else block
+	if [[ $(head -1 $MSK_IMPACT_DATA_DIRECTORY/data_clinical.txt) == *"SEQ_DATE"* ]]; then
+		CLINICAL_SUPP_FILE="$MSK_IMPACT_DATA_DIRECTORY/data_clinical.txt"
+	else:
+		CLINICAL_SUPP_FILE="$MSK_IMPACT_DATA_DIRECTORY/genie_sequencing_date_dump.txt"
+	fi
+
+	# in the case of genie data, the input data directory must be the msk-impact data home, where we expect to see darwin_genie_sample.txt and darwin_genie_patient.txt as well
+	# copy the darwin genie files to the output directory with different filenames
+	cp $MSK_IMPACT_DATA_DIRECTORY/darwin_genie_patient.txt $OUTPUT_DIRECTORY/data_clinical_supp_patient.txt
+	cp $MSK_IMPACT_DATA_DIRECTORY/darwin_genie_sample.txt $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt
+	
+	# run the generate clinical subset script to generate list of sample ids to subset from impact data - subset of sample ids will be written to given $SUBSET_FILENAME
+	$PYTHON_BINARY $PORTAL_HOME/scripts/generate-clinical-subset.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-supp-file="$CLINICAL_SUPP_FILE" --filter-criteria="$FILTER_CRITERIA" --subset-filename="$SUBSET_FILENAME" --anonymize-date='true'
+	# expand data_clinical_supp_sample.txt with ONCOTREE_CODE, SAMPLE_TYPE from data_clinical.txt
+	$PYTHON_BINARY $PORTAL_HOME/scripts/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-supp-file="$MSK_IMPACT_DATA_DIRECTORY/data_clinical.txt" --fields="ONCOTREE_CODE,SAMPLE_TYPE"
+	# generate subset of impact data using the subset file generated above
+	$PYTHON_BINARY $PORTAL_HOME/scripts/merge.py  -d $OUTPUT_DIRECTORY -i "genie" -s "$SUBSET_FILENAME" -x "true" -$MSK_IMPACT_DATA_DIRECTORY
+else
+	# generate subset list of sample ids based on filter criteria and subset MSK-IMPACT using generated list in $SUBSET_FILENAME
+	$PYTHON_BINARY $PORTAL_HOME/scripts/generate-clinical-subset.py --study-id="$STUDY_ID" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-supp-file="$CLINICAL_SUPP_FILE" --filter-criteria="$FILTER_CRITERIA" --subset-filename="$SUBSET_FILENAME"
+	$PYTHON_BINARY $PORTAL_HOME/scripts/merge.py  -d $OUTPUT_DIRECTORY -i "$STUDY_ID" -s "$SUBSET_FILENAME" -x "true" $MSK_IMPACT_DATA_DIRECTORY
+fi


### PR DESCRIPTION
1. Case lists by cancer type bug fix
In the event that there are duplicate sample IDs in a clinical file, the `create_case_lists_by_cancer_type.py` script now ensures that only a unique set of samples gets written to the case list file being generated.

2. Checked in scripts to `cmo-pipelines` from `pipelines` repo
* `import-scripts/expand-clinical-data.py`
* `import-scripts/generate-clinical-subset.py`
* `import-scripts/subset-impact-data.sh`

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>