### PR TITLE
Timeline metafile fix

### DIFF
--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/MetaFileStepTasklet.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/MetaFileStepTasklet.java
@@ -55,7 +55,9 @@ public class MetaFileStepTasklet implements Tasklet {
 
     @Value("#{jobParameters[directory]}")
     private String directory;
-
+    
+    @Value("#{jobParameters[mergeClinicalDataSources]}")
+    private boolean mergeClinicalDataSources;
 
     @Override
     public RepeatStatus execute(StepContribution sc, ChunkContext cc) throws Exception {
@@ -69,8 +71,14 @@ public class MetaFileStepTasklet implements Tasklet {
         for (String clinicalPatientFile : clinicalPatientFiles) {
             createMetaFile(clinicalPatientFile, "PATIENT_ATTRIBUTES", "clinical");
         }
-        for (String timelineFile : timelineFiles) {
-            createMetaFile(timelineFile, "TIMELINE", "timeline");
+        // only want to ever create one timeline file
+        if (!timelineFiles.isEmpty() && mergeClinicalDataSources) {
+            createMetaFile("data_timeline.txt", "TIMELINE", "timeline");
+        }
+        else {
+            for (String timelineFile : timelineFiles) {
+                createMetaFile(timelineFile, "TIMELINE", "timeline");
+            }
         }
         return RepeatStatus.FINISHED;
     }


### PR DESCRIPTION
Only one timeline meta file should be generated for any number of timeline files pulled from REDCap.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>