### PR TITLE
Use NAACCR codes for darwin demographics

### DIFF
--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientDemographics.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientDemographics.java
@@ -45,6 +45,7 @@ public class MskimpactPatientDemographics {
     private String DMP_ID_DEMO;
     private String GENDER;
     private String RACE;
+    private String ETHNICITY;
     private String RELIGION;
     private Integer AGE_AT_DATE_OF_DEATH_IN_DAYS;
     private Integer AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS;
@@ -62,39 +63,18 @@ public class MskimpactPatientDemographics {
     private Integer TM_DX_YEAR;
     private String OS_STATUS;
     private String OS_MONTHS;
+    private String PT_NAACCR_ETHNICITY_CODE;
+    private String PT_NAACCR_RACE_CODE_PRIMARY;
+    private String PT_NAACCR_SEX_CODE;
     private Map<String, Object> additionalProperties = new HashMap<>();
 
-    public MskimpactPatientDemographics() {
-    }
-
-    public MskimpactPatientDemographics(String PT_ID_DEMO, String DMP_ID_DEMO, String GENDER,
-            String RACE, String RELIGION, Integer AGE_AT_DATE_OF_DEATH_IN_DAYS, String DEATH_SOURCE_DESCRIPTION,
-            String PT_COUNTRY, String PT_STATE, String PT_ZIP3_CD, Integer PT_BIRTH_YEAR, String PT_SEX_DESC,
-            String PT_VITAL_STATUS, String PT_MARITAL_STS_DESC, Integer PT_DEATH_YEAR, String PT_MRN_CREATE_YEAR, Integer TM_DX_YEAR) {
-        this.PT_ID_DEMO =  StringUtils.isNotEmpty(PT_ID_DEMO) ? PT_ID_DEMO : "NA";
-        this.DMP_ID_DEMO =  StringUtils.isNotEmpty(DMP_ID_DEMO) ? DMP_ID_DEMO : "NA";
-        this.GENDER =  StringUtils.isNotEmpty(GENDER) ? GENDER : "NA";
-        this.RACE =  StringUtils.isNotEmpty(RACE) ? RACE : "NA";
-        this.RELIGION =  StringUtils.isNotEmpty(RELIGION) ? RELIGION : "NA";
-        this.AGE_AT_DATE_OF_DEATH_IN_DAYS = AGE_AT_DATE_OF_DEATH_IN_DAYS != null ? AGE_AT_DATE_OF_DEATH_IN_DAYS : -1;
-        this.DEATH_SOURCE_DESCRIPTION =  StringUtils.isNotEmpty(DEATH_SOURCE_DESCRIPTION) ? DEATH_SOURCE_DESCRIPTION : "NA";
-        this.PT_COUNTRY =  StringUtils.isNotEmpty(PT_COUNTRY) ? PT_COUNTRY : "NA";
-        this.PT_STATE =  StringUtils.isNotEmpty(PT_STATE) ? PT_STATE : "NA";
-        this.PT_ZIP3_CD =  StringUtils.isNotEmpty(PT_ZIP3_CD) ? PT_ZIP3_CD : "NA";
-        this.PT_BIRTH_YEAR = PT_BIRTH_YEAR != null ? PT_BIRTH_YEAR : -1;
-        this.PT_SEX_DESC =  StringUtils.isNotEmpty(PT_SEX_DESC) ? PT_SEX_DESC : "NA";
-        this.PT_VITAL_STATUS =  StringUtils.isNotEmpty(PT_VITAL_STATUS) ? PT_VITAL_STATUS : "NA";
-        this.PT_MARITAL_STS_DESC =  StringUtils.isNotEmpty(PT_MARITAL_STS_DESC) ? PT_MARITAL_STS_DESC : "NA";
-        this.PT_DEATH_YEAR = PT_DEATH_YEAR != null ? PT_DEATH_YEAR : -1;
-        this.PT_MRN_CREATE_YEAR =  StringUtils.isNotEmpty(PT_MRN_CREATE_YEAR) ? PT_MRN_CREATE_YEAR : "NA";
-        this.TM_DX_YEAR = TM_DX_YEAR != null ? TM_DX_YEAR : -1;
-        this.OS_STATUS = this.PT_VITAL_STATUS;
-    }
+    public MskimpactPatientDemographics() {}
     
-    public MskimpactPatientDemographics(String DMP_ID_DEMO, String GENDER, String RACE, String RELIGION, String PT_VITAL_STATUS, Integer PT_BIRTH_YEAR, Integer PT_DEATH_YEAR, Integer TM_DX_YEAR, Integer AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS, Integer AGE_AT_TM_DX_DATE_IN_DAYS, Integer AGE_AT_DATE_OF_DEATH_IN_DAYS){
+    public MskimpactPatientDemographics(String DMP_ID_DEMO, String PT_NAACCR_SEX_CODE, String PT_NAACCR_RACE_CODE_PRIMARY, String PT_NAACCR_ETHNICITY_CODE, String RELIGION, String PT_VITAL_STATUS, Integer PT_BIRTH_YEAR, Integer PT_DEATH_YEAR, Integer TM_DX_YEAR, Integer AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS, Integer AGE_AT_TM_DX_DATE_IN_DAYS, Integer AGE_AT_DATE_OF_DEATH_IN_DAYS){
         this.DMP_ID_DEMO =  StringUtils.isNotEmpty(DMP_ID_DEMO) ? DMP_ID_DEMO : "NA";
-        this.GENDER =  StringUtils.isNotEmpty(GENDER) ? GENDER : "NA";
-        this.RACE =  StringUtils.isNotEmpty(RACE) ? RACE : "NA";
+        this.PT_NAACCR_SEX_CODE =  StringUtils.isNotEmpty(PT_NAACCR_SEX_CODE) ? PT_NAACCR_SEX_CODE : "-1";
+        this.PT_NAACCR_RACE_CODE_PRIMARY =  StringUtils.isNotEmpty(PT_NAACCR_RACE_CODE_PRIMARY) ? PT_NAACCR_RACE_CODE_PRIMARY : "-1";
+        this.PT_NAACCR_ETHNICITY_CODE =  StringUtils.isNotEmpty(PT_NAACCR_ETHNICITY_CODE) ? PT_NAACCR_ETHNICITY_CODE : "-1";
         this.RELIGION =  StringUtils.isNotEmpty(RELIGION) ? RELIGION : "NA";
         this.PT_VITAL_STATUS =  StringUtils.isNotEmpty(PT_VITAL_STATUS) ? PT_VITAL_STATUS : "NA";
         this.TM_DX_YEAR = TM_DX_YEAR != null ? TM_DX_YEAR : -1;
@@ -104,17 +84,6 @@ public class MskimpactPatientDemographics {
         this.AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS = AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS;
         this.AGE_AT_TM_DX_DATE_IN_DAYS = AGE_AT_TM_DX_DATE_IN_DAYS;
         this.AGE_AT_DATE_OF_DEATH_IN_DAYS = AGE_AT_DATE_OF_DEATH_IN_DAYS;
-    }
-    public MskimpactPatientDemographics(String DMP_ID_DEMO, String GENDER, String RACE, String RELIGION, String PT_VITAL_STATUS, Integer PT_BIRTH_YEAR, Integer PT_DEATH_YEAR){
-        this.DMP_ID_DEMO =  StringUtils.isNotEmpty(DMP_ID_DEMO) ? DMP_ID_DEMO : "NA";
-        this.GENDER =  StringUtils.isNotEmpty(GENDER) ? GENDER : "NA";
-        this.RACE =  StringUtils.isNotEmpty(RACE) ? RACE : "NA";
-        this.RELIGION =  StringUtils.isNotEmpty(RELIGION) ? RELIGION : "NA";
-        this.PT_VITAL_STATUS =  StringUtils.isNotEmpty(PT_VITAL_STATUS) ? PT_VITAL_STATUS : "NA";
-        this.TM_DX_YEAR = -1;
-        this.PT_BIRTH_YEAR = PT_BIRTH_YEAR != null ? PT_BIRTH_YEAR : -1;
-        this.PT_DEATH_YEAR = PT_DEATH_YEAR != null ? PT_DEATH_YEAR : -1;
-        this.OS_STATUS = this.PT_VITAL_STATUS;
     }
     
     public Integer getTM_DX_YEAR() {
@@ -345,6 +314,7 @@ public class MskimpactPatientDemographics {
         fieldNames.add("RACE");
         fieldNames.add("RELIGION");
         fieldNames.add("GENDER");
+        fieldNames.add("ETHNICITY");
         fieldNames.add("PT_VITAL_STATUS");
         fieldNames.add("AGE_AT_DIAGNOSIS");
         fieldNames.add("OS_STATUS");
@@ -360,6 +330,7 @@ public class MskimpactPatientDemographics {
         fieldNames.add("RACE");
         fieldNames.add("RELIGION");
         fieldNames.add("SEX");
+        fieldNames.add("ETHNICITY");
         fieldNames.add("DARWIN_VITAL_STATUS");
         fieldNames.add("AGE_AT_DIAGNOSIS");
         fieldNames.add("OS_STATUS");
@@ -375,6 +346,62 @@ public class MskimpactPatientDemographics {
 
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
+    }
+
+    /**
+     * @return the PT_NAACCR_ETHNICITY_CODE
+     */
+    public String getPT_NAACCR_ETHNICITY_CODE() {
+        return PT_NAACCR_ETHNICITY_CODE;
+    }
+
+    /**
+     * @param PT_NAACCR_ETHNICITY_CODE the PT_NAACCR_ETHNICITY_CODE to set
+     */
+    public void setPT_NAACCR_ETHNICITY_CODE(String PT_NAACCR_ETHNICITY_CODE) {
+        this.PT_NAACCR_ETHNICITY_CODE = PT_NAACCR_ETHNICITY_CODE;
+    }
+
+    /**
+     * @return the PT_NAACCR_RACE_CODE_PRIMARY
+     */
+    public String getPT_NAACCR_RACE_CODE_PRIMARY() {
+        return PT_NAACCR_RACE_CODE_PRIMARY;
+    }
+
+    /**
+     * @param PT_NAACCR_RACE_CODE_PRIMARY the NAACCR_RACE_CODE to set
+     */
+    public void setPT_NAACCR_RACE_CODE_PRIMARY(String PT_NAACCR_RACE_CODE_PRIMARY) {
+        this.PT_NAACCR_RACE_CODE_PRIMARY = PT_NAACCR_RACE_CODE_PRIMARY;
+    }
+
+    /**
+     * @return the PT_NAACCR_SEX_CODE
+     */
+    public String getPT_NAACCR_SEX_CODE() {
+        return PT_NAACCR_SEX_CODE;
+    }
+
+    /**
+     * @param PT_NAACCR_SEX_CODE the PT_NAACCR_SEX_CODE to set
+     */
+    public void setPT_NAACCR_SEX_CODE(String PT_NAACCR_SEX_CODE) {
+        this.PT_NAACCR_SEX_CODE = PT_NAACCR_SEX_CODE;
+    }
+
+    /**
+     * @return the ETHNICITY
+     */
+    public String getETHNICITY() {
+        return ETHNICITY;
+    }
+
+    /**
+     * @param ETHNICITY the ETHNICITY to set
+     */
+    public void setETHNICITY(String ETHNICITY) {
+        this.ETHNICITY = ETHNICITY;
     }
 
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/NAACCREthnicityMapping.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/NAACCREthnicityMapping.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.model;
+
+/**
+ *
+ * @author heinsz
+ */
+public class NAACCREthnicityMapping {
+    private Integer NECM_CODE;
+    private String NECM_CBIOPORTAL_LABEL;
+
+    public NAACCREthnicityMapping() {}
+
+    public NAACCREthnicityMapping(Integer NECM_CODE, String NECM_CBIOPORTAL_LABEL) {
+        this.NECM_CODE = NECM_CODE;
+        this.NECM_CBIOPORTAL_LABEL = NECM_CBIOPORTAL_LABEL;
+    }
+
+    /**
+     * @return the NECM_CODE
+     */
+    public Integer getNECM_CODE() {
+        return NECM_CODE;
+    }
+
+    /**
+     * @param NECM_CODE the NECM_CODE to set
+     */
+    public void setNECM_CODE(Integer NECM_CODE) {
+        this.NECM_CODE = NECM_CODE;
+    }
+
+    /**
+     * @return the NECM_CBIOPORTAL_LABEL
+     */
+    public String getNECM_CBIOPORTAL_LABEL() {
+        return NECM_CBIOPORTAL_LABEL;
+    }
+
+    /**
+     * @param NECM_CBIOPORTAL_LABEL the NECM_CBIOPORTAL_LABEL to set
+     */
+    public void setNECM_CBIOPORTAL_LABEL(String NECM_CBIOPORTAL_LABEL) {
+        this.NECM_CBIOPORTAL_LABEL = NECM_CBIOPORTAL_LABEL;
+    }
+}

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/NAACCRRaceMapping.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/NAACCRRaceMapping.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.model;
+
+/**
+ *
+ * @author heinsz
+ */
+public class NAACCRRaceMapping {
+    private Integer NRCM_CODE;
+    private String NRCM_CBIOPORTAL_LABEL;
+
+    public NAACCRRaceMapping() {}
+
+    public NAACCRRaceMapping(Integer NRCM_CODE, String NRCM_CBIOPORTAL_LABEL) {
+        this.NRCM_CODE = NRCM_CODE;
+        this.NRCM_CBIOPORTAL_LABEL = NRCM_CBIOPORTAL_LABEL;
+    }
+
+    /**
+     * @return the NRCM_CODE
+     */
+    public Integer getNRCM_CODE() {
+        return NRCM_CODE;
+    }
+
+    /**
+     * @param NRCM_CODE the NRCM_CODE to set
+     */
+    public void setNRCM_CODE(Integer NRCM_CODE) {
+        this.NRCM_CODE = NRCM_CODE;
+    }
+
+    /**
+     * @return the NRCM_CBIOPORTAL_LABEL
+     */
+    public String getNRCM_CBIOPORTAL_LABEL() {
+        return NRCM_CBIOPORTAL_LABEL;
+    }
+
+    /**
+     * @param NRCM_CBIOPORTAL_LABEL the NRCM_CBIOPORTAL_LABEL to set
+     */
+    public void setNRCM_CBIOPORTAL_LABEL(String NRCM_CBIOPORTAL_LABEL) {
+        this.NRCM_CBIOPORTAL_LABEL = NRCM_CBIOPORTAL_LABEL;
+    }
+}

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/NAACCRSexMapping.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/NAACCRSexMapping.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.model;
+
+/**
+ *
+ * @author heinsz
+ */
+public class NAACCRSexMapping {
+    private Integer NSCM_CODE;
+    private String NSCM_CBIOPORTAL_LABEL;
+
+    public NAACCRSexMapping() {}
+
+    public NAACCRSexMapping(Integer NSCM_CODE, String NSCM_CBIOPORTAL_LABEL) {
+        this.NSCM_CODE = NSCM_CODE;
+        this.NSCM_CBIOPORTAL_LABEL = NSCM_CBIOPORTAL_LABEL;
+    }
+
+    /**
+     * @return the NSCM_CODE
+     */
+    public Integer getNSCM_CODE() {
+        return NSCM_CODE;
+    }
+
+    /**
+     * @param NSCM_CODE the NSCM_CODE to set
+     */
+    public void setNSCM_CODE(Integer NSCM_CODE) {
+        this.NSCM_CODE = NSCM_CODE;
+    }
+
+    /**
+     * @return the NSCM_CBIOPORTAL_LABEL
+     */
+    public String getNSCM_CBIOPORTAL_LABEL() {
+        return NSCM_CBIOPORTAL_LABEL;
+    }
+
+    /**
+     * @param NSCM_CBIOPORTAL_LABEL the NSCM_CBIOPORTAL_LABEL to set
+     */
+    public void setNSCM_CBIOPORTAL_LABEL(String NSCM_CBIOPORTAL_LABEL) {
+        this.NSCM_CBIOPORTAL_LABEL = NSCM_CBIOPORTAL_LABEL;
+    }
+
+}


### PR DESCRIPTION
- Query the demographics view for the naaccr codes for sex, race, and ethnicity and translate them using the Darwin naaccr mapping tables
- Added field `ETHNICITY`
- Removed some unnecessary constructors in the `MskimpactPatientDemographics` class

@angelicaochoa @sheridancbio 