### PR TITLE
Immunotherapy timeline and clinical attributes

### DIFF
--- a/darwin/pom.xml
+++ b/darwin/pom.xml
@@ -36,6 +36,11 @@
             <type>jar</type>
         </dependency>
         <dependency>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+          <version>3.2.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>4.1.8.RELEASE</version>

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactMedicalTherapy.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactMedicalTherapy.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 2of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.model;
+
+import java.util.*;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+/**
+ * Class to model relevant data from record within DVCBIO.PHARMACY_V.
+ *
+ * @author Benjamin Gross
+ */
+public class MskimpactMedicalTherapy implements Comparable<MskimpactMedicalTherapy>
+{
+    private String PT_ID_PHARMACY;
+    private String DMP_ID_PHARMACY;
+    private Integer AGE_AT_DISPENSE_DATE_IN_DAYS;
+    private String GENERIC_DRUG_NAME;
+    private Float DOSAGE;
+    private String DOSE_UNIT;
+    private Float DISPENSED_QUANTITY;
+    private Integer START_DATE;
+    private Integer STOP_DATE;
+
+    public MskimpactMedicalTherapy() {}
+
+    /**
+     * All fields are coming directly from DVCBIO.PHARMACY_V
+     */
+    public MskimpactMedicalTherapy(String PT_ID_PHARMACY, String DMP_ID_PHARMACY,
+                                   Integer AGE_AT_DISPENSE_DATE_IN_DAYS, String GENERIC_DRUG_NAME,
+                                   Float DOSAGE, String DOSE_UNIT, Float DISPENSED_QUANTITY) {
+        this(PT_ID_PHARMACY, DMP_ID_PHARMACY, AGE_AT_DISPENSE_DATE_IN_DAYS,
+             GENERIC_DRUG_NAME, DOSAGE, DOSE_UNIT, DISPENSED_QUANTITY,
+             AGE_AT_DISPENSE_DATE_IN_DAYS, AGE_AT_DISPENSE_DATE_IN_DAYS);
+    }
+
+    /**
+     * All fields are coming from DVCBIO.PHARMACY_V with the exception of 
+     * START_DATE, STOP_DATE  which are chosen "AGE_AT_DISPENSE_DATE_IN_DAYS" of patient
+     * - see MksimpactMedicalTherapyProcessor for more information.
+     */
+    public MskimpactMedicalTherapy(String PT_ID_PHARMACY, String DMP_ID_PHARMACY,
+                                   Integer AGE_AT_DISPENSE_DATE_IN_DAYS, String GENERIC_DRUG_NAME,
+                                   Float DOSAGE, String DOSE_UNIT, Float DISPENSED_QUANTITY,
+                                   Integer START_DATE, Integer STOP_DATE) {
+        this.PT_ID_PHARMACY = PT_ID_PHARMACY.trim();
+        this.DMP_ID_PHARMACY = DMP_ID_PHARMACY.trim();
+        this.AGE_AT_DISPENSE_DATE_IN_DAYS = AGE_AT_DISPENSE_DATE_IN_DAYS;
+        this.GENERIC_DRUG_NAME = GENERIC_DRUG_NAME.trim();
+        this.DOSAGE = DOSAGE;
+        this.DOSE_UNIT = DOSE_UNIT.trim();
+        this.DISPENSED_QUANTITY = DISPENSED_QUANTITY;
+        this.START_DATE = START_DATE;
+        this.STOP_DATE = STOP_DATE;
+    }
+
+    public String getPT_ID_PHARMACY() {
+        return PT_ID_PHARMACY;
+    }
+
+    public String getDMP_ID_PHARMACY() {
+        return DMP_ID_PHARMACY;
+    }
+
+    public Integer getAGE_AT_DISPENSE_DATE_IN_DAYS() {
+        return AGE_AT_DISPENSE_DATE_IN_DAYS;
+    }
+
+    public String getGENERIC_DRUG_NAME() {
+        return GENERIC_DRUG_NAME;
+    }
+
+    public Float getDOSAGE() {
+        return DOSAGE;
+    }
+
+    public String getDOSE_UNIT() {
+        return DOSE_UNIT;
+    }
+
+    public Float getDISPENSED_QUANTITY() {
+        return DISPENSED_QUANTITY;
+    }
+
+    public Integer getSTART_DATE() {
+        return START_DATE;
+    }
+
+    public Integer getSTOP_DATE() {
+        return STOP_DATE;
+    }
+
+    public static List<String> getHeaders(){
+        return Arrays.asList("PATIENT_ID", "START_DATE", "STOP_DATE", "EVENT_TYPE",
+                             "TREATMENT_TYPE", "SUBTYPE", "AGENT", "DOSAGE");
+    }
+
+    /**
+     * MskimpactMedicalTherapyProcessor will sort a collection of these records
+     * by AGE_AT_DISPENSE_DATE_IN_DAYS in order to create a START_DATE-STOP_DATE range.
+     */
+    @Override
+    public int compareTo(MskimpactMedicalTherapy that) {
+        if (this.AGE_AT_DISPENSE_DATE_IN_DAYS < that.AGE_AT_DISPENSE_DATE_IN_DAYS) return -1;
+        if (this.AGE_AT_DISPENSE_DATE_IN_DAYS > that.AGE_AT_DISPENSE_DATE_IN_DAYS) return 1;
+        return 0;
+    }
+
+    /**
+     * This is called to create a record with within the timeline file
+     */
+    @Override
+    public String toString() {
+        return (DMP_ID_PHARMACY + "\t" + START_DATE + "\t" + STOP_DATE + "\t" +
+                "TREATMENT\tMedical Therapy\tImmunotherapy\t" +
+                GENERIC_DRUG_NAME + "\t" + Math.round(DOSAGE) + " " + DOSE_UNIT);
+    }
+}

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyClinicalWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyClinicalWriter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.mskimpact_medicaltherapy;
+
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactMedicalTherapy;
+
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.core.io.*;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Value;
+import java.io.*;
+import java.util.*;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * @author Benjamin Gross
+ */
+public class MskimpactMedicalTherapyClinicalWriter implements ItemStreamWriter<MskimpactMedicalTherapy>
+{
+    @Value("#{jobParameters[outputDirectory]}")
+    private String outputDirectory;
+    
+    @Value("${darwin.medicaltherapy_clinical_filename}")
+    private String outputFilename;
+
+    private String stagingFile;
+
+    private List<String> writeList = new ArrayList<>();
+    private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
+        
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException{
+        PassThroughLineAggregator aggr = new PassThroughLineAggregator();
+        flatFileItemWriter.setLineAggregator(aggr);
+        flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback(){
+            @Override
+            public void writeHeader(Writer writer) throws IOException{
+                writer.write("PATIENT_ID\tIMMUNE_TREATMENT");
+            }
+        });
+        stagingFile = outputDirectory + File.separator + outputFilename;
+        flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
+        flatFileItemWriter.open(executionContext);
+    }
+    
+    @Override
+    public void update(ExecutionContext executionContext) throws ItemStreamException{}
+    
+    @Override
+    public void close() throws ItemStreamException{
+        flatFileItemWriter.close();
+    }
+    
+    @Override
+    public void write(List<? extends MskimpactMedicalTherapy> items) throws Exception{
+        writeList.clear();
+        for (MskimpactMedicalTherapy item : items) {
+            writeList.add(item.getDMP_ID_PHARMACY() + "\tYes");
+        }
+        flatFileItemWriter.write(writeList);
+    }
+}

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.mskimpact_medicaltherapy;
+
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactMedicalTherapy;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.collections.map.MultiKeyMap;
+
+import org.springframework.batch.item.ItemProcessor;
+
+import java.util.*;
+
+/**
+ * This processor takes a list of medical therapy records all for a single patient, grouped by
+ * DMP-ID/drug-name/dosage/dose-unit/dispensed quantity and collapses them down into a single record
+ * with a start/stop date based on a sort of the AGE_AT_DISPENSE_DATE_IN_DAYS values across all records.
+ *
+ * @author Benjamin Gross
+ */
+public class MskimpactMedicalTherapyProcessor implements ItemProcessor<List<MskimpactMedicalTherapy>, MskimpactMedicalTherapy>
+{
+    /**
+     * All items in the list are identical with the exception of AGE_AT_DISPENSE_DATE_IN_DAYS, the time at which
+     * the drug was dispensed to the patient.
+     */
+    @Override
+    public MskimpactMedicalTherapy process(final List<MskimpactMedicalTherapy> listMedicalTherapyRecords) throws Exception {
+        checkConsistencyOfRecords(listMedicalTherapyRecords);
+        Collections.sort(listMedicalTherapyRecords);
+        MskimpactMedicalTherapy oldestRecord = listMedicalTherapyRecords.get(0);
+        MskimpactMedicalTherapy youngestRecord = listMedicalTherapyRecords.get(listMedicalTherapyRecords.size()-1);
+        // we can use any record in the list to populate all fields except for START_DATE, STOP_DATE
+        return new MskimpactMedicalTherapy(oldestRecord.getPT_ID_PHARMACY(),
+                                           oldestRecord.getDMP_ID_PHARMACY(),
+                                           -1,
+                                           oldestRecord.getGENERIC_DRUG_NAME(),
+                                           oldestRecord.getDOSAGE(),
+                                           oldestRecord.getDOSE_UNIT(),
+                                           oldestRecord.getDISPENSED_QUANTITY(),
+                                           oldestRecord.getAGE_AT_DISPENSE_DATE_IN_DAYS(),
+                                           youngestRecord.getAGE_AT_DISPENSE_DATE_IN_DAYS());
+        
+    }
+
+    private void checkConsistencyOfRecords(List<MskimpactMedicalTherapy> listMedicalTherapyRecords) {
+        MultiKeyMap byRecordAttributes = new MultiKeyMap();
+        for (MskimpactMedicalTherapy record : listMedicalTherapyRecords) {
+            byRecordAttributes.put(record.getDMP_ID_PHARMACY(), record.getGENERIC_DRUG_NAME(),
+                                 record.getDOSAGE(), record.getDOSE_UNIT(), record.getDISPENSED_QUANTITY());
+        }
+
+        assert byRecordAttributes.keySet().size() == 1;
+    }
+}

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyReader.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyReader.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.mskimpact_medicaltherapy;
+
+import org.mskcc.cmo.ks.darwin.pipeline.model.*;
+
+import com.querydsl.sql.SQLQueryFactory;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.BooleanBuilder;
+import static com.querydsl.core.alias.Alias.*;
+
+import org.springframework.batch.item.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import org.apache.log4j.Logger;
+import org.apache.commons.collections.MapIterator;
+import org.apache.commons.collections.map.MultiKeyMap;
+
+import java.util.*;
+import javax.annotation.Resource;
+
+/**
+ * Code reads information out of DVCBIO.PHARMACY_V looking 
+ * for records in which immunotherapy related drugs were dispensed.
+ *
+ * @author Benjamin Gross
+ */
+public class MskimpactMedicalTherapyReader implements ItemStreamReader<List<MskimpactMedicalTherapy>>
+{
+    private String pharmacyView = "PHARMACY_V";
+
+    @Value("${darwin.pathology_dmp_view}")
+    private String pathologyView;
+
+    @Value("${darwin.medicaltherapy.pharmacy_druglist}")
+    private String pharmacyViewDrugList;
+
+    @Value("${darwin.medicaltherapy.skip_negative_dosage_records}")
+    private Boolean skipNegativeDosageRecords;
+
+    @Value("#{jobParameters[studyID]}")
+    private String studyID;
+
+    @Resource(name="studyIdRegexMap")
+    Map<String, String> studyIdRegexMap;
+
+    @Autowired
+    SQLQueryFactory darwinQueryFactory;
+
+    private MultiKeyMap byPharmacyRecordAttributes;
+
+    Logger log = Logger.getLogger(MskimpactMedicalTherapyReader.class);
+
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        byPharmacyRecordAttributes = groupPharmacyViewResults(getPharmacyViewResults());
+    }
+
+    @Transactional
+    private List<MskimpactMedicalTherapy> getPharmacyViewResults() {
+
+        if (log.isInfoEnabled()) {
+            log.info("Start of " + pharmacyView + " record fetching...");
+        }
+        
+        MskimpactMedicalTherapy pharmacyViewRecord = alias(MskimpactMedicalTherapy.class, pharmacyView);
+        MskimpactPathologyDmp pathologyViewRecord = alias(MskimpactPathologyDmp.class, pathologyView);
+        List<MskimpactMedicalTherapy> pharmacyViewResults =
+            darwinQueryFactory.select(Projections.constructor(MskimpactMedicalTherapy.class,
+                $(pharmacyViewRecord.getPT_ID_PHARMACY()),
+                $(pharmacyViewRecord.getDMP_ID_PHARMACY()),
+                $(pharmacyViewRecord.getAGE_AT_DISPENSE_DATE_IN_DAYS()),
+                $(pharmacyViewRecord.getGENERIC_DRUG_NAME()),
+                $(pharmacyViewRecord.getDOSAGE()),
+                $(pharmacyViewRecord.getDOSE_UNIT()),
+                $(pharmacyViewRecord.getDISPENSED_QUANTITY())))
+            .from($(pharmacyViewRecord))
+            .innerJoin($(pathologyViewRecord))
+            .on($(pharmacyViewRecord.getPT_ID_PHARMACY()).eq($(pathologyViewRecord.getPT_ID_PATH_DMP())))
+            .where($(pathologyViewRecord.getSAMPLE_ID_PATH_DMP()).like(studyIdRegexMap.get(studyID))
+                   .and(getDrugClause(pharmacyViewRecord)))
+            .fetch();
+
+        if (log.isInfoEnabled()) {
+            log.info("Fetched " + pharmacyViewResults.size() + " records from " + pharmacyView + ".");
+        }
+
+        return pharmacyViewResults;
+    }
+
+    /**
+     * This method constructs part of the pharmacy view 'where' clause 
+     * such that only records that contain a drug or drugs of interest (provided by application.properties)
+     * are returned from the query.
+     */
+    private BooleanBuilder getDrugClause(MskimpactMedicalTherapy pharmacyViewRecord) {
+        BooleanBuilder builder = new BooleanBuilder();
+        for (String drug : pharmacyViewDrugList.split(";")) {
+            builder.or($(pharmacyViewRecord.getGENERIC_DRUG_NAME()).toUpperCase().like("%" + drug + "%"));
+        }
+        return builder;
+    }
+
+    /**
+     * This method collects all pharmacy records for a patient into a list group by
+     * DMP-ID/drug-name/dosage/dose-unit/dispensed quantity.
+     */
+    private MultiKeyMap groupPharmacyViewResults(List<MskimpactMedicalTherapy> pharmacyViewResults) {
+        MultiKeyMap toReturn = new MultiKeyMap();
+        for (MskimpactMedicalTherapy pharmacyViewResult : pharmacyViewResults) {
+            if (skipNegativeDosageRecords && pharmacyViewResult.getDOSAGE() < 0) continue;
+            if (!toReturn.containsKey(pharmacyViewResult.getDMP_ID_PHARMACY(),
+                                      pharmacyViewResult.getGENERIC_DRUG_NAME(),
+                                      pharmacyViewResult.getDOSAGE(),
+                                      pharmacyViewResult.getDOSE_UNIT(),
+                                      pharmacyViewResult.getDISPENSED_QUANTITY())) {
+                List<MskimpactMedicalTherapy> newMedicalTherapyList = new ArrayList<MskimpactMedicalTherapy>();
+                newMedicalTherapyList.add(pharmacyViewResult);
+                toReturn.put(pharmacyViewResult.getDMP_ID_PHARMACY(),
+                             pharmacyViewResult.getGENERIC_DRUG_NAME(),
+                             pharmacyViewResult.getDOSAGE(),
+                             pharmacyViewResult.getDOSE_UNIT(),
+                             pharmacyViewResult.getDISPENSED_QUANTITY(),
+                             newMedicalTherapyList);
+            }
+            else {
+                List<MskimpactMedicalTherapy> existingMedicalTherapyList =
+                    (List<MskimpactMedicalTherapy>)toReturn.get(pharmacyViewResult.getDMP_ID_PHARMACY(),
+                                                                pharmacyViewResult.getGENERIC_DRUG_NAME(),
+                                                                pharmacyViewResult.getDOSAGE(),
+                                                                pharmacyViewResult.getDOSE_UNIT(),
+                                                                pharmacyViewResult.getDISPENSED_QUANTITY());
+                existingMedicalTherapyList.add(pharmacyViewResult);
+                toReturn.put(pharmacyViewResult.getDMP_ID_PHARMACY(),
+                             pharmacyViewResult.getGENERIC_DRUG_NAME(),
+                             pharmacyViewResult.getDOSAGE(),
+                             pharmacyViewResult.getDOSE_UNIT(),
+                             pharmacyViewResult.getDISPENSED_QUANTITY(),
+                             existingMedicalTherapyList);
+            }
+        }
+        return toReturn;
+    }
+
+    @Override
+    public void update(ExecutionContext executionContext) throws ItemStreamException{}
+
+    @Override
+    public void close() throws ItemStreamException{}
+
+    @Override
+    public List<MskimpactMedicalTherapy> read() throws Exception {
+        MapIterator it = byPharmacyRecordAttributes.mapIterator();
+        if (it.hasNext()) {
+            it.next(); // calling .next() allows us to make the subsequent getValue() call
+            List<MskimpactMedicalTherapy> toReturn = (List<MskimpactMedicalTherapy>)it.getValue();
+            it.remove();
+            return toReturn;
+        }
+        return null;
+    }
+
+}

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyTimelineWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyTimelineWriter.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.darwin.pipeline.mskimpact_medicaltherapy;
+
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactMedicalTherapy;
+
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.core.io.*;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Value;
+import java.io.*;
+import java.util.*;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * @author Benjamin Gross
+ */
+public class MskimpactMedicalTherapyTimelineWriter implements ItemStreamWriter<MskimpactMedicalTherapy>
+{
+    @Value("#{jobParameters[outputDirectory]}")
+    private String outputDirectory;
+    
+    @Value("${darwin.medicaltherapy_timeline_filename}")
+    private String outputFilename;
+
+    private String stagingFile;
+
+    private List<String> writeList = new ArrayList<>();
+    private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
+        
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException{
+        PassThroughLineAggregator aggr = new PassThroughLineAggregator();
+        flatFileItemWriter.setLineAggregator(aggr);
+        flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback(){
+            @Override
+            public void writeHeader(Writer writer) throws IOException{
+                writer.write(StringUtils.join(MskimpactMedicalTherapy.getHeaders(), "\t"));
+            }
+        });
+        stagingFile = outputDirectory + File.separator + outputFilename;
+        flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
+        flatFileItemWriter.open(executionContext);
+    }
+    
+    @Override
+    public void update(ExecutionContext executionContext) throws ItemStreamException{}
+    
+    @Override
+    public void close() throws ItemStreamException{
+        flatFileItemWriter.close();
+    }
+    
+    @Override
+    public void write(List<? extends MskimpactMedicalTherapy> items) throws Exception {
+        // TBD: figure out why we cannot pass items to FlatFileItemWriter directly
+        writeList.clear();
+         for (MskimpactMedicalTherapy item : items) {
+            writeList.add(item.toString());
+        }
+        flatFileItemWriter.write(writeList);
+    }
+}

--- a/darwin/src/main/resources/application.properties.EXAMPLE
+++ b/darwin/src/main/resources/application.properties.EXAMPLE
@@ -41,6 +41,10 @@ darwin.timeline_bs_imaging=data_timeline_diagnostics_caisis_gbm.txt
 darwin.timeline_bs_surgery=data_timeline_surgery_caisis_gbm.txt
 darwin.clinical_view=DMT_CLINICAL_BRAINSPINE_V
 darwin.clinical_filename=data_clinical_supp_caisis_gbm.txt
+darwin.medicaltherapy.pharmacy_druglist=IPILIMUMAB;PEMBROLIZUMAB;NIVOLUMAB;ATEZOLIZUMAB # drug names should be in all UPPERCASE
+darwin.medicaltherapy_timeline_filename=data_timeline_medical_therapy.txt
+darwin.medicaltherapy_clinical_filename=data_clinical_supp_medical_therapy.txt
+darwin.medicaltherapy.skip_negative_dosage_records=true
 
 # For redcap metadata clinical attributes header generation
 metadata_project=


### PR DESCRIPTION
Code to generate immunotherapy timelines and clinical attributes for IMPACT patients via DVCBIO.PHARMACY_V.  Currently turned of until we can get a proper age at diagnosis to use as "time zero" to compute start/stop dates of treatment. 