### PR TITLE
Trim SV gene data from CVR

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionFieldSetMapper.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionFieldSetMapper.java
@@ -54,7 +54,7 @@ public class CVRFusionFieldSetMapper implements  FieldSetMapper<CVRFusionRecord>
         for (int i = 0; i < fields.size(); i++) {
             String field = fields.get(i);
             try {
-                record.getClass().getMethod("set" + field, String.class).invoke(record, fs.readString(i));
+                record.getClass().getMethod("set" + field, String.class).invoke(record, fs.readString(i).trim());
             } catch (Exception e) {
                 if (e.getClass().equals(NoSuchMethodException.class)) {
                     log.info("No set method exists for " + field);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRFusionRecord.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRFusionRecord.java
@@ -55,11 +55,13 @@ public class CVRFusionRecord {
     }
 
     public CVRFusionRecord(CVRSvVariant variant, String sampleId, boolean reversed) {
-        this.hugoSymbol = reversed ? variant.getSite2_Gene() : variant.getSite1_Gene();
+        String site1GeneTrimmed = variant.getSite1_Gene().trim();
+        String site2GeneTrimmed = variant.getSite2_Gene().trim();
+        this.hugoSymbol = reversed ? site2GeneTrimmed : site1GeneTrimmed;
         this.entrezGeneId = "0";
         this.center = "MSKCC-DMP";
         this.tumorSampleBarcode = sampleId;
-        this.fusion = variant.getSite1_Gene().equals(variant.getSite2_Gene()) ? variant.getSite1_Gene() + "-intragenic" : variant.getSite2_Gene() + "-" + variant.getSite1_Gene() + " fusion";
+        this.fusion = site1GeneTrimmed.equals(site2GeneTrimmed) ? site1GeneTrimmed + "-intragenic" : site2GeneTrimmed + "-" + site1GeneTrimmed + " fusion";
         this.dnaSupport = "yes";
         this.rnaSupport = "unknown";
         this.method = "NA";

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/sv/CVRSvDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/sv/CVRSvDataReader.java
@@ -98,6 +98,8 @@ public class CVRSvDataReader implements ItemStreamReader<CVRSvRecord> {
                 CVRSvRecord to_add;
                 while ((to_add = reader.read()) != null) {
                     if (!cvrUtilities.getNewIds().contains(to_add.getSampleId()) && to_add.getSampleId()!= null) {
+                        to_add.setSite1_Gene(to_add.getSite1_Gene().trim());
+                        to_add.setSite2_Gene(to_add.getSite2_Gene().trim());
                         svRecords.add(to_add);
                     }
                 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/sv/CVRSvFieldSetMapper.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/sv/CVRSvFieldSetMapper.java
@@ -54,7 +54,7 @@ public class CVRSvFieldSetMapper implements  FieldSetMapper<CVRSvRecord> {
         for (int i = 0; i < fields.size(); i++) {
             String field = fields.get(i);
             try {
-                record.getClass().getMethod("set" + field, String.class).invoke(record, fs.readString(i));
+                record.getClass().getMethod("set" + field, String.class).invoke(record, fs.readString(i).trim());
             } catch (Exception e) {
                 if (e.getClass().equals(NoSuchMethodException.class)) {
                     log.info("No set method exists for " + field);


### PR DESCRIPTION
CVR should be fixing this issue in their code in the next release, but it doesn't hurt to be defensive in reading the gene names. Potentially we would want to trim all fields coming from CVR, but this PR is just a band-aid to fix the current issue.

@sheridancbio 
@angelicaochoa 