### PR TITLE
Added multiple restarts to import-dmp-impact-data.sh script

### DIFF
--- a/import-scripts/import-cmo-data-msk.sh
+++ b/import-scripts/import-cmo-data-msk.sh
@@ -3,7 +3,7 @@
 # set necessary env variables with automation-environment.sh
 
 tmp=$PORTAL_HOME/tmp/import-cron-cmo-msk
-if [[ -d "$tmp" && "$tmp" != "/" ]] ; then
+if [[ -d "$tmp" && "$tmp" != "/" ]]; then
 	rm -rf "$tmp"/*
 fi
 email_list="heinsz@mskcc.org, sheridar@mskcc.org, grossb1@mskcc.org, ochoaa@mskcc.org, wilsonm2@mskcc.org"
@@ -14,14 +14,12 @@ DB_VERSION_FAIL=0
 # check database version before importing anything
 echo "Checking if database version is compatible"
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27184 -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-dmp-importer.jar org.mskcc.cbio.importer.Admin --check-db-version
-if [ $? -gt 0 ]
-then
+if [ $? -gt 0 ]; then
     echo "Database version expected by portal does not match version in database!"
     DB_VERSION_FAIL=1
 fi
 
-if [ $DB_VERSION_FAIL -eq 0 ]
-then
+if [ $DB_VERSION_FAIL -eq 0 ]; then
     # import vetted studies into MSK portal
     echo "importing cancer type updates into msk portal database..."
     $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27184 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-cmo-importer.jar org.mskcc.cbio.importer.Admin --import-types-of-cancer
@@ -30,27 +28,25 @@ then
     num_studies_updated=`cat $tmp/num_studies_updated.txt`
 
     # redeploy war
-    if [ $num_studies_updated -gt 0 ]
-    then
+    if [ $num_studies_updated -gt 0 ]; then
 	    echo "'$num_studies_updated' studies have been updated, requesting redeployment of msk portal war..."
-    	ssh -i $HOME/.ssh/id_rsa_tomcat_restarts_key cbioportal_importer@dashi.cbio.mskcc.org touch /srv/data/portal-cron/schultz-tomcat-restart
+    	ssh -i $HOME/.ssh/id_rsa_tomcat_restarts_key cbioportal_importer@dashi.cbio.mskcc.org touch /srv/data/portal-cron/msk-tomcat-restart
+        ssh -i $HOME/.ssh/id_rsa_tomcat_restarts_key cbioportal_importer@dashi2.cbio.mskcc.org touch /srv/data/portal-cron/msk-tomcat-restart
 	    echo "'$num_studies_updated' studies have been updated (no longer need to restart schultz-tomcat server...)"
     else
-	    #echo "No studies have been updated, skipping redeploy of msk portal war..."
-    	echo "No studies have been updated.."
+	    echo "No studies have been updated, skipping redeploy of msk portal war..."
     fi
 fi
 
 EMAIL_BODY="The GDAC database version is incompatible. Imports will be skipped until database is updated."
 # send email if db version isn't compatible
-if [ $DB_VERSION_FAIL -gt 0 ]
-then
+if [ $DB_VERSION_FAIL -gt 0 ]; then
     echo -e "Sending email $EMAIL_BODY"
     echo -e "$EMAIL_BODY" | mail -s "GDAC Update Failure: DB version is incompatible" $email_list
 fi
 
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27184 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-cmo-importer.jar org.mskcc.cbio.importer.Admin --send-update-notification --portal msk-automation-portal --notification-file "$msk_automation_notification_file"
 
-if [[ -d "$tmp" && "$tmp" != "/" ]] ; then
+if [[ -d "$tmp" && "$tmp" != "/" ]]; then
 	rm -rf "$tmp"/*
 fi

--- a/import-scripts/import-temp-study.sh
+++ b/import-scripts/import-temp-study.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# temp sudy import arguments
-# (1): cancer study id [ mskimpact | mskimpact_heme | mskraindance | mskarcher | mixedpact ]
-# (2): temp study id [ temporary_mskimpact | temporary_mskimpact_heme | temporary_mskraindance | temporary_mskarcher | temporary_mixedpact ]
-# (3): backup study id [ yesterday_mskimpact | yesterday_mskimpact_heme | yesterday_mskraindance | yesterday_mskarcher | yesterday_mixedpact ]
-# (4): portal name [ mskimpact-portal | mskheme-portal | mskraindance-portal | mskarcher-portal | mixedpact-portal ]
-# (5): study path [ $MSK_IMPACT_DATA_HOME | $MSK_HEMEPACT_DATA_HOME | $MSK_RAINDANCE_DATA_HOME | $MSK_ARCHER_DATA_HOME | $MSK_MIXEDPACT_DATA_HOME ]
-# (6): notification file [ $mskimpact_notification_file | $mskheme_notification_file | $mskraindance_notification_file | $mixedpact_notification_file ]
+# Temp study importer arguments
+# (1): cancer study id [ mskimpact | mskimpact_heme | mskraindance | mskarcher | mixedpact | msk_kingscounty | msk_lehighvalley | msk_queenscancercenter ]
+# (2): temp study id [ temporary_mskimpact | temporary_mskimpact_heme | temporary_mskraindance | temporary_mskarcher | temporary_mixedpact | temporary_msk_kingscounty | temporary_msk_lehighvalley | temporary_msk_queenscancercenter ]
+# (3): backup study id [ yesterday_mskimpact | yesterday_mskimpact_heme | yesterday_mskraindance | yesterday_mskarcher | yesterday_mixedpact | yesterday_msk_kingscounty | yesterday_msk_lehighvalley | yesterday_msk_queenscancercenter ]
+# (4): portal name [ mskimpact-portal | mskheme-portal | mskraindance-portal | mskarcher-portal | mixedpact-portal |  msk-kingscounty-portal | msk-lehighvalley-portal | msk-queenscancercenter-portal ]
+# (5): study path [ $MSK_IMPACT_DATA_HOME | $MSK_HEMEPACT_DATA_HOME | $MSK_RAINDANCE_DATA_HOME | $MSK_ARCHER_DATA_HOME | $MSK_MIXEDPACT_DATA_HOME | $MSK_KINGS_DATA_HOME | $MSK_LEHIGH_DATA_HOME | $MSK_QUEENS_DATA_HOME ]
+# (6): notification file [ $mskimpact_notification_file | $mskheme_notification_file | $mskraindance_notification_file | $mixedpact_notification_file | $kingscounty_notification_file | $lehighvalley_notification_file | $queenscancercenter_notification_file ]
 # (7): tmp directory
 # (8): email list
 # (9): importer jar
@@ -34,51 +34,52 @@ function usage {
 	echo -e "\t-j | --importer-jar          importer jar"
 }
 
+echo "Input arguments:"
 for i in "$@"; do
 case $i in
     -i=*|--study-id=*)
     CANCER_STUDY_IDENTIFIER="${i#*=}"
-    echo "study id=$CANCER_STUDY_IDENTIFIER"
+    echo -e "\tstudy id=$CANCER_STUDY_IDENTIFIER"
     shift
     ;;
     -t=*|--temp-study-id=*)
     TEMP_CANCER_STUDY_IDENTIFIER="${i#*=}"
-    echo "temp id=$TEMP_CANCER_STUDY_IDENTIFIER"
+    echo -e "\ttemp id=$TEMP_CANCER_STUDY_IDENTIFIER"
     shift
     ;;
     -b=*|--backup-study-id=*)
     BACKUP_CANCER_STUDY_IDENTIFIER="${i#*=}"
-    echo "backup id=$BACKUP_CANCER_STUDY_IDENTIFIER"
+    echo -e "\tbackup id=$BACKUP_CANCER_STUDY_IDENTIFIER"
     shift
     ;;
     -p=*|--portal-name=*)
     PORTAL_NAME="${i#*=}"
-    echo "portal name=$PORTAL_NAME"
+    echo -e "\tportal name=$PORTAL_NAME"
     shift
     ;;
     -s=*|--study-path=*)
     STUDY_PATH="${i#*=}"
-    echo "study path=$STUDY_PATH"
+    echo -e "\tstudy path=$STUDY_PATH"
     shift
     ;;
     -n=*|--notification-file=*)
     NOTIFICATION_FILE="${i#*=}"
-    echo "notifcation file=$NOTIFICATION_FILE"
+    echo -e "\tnotifcation file=$NOTIFICATION_FILE"
     shift
     ;;
     -d=*|--tmp-directory=*)
     TMP_DIRECTORY="${i#*=}"
-    echo "tmp dir=$TMP_DIRECTORY"
+    echo -e "\ttmp dir=$TMP_DIRECTORY"
     shift
     ;;
     -e=*|--email-list=*)
     EMAIL_LIST="${i#*=}"
-    echo "email list=$EMAIL_LIST"
+    echo -e "\temail list=$EMAIL_LIST"
     shift
     ;;
     -j=*|--importer-jar=*)
     IMPORTER_JAR="${i#*=}"
-    echo "importer jar=$IMPORTER_JAR"
+    echo -e "\timporter jar=$IMPORTER_JAR"
     shift
     ;;
     *)

--- a/import-scripts/subset-impact-data.sh
+++ b/import-scripts/subset-impact-data.sh
@@ -35,11 +35,11 @@ case $i in
 esac
 done
 echo "Input arguments: "
-echo "\tSTUDY_ID="$STUDY_ID
-echo "\tOUTPUT_DIRECTORY="$OUTPUT_DIRECTORY
-echo "\tMSK_IMPACT_DATA_DIRECTORY="$MSK_IMPACT_DATA_DIRECTORY
-echo "\tFILTER_CRITERIA="$FILTER_CRITERIA
-echo "\tSUBSET_FILENAME="$SUBSET_FILENAME
+echo -e "\tSTUDY_ID="$STUDY_ID
+echo -e "\tOUTPUT_DIRECTORY="$OUTPUT_DIRECTORY
+echo -e "\tMSK_IMPACT_DATA_DIRECTORY="$MSK_IMPACT_DATA_DIRECTORY
+echo -e "\tFILTER_CRITERIA="$FILTER_CRITERIA
+echo -e "\tSUBSET_FILENAME="$SUBSET_FILENAME
 
 if [ $STUDY_ID == "genie" ]; then
     # once cvr pipeline captures SEQ_DATE, we can get rid of this if/else block


### PR DESCRIPTION
1. Added multiple restarts to `import-dmp-impact-data.sh`

Tomcats will now be restarted at the following points:
* If MSK-IMPACT imports succesffully then tomcats will restart - this will skip restart if there isn't anything to update in the event that IMPACT fails to import
* Following import of MIXEDPACT - tomcats will be restarted regardless if the updates were successful. This restart will make updates available for: HEMEPACT, RAINDANCE, ARCHER, and MIXEDPACT
* Following import of MSK affiliate studies - this restarting point is the same point as before, which is after all studies have attempted import

2. Added restart for msk portal on dashi2 to `import-cmo-data-msk.sh`

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>