### PR TITLE
Fixed missing annotated headers issue in CVR unfiltered mutation reader

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRUnfilteredMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRUnfilteredMutationDataReader.java
@@ -104,12 +104,10 @@ public class CVRUnfilteredMutationDataReader implements ItemStreamReader<Annotat
                     log.warn("Failed to annotate a record from json! Sample: " + sampleId + " Variant: " + record.getChromosome() + ":" + record.getStart_Position() + record.getReference_Allele() + ">" + record.getTumor_Seq_Allele2());
                     annotatedRecord = cvrUtilities.buildCVRAnnotatedRecord(record);
                 }
-                Map<String, String> additionalProperties = annotatedRecord.getAdditionalProperties();
-                additionalProperties.put("IS_NEW", cvrUtilities.IS_NEW);
-                record.setAdditionalProperties(additionalProperties);
+                annotatedRecord.getAdditionalProperties().put("IS_NEW", cvrUtilities.IS_NEW);
                 mutationRecords.add(annotatedRecord);
-                header.addAll(record.getHeaderWithAdditionalFields());
-                additionalPropertyKeys.addAll(record.getAdditionalProperties().keySet());
+                header.addAll(annotatedRecord.getHeaderWithAdditionalFields());
+                additionalPropertyKeys.addAll(annotatedRecord.getAdditionalProperties().keySet());
                 mutationMap.getOrDefault(annotatedRecord.getTumor_Sample_Barcode(), new ArrayList()).add(annotatedRecord);
             }
         }


### PR DESCRIPTION
`CVRUnfilteredMutationDataReader.java` was not adding the annotated headers when loading mutation records from the unfiltered MAF. Therefore when the unfiltered MAF was generated, the MAF was still missing the extra headers expected after annotation.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>