### PR TITLE
Master list check bug fix

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CvrSampleListUtil.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CvrSampleListUtil.java
@@ -110,7 +110,6 @@ public class CvrSampleListUtil {
      * @return the portalSamples
      */
     public Set<String> getPortalSamples() {
-        this.portalSamples.removeAll(portalSamplesNotInDmp);        
         return portalSamples;
     }
 
@@ -231,7 +230,7 @@ public class CvrSampleListUtil {
         updatePortalSamplesNotInDmp();
         updateDmpSamplesNotInPortal();
         
-        boolean maxSamplesToRemoveThresholdExceeded = (maxNumSamplesToRemove > 0 && portalSamplesNotInDmp.size() >= maxNumSamplesToRemove);
+        boolean maxSamplesToRemoveThresholdExceeded = (maxNumSamplesToRemove <= 0 || (maxNumSamplesToRemove > 0 && portalSamplesNotInDmp.size() >= maxNumSamplesToRemove));
         if (maxSamplesToRemoveThresholdExceeded) {
             String message;
             if (maxNumSamplesToRemove > 0) {
@@ -246,19 +245,15 @@ public class CvrSampleListUtil {
         }
         else {
             portalSamples.removeAll(portalSamplesNotInDmp);
-            log.info("updateSampleLists(),  Number of samples in 'portalSamplesNotInDmp' passes threshold check - samples not in 'dmpMasterList' will be removed from the data");
+            String message = "updateSampleLists(),  Number of samples in 'portalSamplesNotInDmp' passes threshold check - ";
+            if (portalSamplesNotInDmp.size() == 0) {
+                message += "'portalSamplesNotInDmp' list is empty, no sample data will be removed";
+            }
+            else {
+                message += "'portalSamplesNotInDmp' contains " + String.valueOf(portalSamplesNotInDmp.size()) + " samples. Data for these samples will be removed";
+            }
+            log.info(message);
         }
-    }
-    
-    public boolean isMaxSamplesToRemoveThresholdExceeded() {
-        boolean exceeded = (maxNumSamplesToRemove > 0 && portalSamplesNotInDmp.size() >= maxNumSamplesToRemove);
-        if (!exceeded) {
-            portalSamples.removeAll(portalSamplesNotInDmp);
-        }
-        else {
-            saveSampleListStats();
-        }
-        return exceeded;
     }
 
     /**

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/masterlist/CvrMasterListTasklet.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/masterlist/CvrMasterListTasklet.java
@@ -56,7 +56,12 @@ public class CvrMasterListTasklet implements Tasklet {
         Set<String> dmpMasterList = new HashSet<>();
         try {
             dmpMasterList = generateDmpMasterList();
-            log.info("DMP master list for " + studyId + " contains " + String.valueOf(dmpMasterList.size()) + " samples");
+            if (dmpMasterList.size() > 0) {
+                log.info("DMP master list for " + studyId + " contains " + String.valueOf(dmpMasterList.size()) + " samples");
+            }
+            else {
+                log.warn("No sample IDs were returned using DMP master list endpoint for study " + studyId);
+            }
         }
         catch (HttpClientErrorException e) {
             log.warn("Error occurred while retrieving master list for " + studyId + " - the default master list will be set to samples already in portal.\n" 

--- a/import-scripts/import-dmp-impact-data.sh
+++ b/import-scripts/import-dmp-impact-data.sh
@@ -110,10 +110,10 @@ IMPORT_FAIL_QUEENS=0
 # fetch new/updated IMPACT samples using CVR Web service   (must come after mercurial fetching)
 echo "fetching samples from CVR Web service  ..."
 echo $(date)
-$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -d $MSK_IMPACT_DATA_HOME -i mskimpact
+$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -d $MSK_IMPACT_DATA_HOME -i mskimpact -r 150
 if [ $? -gt 0 ]; then
     echo "CVR fetch failed!"
-    cd $MSK_IMPACT_DATA_HOME;$HG_BINARY revert --all --no-backup;rm *.orig
+    cd $MSK_IMPACT_DATA_HOME;$HG_BINARY update -C;rm *.orig
     IMPORT_STATUS_IMPACT=1
 else
     echo "committing cvr data"
@@ -126,7 +126,7 @@ echo $(date)
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -d $MSK_IMPACT_DATA_HOME -g -i mskimpact
 if [ $? -gt 0 ]; then
     echo "CVR Germline fetch failed!"
-    cd $MSK_IMPACT_DATA_HOME;$HG_BINARY revert --all --no-backup;rm *.orig
+    cd $MSK_IMPACT_DATA_HOME;$HG_BINARY update -C;rm *.orig
     IMPORT_STATUS_IMPACT=1
 else
     echo "committing CVR germline data"
@@ -140,7 +140,7 @@ $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,add
 if [ $? -gt 0 ]; then
     echo "CVR raindance fetch failed!"
     echo "This will not affect importing of mskimpact"
-    cd $MSK_RAINDANCE_DATA_HOME;$HG_BINARY revert --all --no-backup;rm *.orig
+    cd $MSK_RAINDANCE_DATA_HOME;$HG_BINARY update -C;rm *.orig
     IMPORT_STATUS_RAINDANCE=1
 else
     # raindance does not provide copy number or fusions data.
@@ -149,14 +149,14 @@ else
     cd $MSK_RAINDANCE_DATA_HOME;$HG_BINARY commit -m "Latest Raindance dataset"
 fi
 
-# fetch new/updated heme samples using CVR Web service (must come after mercurial fetching).
+# fetch new/updated heme samples using CVR Web service (must come after mercurial fetching). Threshold is set to 50 since heme contains only 190 samples (07/12/2017)
 echo "fetching CVR heme data..."
 echo $(date)
-$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -d $MSK_HEMEPACT_DATA_HOME -i mskimpact_heme
+$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -jar $PORTAL_HOME/lib/cvr_fetcher.jar -d $MSK_HEMEPACT_DATA_HOME -i mskimpact_heme -r 50
 if [ $? -gt 0 ]; then
       echo "CVR heme fetch failed!"
       echo "This will not affect importing of mskimpact"
-      cd $MSK_HEMEPACT_DATA_HOME;$HG_BINARY revert --all --no-backup;rm *.orig
+      cd $MSK_HEMEPACT_DATA_HOME;$HG_BINARY update -C;rm *.orig
       IMPORT_STATUS_HEME=1
 else
       cd $MSK_HEMEPACT_DATA_HOME;$HG_BINARY commit -m "Latest heme dataset"
@@ -169,7 +169,7 @@ $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,add
 if [ $? -gt 0 ]; then
     echo "CVR Archer fetch failed!"
     echo "This will not affect importing of mskimpact"
-    cd $MSK_ARCHER_DATA_HOME;$HG_BINARY revert --all --no-backup;rm *.orig
+    cd $MSK_ARCHER_DATA_HOME;$HG_BINARY update -C;rm *.orig
     IMPORT_STATUS_ARCHER=1
 else
     # mskarcher does not provide copy number, mutations, or seg data, renaming gene matrix file until we get the mskarcher gene panel imported
@@ -400,7 +400,7 @@ fi
 # commit or revert changes for MIXEDPACT
 if [ $IMPORT_FAIL_MIXEDPACT -gt 0 ]; then
     echo "MIXEDPACT merge and/or updates failed! Reverting data to last commit."
-    cd $MSK_MIXEDPACT_DATA_HOME;$HG_BINARY revert --all --no-backup;
+    cd $MSK_MIXEDPACT_DATA_HOME;$HG_BINARY update -C
     rm $MSK_MIXEDPACT_DATA_HOME/*.orig
     rm $MSK_MIXEDPACT_DATA_HOME/case_lists/*.orig
 else
@@ -479,7 +479,7 @@ fi
 # commit or revert changes for KINGSCOUNTY
 if [ $IMPORT_FAIL_KINGS -gt 0 ]; then
     echo "KINGSCOUNTY subset and/or updates failed! Reverting data to last commit."
-    cd $MSK_KINGS_DATA_HOME;$HG_BINARY revert --all --no-backup;
+    cd $MSK_KINGS_DATA_HOME;$HG_BINARY update -C
     rm $MSK_KINGS_DATA_HOME/*.orig
     rm $MSK_KINGS_DATA_HOME/case_lists/*.orig
 else
@@ -504,7 +504,7 @@ fi
 # commit or revert changes for LEHIGHVALLEY
 if [ $IMPORT_FAIL_LEHIGH -gt 0 ]; then
     echo "LEHIGHVALLEY subset and/or updates failed! Reverting data to last commit."
-    cd $MSK_LEHIGH_DATA_HOME;$HG_BINARY revert --all --no-backup;
+    cd $MSK_LEHIGH_DATA_HOME;$HG_BINARY update -C
     rm $MSK_LEHIGH_DATA_HOME/*.orig
     rm $MSK_LEHIGH_DATA_HOME/case_lists/*.orig
 else
@@ -529,7 +529,7 @@ fi
 # commit or revert changes for QUEENSCANCERCENTER
 if [ $IMPORT_FAIL_QUEENS -gt 0 ]; then
     echo "QUEENSCANCERCENTER subset and/or updates failed! Reverting data to last commit."
-    cd $MSK_QUEENS_DATA_HOME;$HG_BINARY revert --all --no-backup;
+    cd $MSK_QUEENS_DATA_HOME;$HG_BINARY update -C
     rm $MSK_QUEENS_DATA_HOME/*.orig
     rm $MSK_QUEENS_DATA_HOME/case_lists/*.orig
 else


### PR DESCRIPTION
* Portal samples not found in the DMP master list were being removed regardless of whether a max number of samples to remove threshold was set or not. Bug was introduced as part of one of the initial iterations of adding the master list check for each assay and was left behind by accident.
* Improved logging in master list tasklet
* Updated `import-dmp-impact-data.sh` with options for setting a threshold for max num samples to remove for assays mskimpact and heme. No threshold is set for archer or raindance since their master list endpoints have issues - this will prevent any sample data from being removed for these assays.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>