### PR TITLE
Updates to import dmp script

### DIFF
--- a/import-scripts/automation-environment.sh
+++ b/import-scripts/automation-environment.sh
@@ -2,16 +2,16 @@
 export PORTAL_DATA_HOME=/data/portal-cron/cbio-portal-data
 export PORTAL_HOME=/data/portal-cron
 export PORTAL_CONFIG_HOME=$PORTAL_DATA_HOME/portal-configuration
-export MSK_IMPACT_DATA_HOME=/data/portal-cron/cbio-portal-data/msk-impact/msk-impact
-export MSK_RAINDANCE_DATA_HOME=/data/portal-cron/cbio-portal-data/msk-impact/raindance
-export MSK_HEMEPACT_DATA_HOME=/data/portal-cron/cbio-portal-data/msk-impact/hemepact
-export MSK_ARCHER_DATA_HOME=/data/portal-cron/cbio-portal-data/msk-impact/mskarcher
-export MSK_MIXEDPACT_DATA_HOME=/data/portal-cron/cbio-portal-data/msk-impact/mixedpact
-export MSK_KINGS_DATA_HOME=/data/portal-cron/cbio-portal-data/msk-impact/msk_kingscounty
-export MSK_LEHIGH_DATA_HOME=/data/portal-cron/cbio-portal-data/msk-impact/msk_lehighvalley
-export MSK_QUEENS_DATA_HOME=/data/portal-cron/cbio-portal-data/msk-impact/msk_queenscancercenter
-export IMPACT_DATA_HOME=/data/portal-cron/cbio-portal-data/impact
-export FOUNDATION_DATA_HOME=/data/portal-cron/cbio-portal-data/foundation
+export MSK_IMPACT_DATA_HOME=$PORTAL_DATA_HOME/msk-impact/msk-impact
+export MSK_RAINDANCE_DATA_HOME=$PORTAL_DATA_HOME/msk-impact/raindance
+export MSK_HEMEPACT_DATA_HOME=$PORTAL_DATA_HOME/msk-impact/hemepact
+export MSK_ARCHER_DATA_HOME=$PORTAL_DATA_HOME/msk-impact/mskarcher
+export MSK_MIXEDPACT_DATA_HOME=$PORTAL_DATA_HOME/msk-impact/mixedpact
+export MSK_KINGS_DATA_HOME=$PORTAL_DATA_HOME/msk-impact/msk_kingscounty
+export MSK_LEHIGH_DATA_HOME=$PORTAL_DATA_HOME/msk-impact/msk_lehighvalley
+export MSK_QUEENS_DATA_HOME=$PORTAL_DATA_HOME/msk-impact/msk_queenscancercenter
+export IMPACT_DATA_HOME=$PORTAL_DATA_HOME/impact
+export FOUNDATION_DATA_HOME=$PORTAL_DATA_HOME/foundation
 # CMO_DATA_HOME looks unused
 #export CMO_DATA_HOME=/data/cbio-portal-data/bic-mskcc
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk.x86_64

--- a/import-scripts/impact_timeline.py
+++ b/import-scripts/impact_timeline.py
@@ -144,7 +144,9 @@ def process_hg(changeset_date_dict, hgrepo):
     # or whose data have been redacted at an earlier date
     for changeset, date in reversed(sorted(changeset_date_dict.items())):
     	# reverts clinical file to specificied changeset 
-        subprocess.call(['hg', 'revert', '-r', str(changeset), clin_filename, '--cwd', hgrepo, '--no-backup'])		
+        subprocess.call(['hg', 'revert', '-r', str(changeset), clin_filename, '--cwd', hgrepo, '--no-backup'])
+        if not os.path.exists(clin_filename):
+        	continue
         try:
             clin_file = open(os.path.join(hgrepo, CLINICAL_FILENAME), 'rU')
         except IOError:


### PR DESCRIPTION
`import-dmp-impact-data.sh` updates:
* Added case lists by cancer type generation for raindance, hemepact, and archer studies
* Added "date added" attributes for raindance, hemepact, and archer studies

Modified the `automation-environment.sh` script to use env var `$PORTAL_DATA_HOME` when setting all MSK pipeline data directories

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>