### PR TITLE
Fixed CVR mutation data reader

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
@@ -105,12 +105,10 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                         log.warn("Failed to annotate a record from json! Sample: " + sampleId + " Variant: " + record.getChromosome() + ":" + record.getStart_Position() + record.getReference_Allele() + ">" + record.getTumor_Seq_Allele2());
                         annotatedRecord = cvrUtilities.buildCVRAnnotatedRecord(record);
                     }
-                    Map<String, String> additionalProperties = record.getAdditionalProperties();
-                    additionalProperties.put("IS_NEW", cvrUtilities.IS_NEW);
-                    record.setAdditionalProperties(additionalProperties);
+                    annotatedRecord.getAdditionalProperties().put("IS_NEW", cvrUtilities.IS_NEW);
                     mutationRecords.add(annotatedRecord);
-                    header.addAll(record.getHeaderWithAdditionalFields());
-                    additionalPropertyKeys.addAll(record.getAdditionalProperties().keySet());
+                    header.addAll(annotatedRecord.getHeaderWithAdditionalFields());
+                    additionalPropertyKeys.addAll(annotatedRecord.getAdditionalProperties().keySet());
                     mutationMap.getOrDefault(annotatedRecord.getTumor_Sample_Barcode(), new ArrayList()).add(annotatedRecord);
                 }
             }


### PR DESCRIPTION
Mutation reader was not capturing the additional annotated field names because the header was being generated from the record loaded either (1) from the existing mutation data file or (2) from manually building an annotated record from the record in the file when annotation fails.

To fix this the mutation file header is now generated from the returned annotated record instead.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>