### PR TITLE
CVR option for reannotating mafs

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
@@ -63,7 +63,8 @@ public class CVRPipeline {
             .addOption("i", "study_id", true, "Study identifier (i.e., mskimpact, raindance, archer, etc.)")
             .addOption("t", "test", false, "Flag for running pipeline in testing mode so that samples are not consumed")
             .addOption("c", "consume_samples", true, "Path to CVR json filename")
-            .addOption("r", "max_samples_to_remove", true, "The max number of samples that can be removed from data");
+            .addOption("r", "max_samples_to_remove", true, "The max number of samples that can be removed from data")
+            .addOption("f", "force_annotation", false, "Flag for forcing reannotation of samples");
         return gnuOptions;
     }
 
@@ -74,7 +75,7 @@ public class CVRPipeline {
     }
 
     private static void launchCvrPipelineJob(String[] args, String directory, String studyId, Boolean json, Boolean gml, 
-            Boolean gmljson, Boolean skipSeg, boolean testingMode, Integer maxNumSamplesToRemove) throws Exception {
+            Boolean gmljson, Boolean skipSeg, boolean testingMode, Integer maxNumSamplesToRemove, Boolean forceAnnotation) throws Exception {
         // log wether in testing mode or not
         if (testingMode) {
             log.warn("CvrPipelineJob running in TESTING MODE - samples will NOT be requeued.");
@@ -93,7 +94,8 @@ public class CVRPipeline {
         builder.addString("stagingDirectory", directory)
                 .addString("studyId", studyId)
                 .addString("testingMode", String.valueOf(testingMode))
-                .addString("maxNumSamplesToRemove", String.valueOf(maxNumSamplesToRemove));
+                .addString("maxNumSamplesToRemove", String.valueOf(maxNumSamplesToRemove))
+                .addString("forceAnnotation", String.valueOf(forceAnnotation));
         if (json) {
             jobName = BatchConfiguration.JSON_JOB;
         }
@@ -182,7 +184,8 @@ public class CVRPipeline {
             
             launchCvrPipelineJob(args, commandLine.getOptionValue("d"), commandLine.getOptionValue("i"),
                 commandLine.hasOption("j"), commandLine.hasOption("g"), commandLine.hasOption("m"),
-                commandLine.hasOption("s"), commandLine.hasOption("t"), maxNumSamplesToRemove);
+                commandLine.hasOption("s"), commandLine.hasOption("t"), maxNumSamplesToRemove,
+                commandLine.hasOption("f"));
         }
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
@@ -57,6 +57,9 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
     @Value("#{jobParameters[stagingDirectory]}")
     private String stagingDirectory;
 
+    @Value("#{jobParameters[forceAnnotation]}")
+    private boolean forceAnnotation;
+
     @Autowired
     public CVRUtilities cvrUtilities;
     
@@ -76,7 +79,7 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
 
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
-        CVRData cvrData = new CVRData();        
+        CVRData cvrData = new CVRData();
         // load cvr data from cvr_data.json file
         File cvrFile = new File(stagingDirectory, cvrUtilities.CVR_FILE);
         try {
@@ -85,7 +88,7 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
             log.error("Error reading file: " + cvrFile.getName());
             throw new ItemStreamException(e);
         }
-        
+
         Set<String> header = new LinkedHashSet<>();
         for (CVRMergedResult result : cvrData.getResults()) {
             String sampleId = result.getMetaData().getDmpSampleId();
@@ -100,7 +103,7 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                     MutationRecord record = cvrUtilities.buildCVRMutationRecord(snp, sampleId, somaticStatus);
                     AnnotatedRecord annotatedRecord;
                     try {
-                        annotatedRecord = annotator.annotateRecord(record, false, "mskcc", false);
+                        annotatedRecord = annotator.annotateRecord(record, false, "mskcc", forceAnnotation);
                     } catch (HttpServerErrorException e) {
                         log.warn("Failed to annotate a record from json! Sample: " + sampleId + " Variant: " + record.getChromosome() + ":" + record.getStart_Position() + record.getReference_Allele() + ">" + record.getTumor_Seq_Allele2());
                         annotatedRecord = cvrUtilities.buildCVRAnnotatedRecord(record);
@@ -112,18 +115,18 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                 }
             }
         }
-        
+
         this.mutationFile = new File(stagingDirectory, cvrUtilities.MUTATION_FILE);
         if (!mutationFile.exists()) {
             log.info("File does not exist - skipping data loading from mutation file: " + mutationFile.getName());
         }
         else {
-            log.info("Loading mutation data from: " + mutationFile.getName());            
+            log.info("Loading mutation data from: " + mutationFile.getName());
             final DelimitedLineTokenizer tokenizer = new DelimitedLineTokenizer(DelimitedLineTokenizer.DELIMITER_TAB);
             DefaultLineMapper<MutationRecord> mapper = new DefaultLineMapper<>();
             mapper.setLineTokenizer(tokenizer);
             mapper.setFieldSetMapper(new CVRMutationFieldSetMapper());
-            
+
             FlatFileItemReader<MutationRecord> reader = new FlatFileItemReader<>();
             reader.setResource(new FileSystemResource(mutationFile));
             reader.setLineMapper(mapper);
@@ -135,7 +138,7 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                 }
             });
             reader.open(ec);
-            
+
             try {
                 MutationRecord to_add;
                 while ((to_add = reader.read()) != null && to_add.getTumor_Sample_Barcode() != null) {
@@ -143,7 +146,7 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                             !cvrUtilities.isDuplicateRecord(to_add, mutationMap.get(to_add.getTumor_Sample_Barcode()))) {
                         AnnotatedRecord to_add_annotated;
                         try {
-                            to_add_annotated = annotator.annotateRecord(to_add, false, "mskcc", false);
+                            to_add_annotated = annotator.annotateRecord(to_add, false, "mskcc", forceAnnotation);
                         } catch (HttpServerErrorException e) {
                             log.warn("Failed to annotate a record from existing file! Sample: " + to_add.getTumor_Sample_Barcode() + " Variant: " + to_add.getChromosome() + ":" + to_add.getStart_Position() + to_add.getReference_Allele() + ">" + to_add.getTumor_Seq_Allele2());
                             to_add_annotated = cvrUtilities.buildCVRAnnotatedRecord(to_add);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/GMLMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/GMLMutationDataReader.java
@@ -62,6 +62,9 @@ public class GMLMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
     public CvrSampleListUtil cvrSampleListUtil;
     
     private final Map<String, List<String>> patientSampleMap = cvrSampleListUtil.getGmlPatientSampleMap();
+    
+    @Value("#{jobParameters[forceAnnotation]}")
+    private boolean forceAnnotation;
 
     @Autowired
     public CVRUtilities cvrUtilities;
@@ -105,7 +108,7 @@ public class GMLMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                         MutationRecord record = cvrUtilities.buildGMLMutationRecord(snp, sampleId);
                         AnnotatedRecord annotatedRecord;
                         try {
-                            annotatedRecord = annotator.annotateRecord(record, false, "mskcc", false);
+                            annotatedRecord = annotator.annotateRecord(record, false, "mskcc", forceAnnotation);
                         }
                         catch (HttpServerErrorException e) {
                             log.warn("Failed to annotate a record from json! Sample: " + sampleId + " Variant: " + record.getChromosome() + ":" + record.getStart_Position() + record.getReference_Allele() + ">" + record.getTumor_Seq_Allele2());
@@ -148,7 +151,7 @@ public class GMLMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                 while ((to_add = reader.read()) != null && to_add.getTumor_Sample_Barcode() != null) {
                     AnnotatedRecord to_add_annotated;
                     try {
-                        to_add_annotated = annotator.annotateRecord(to_add, false, "mskcc", false);
+                        to_add_annotated = annotator.annotateRecord(to_add, false, "mskcc", forceAnnotation);
                     }
                     catch (HttpServerErrorException e) {
                         log.warn("Failed to annotate a record from existing file! Sample: " + to_add.getTumor_Sample_Barcode() + " Variant: " + to_add.getChromosome() + ":" + to_add.getStart_Position() + to_add.getReference_Allele() + ">" + to_add.getTumor_Seq_Allele2());


### PR DESCRIPTION
This is sometimes necessary when we have bug fixes to genome nexus/VEP. This would allow us to easily and automatically reannotate our clinical data set mafs.

Signed-off-by: zheins <zackheins@gmail.com>