### PR TITLE
Set min age for darwin

### DIFF
--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientDemographics.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientDemographics.java
@@ -288,12 +288,18 @@ public class MskimpactPatientDemographics {
                 if (i >= 90){
                     return "90";
                 }
+                else if (i <= 18) {
+                    return "18";
+                }
                 return i.toString();
             }
             Integer i = currentYear-this.PT_BIRTH_YEAR;
             //Age > 90 is considered identifying
             if (i >= 90) {
                 return "90";
+            }
+            else if (i <= 18) {
+                return "18";
             }
             return i.toString();
         }


### PR DESCRIPTION
Reporting ages under 18 is a potential patient identification issue. We will in the future support "<" and ">" characters in the age field.

@angelicaochoa @sheridancbio 