### PR TITLE
Genie clinical data generation scripts fixes

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataProcessor.java
@@ -54,18 +54,18 @@ public class CVRClinicalDataProcessor implements ItemProcessor<CVRClinicalRecord
         List<String> record = new ArrayList<>();
         List<String> seqDateRecord = new ArrayList<>();
         for (String field : CVRClinicalRecord.getFieldNames()) {
-            record.add(i.getClass().getMethod("get" + field).invoke(i).toString().replaceAll("[\\t\\n\\r]+"," "));
+            record.add(i.getClass().getMethod("get" + field).invoke(i).toString().replaceAll("[\\t\\n\\r]+"," ").trim());
         }
         for (String field : MskimpactSeqDate.getFieldNames()) {
-            seqDateRecord.add(i.getClass().getMethod("get" + field).invoke(i).toString().replaceAll("[\\t\\n\\r]+"," "));
+            seqDateRecord.add(i.getClass().getMethod("get" + field).invoke(i).toString().replaceAll("[\\t\\n\\r]+"," ").trim());
         }
         CompositeClinicalRecord compRecord = new CompositeClinicalRecord();
         if (cvrSampleListUtil.getNewDmpSamples().contains(i.getSAMPLE_ID())) {
-            compRecord.setNewClinicalRecord(StringUtils.join(record, "\t").trim());
+            compRecord.setNewClinicalRecord(StringUtils.join(record, "\t"));
         } else {
-            compRecord.setOldClinicalRecord(StringUtils.join(record, "\t").trim());
+            compRecord.setOldClinicalRecord(StringUtils.join(record, "\t"));
         }
-        compRecord.setSeqDateRecord(StringUtils.join(seqDateRecord, "\t").trim());
+        compRecord.setSeqDateRecord(StringUtils.join(seqDateRecord, "\t"));
         return compRecord;
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
@@ -245,7 +245,7 @@ public class CVRClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
                     for(CVRClinicalRecord record : patientToRecordMap.get(mskimpactSeqDate.getPATIENT_ID())) {
                         if (record.getSAMPLE_ID().equals(mskimpactSeqDate.getSAMPLE_ID())) {
                             record.setSEQ_DATE(mskimpactSeqDate.getSEQ_DATE());
-                            continue;
+                            break;
                         }
                     }
                 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/MskimpactSeqDate.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/MskimpactSeqDate.java
@@ -46,7 +46,7 @@ public class MskimpactSeqDate {
      * @return the SAMPLE_ID
      */
     public String getSAMPLE_ID() {
-        return SAMPLE_ID;
+        return SAMPLE_ID != null ? SAMPLE_ID : "";
     }
 
     /**
@@ -60,7 +60,7 @@ public class MskimpactSeqDate {
      * @return the PATIENT_ID
      */
     public String getPATIENT_ID() {
-        return PATIENT_ID;
+        return PATIENT_ID != null ? PATIENT_ID : "";
     }
 
     /**
@@ -74,7 +74,7 @@ public class MskimpactSeqDate {
      * @return the SEQ_DATE
      */
     public String getSEQ_DATE() {
-        return SEQ_DATE;
+        return SEQ_DATE != null ? SEQ_DATE : "";
     }
 
     /**

--- a/import-scripts/generate-clinical-subset.py
+++ b/import-scripts/generate-clinical-subset.py
@@ -64,7 +64,8 @@ def update_data_with_sequencing_date(study_id, clinical_filename):
 
 def filter_samples_by_sequencing_date(clinical_supp_filename, sequencing_date_limit, anonymize_date, impact_data_only):
 	""" Generates list of sample IDs from sequencing date file meeting the sequencing date limit criteria. """
-	seq_date_limit = datetime.strptime(sequencing_date_limit, '%a, %d %b %Y %H:%M:%S')
+	seq_date_limit = datetime.strptime(sequencing_date_limit, '%Y/%m/%d %H:%M:%S')
+
 
 	data_file = open(clinical_supp_filename, 'rU')
 	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
@@ -78,12 +79,10 @@ def filter_samples_by_sequencing_date(clinical_supp_filename, sequencing_date_li
 		if impact_data_only and not is_impact_sample(sample_id):
 			continue
 
-		# figure out which column to use
-		if 'SeqDate' in line.keys():
-			seq_date_val = line['SeqDate']
-		else:
-			seq_date_val = line['SEQ_DATE']
-		raw_sample_seq_date = datetime.strptime(seq_date_val, '%Y-%m-%d %H:%M:%S')
+		seq_date_val = line['SEQ_DATE']
+		if not seq_date_val:
+			continue
+		raw_sample_seq_date = datetime.strptime(seq_date_val, '%a, %d %b %Y %H:%M:%S %Z')
 
 		# if sample sequencing date meets criteria then anonymize the sequencing date
 		if raw_sample_seq_date <= seq_date_limit:
@@ -174,7 +173,7 @@ def is_valid_clin_header(clinical_filename, is_seq_date):
 def parse_filter_criteria(filter_criteria):
 	attr_name = filter_criteria.split('=')[0]
 	attr_values = filter_criteria.split('=')[1].split(',')
-	if attr_name == 'SEQUENCING_DATE':
+	if attr_name == 'SEQ_DATE':
 		if len(attr_values) > 1:
 			print >> ERROR_FILE, "Only ONE sequencing date can be provided for filtering."
 			exit(2)

--- a/import-scripts/subset-impact-data.sh
+++ b/import-scripts/subset-impact-data.sh
@@ -3,7 +3,7 @@
 # (1): study id
 # (2): output directory
 # (3): mskimpact data directory
-# (4): data filter criteria to subset IMPACT data with (either SEQUENCING_DATE or <ATTRIBUTE_NAME>=[ATTRIBUTE_VAL1,ATTRIBUTE_VAL2,...])
+# (4): data filter criteria to subset IMPACT data with (either SEQ_DATE or <ATTRIBUTE_NAME>=[ATTRIBUTE_VAL1,ATTRIBUTE_VAL2,...])
 # (5): output subset filename
 
 for i in "$@"; do
@@ -28,6 +28,10 @@ case $i in
     SUBSET_FILENAME="${i#*=}"
     shift # past argument=value
     ;;
+    -p=*|--portal-scripts-directory=*)
+    PORTAL_SCRIPTS_DIRECTORY="${i#*=}"
+    shift # past argument=value
+    ;;
     *)
       # default option
       echo "This option does not exist!  " "${i#*=}"
@@ -40,29 +44,33 @@ echo -e "\tOUTPUT_DIRECTORY="$OUTPUT_DIRECTORY
 echo -e "\tMSK_IMPACT_DATA_DIRECTORY="$MSK_IMPACT_DATA_DIRECTORY
 echo -e "\tFILTER_CRITERIA="$FILTER_CRITERIA
 echo -e "\tSUBSET_FILENAME="$SUBSET_FILENAME
+if [ -z $PORTAL_SCRIPTS_DIRECTORY ]; then
+    PORTAL_SCRIPTS_DIRECTORY="$PORTAL_HOME/scripts"
+fi
+echo -e "\tPORTAL_SCRIPTS_DIRECTORY="$PORTAL_SCRIPTS_DIRECTORY
 
 if [ $STUDY_ID == "genie" ]; then
-    # once cvr pipeline captures SEQ_DATE, we can get rid of this if/else block
-    if [[ $(head -1 $MSK_IMPACT_DATA_DIRECTORY/data_clinical.txt) == *"SEQ_DATE"* ]]; then
-        CLINICAL_SUPP_FILE="$MSK_IMPACT_DATA_DIRECTORY/data_clinical.txt"
-    else:
-        CLINICAL_SUPP_FILE="$MSK_IMPACT_DATA_DIRECTORY/genie_sequencing_date_dump.txt"
-    fi
-	# in the case of genie data, the input data directory must be the msk-impact data home, where we expect to see darwin_genie_sample.txt and darwin_genie_patient.txt as well
-	# copy the darwin genie files to the output directory with different filenames
-	cp $MSK_IMPACT_DATA_DIRECTORY/darwin_genie_patient.txt $OUTPUT_DIRECTORY/data_clinical_supp_patient.txt
-	cp $MSK_IMPACT_DATA_DIRECTORY/darwin_genie_sample.txt $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt
-	
-	# run the generate clinical subset script to generate list of sample ids to subset from impact data - subset of sample ids will be written to given $SUBSET_FILENAME
-	$PYTHON_BINARY $PORTAL_HOME/scripts/generate-clinical-subset.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-supp-file="$CLINICAL_SUPP_FILE" --filter-criteria="$FILTER_CRITERIA" --subset-filename="$SUBSET_FILENAME" --anonymize-date='true' --clinical-patient-file="$OUTPUT_DIRECTORY/data_clinical_supp_patient.txt"
-	# expand data_clinical_supp_sample.txt with ONCOTREE_CODE, SAMPLE_TYPE from data_clinical.txt
-	$PYTHON_BINARY $PORTAL_HOME/scripts/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-supp-file="$MSK_IMPACT_DATA_DIRECTORY/data_clinical.txt" --fields="ONCOTREE_CODE,SAMPLE_TYPE,GENE_PANEL"
+    CLINICAL_SUPP_FILE="$MSK_IMPACT_DATA_DIRECTORY/seq_date.txt"
+
+    # in the case of genie data, the input data directory must be the msk-impact data home, where we expect to see darwin_genie_sample.txt and darwin_genie_patient.txt as well
+    # copy the darwin genie files to the output directory with different filenames
+    cp $MSK_IMPACT_DATA_DIRECTORY/darwin_naaccr.txt $OUTPUT_DIRECTORY/data_clinical_supp_patient.txt
+    cut -f1,2 $MSK_IMPACT_DATA_DIRECTORY/data_clinical.txt > $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt
+    
+    # run the generate clinical subset script to generate list of sample ids to subset from impact data - subset of sample ids will be written to given $SUBSET_FILENAME
+    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/generate-clinical-subset.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-supp-file="$CLINICAL_SUPP_FILE" --filter-criteria="$FILTER_CRITERIA" --subset-filename="$SUBSET_FILENAME" --anonymize-date='true' --clinical-patient-file="$OUTPUT_DIRECTORY/data_clinical_supp_patient.txt"
+
+    # expand data_clinical_supp_sample.txt with ONCOTREE_CODE, SAMPLE_TYPE, GENE_PANEL from data_clinical.txt
+    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-supp-file="$MSK_IMPACT_DATA_DIRECTORY/data_clinical.txt" --fields="ONCOTREE_CODE,SAMPLE_TYPE,GENE_PANEL"
+
+    #rename GENE_PANEL to SEQ_ASSAY_ID
     sed 's/GENE_PANEL/SEQ_ASSAY_ID/' $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt > $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt.tmp
     mv $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt.tmp $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt
-	# generate subset of impact data using the subset file generated above
-	$PYTHON_BINARY $PORTAL_HOME/scripts/merge.py  -d $OUTPUT_DIRECTORY -i "genie" -s "$SUBSET_FILENAME" -x "true" -$MSK_IMPACT_DATA_DIRECTORY
+    
+    # generate subset of impact data using the subset file generated above
+    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/merge.py  -d $OUTPUT_DIRECTORY -i "genie" -s "$SUBSET_FILENAME" -x "true" $MSK_IMPACT_DATA_DIRECTORY
 else
     # generate subset list of sample ids based on filter criteria and subset MSK-IMPACT using generated list in $SUBSET_FILENAME
-    $PYTHON_BINARY $PORTAL_HOME/scripts/generate-clinical-subset.py --study-id="$STUDY_ID" --clinical-file="$MSK_IMPACT_DATA_DIRECTORY/data_clinical.txt" --filter-criteria="$FILTER_CRITERIA" --subset-filename="$SUBSET_FILENAME"
-    $PYTHON_BINARY $PORTAL_HOME/scripts/merge.py  -d $OUTPUT_DIRECTORY -i "$STUDY_ID" -s "$SUBSET_FILENAME" -x "true" -m "true" $MSK_IMPACT_DATA_DIRECTORY
+    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/generate-clinical-subset.py --study-id="$STUDY_ID" --clinical-file="$MSK_IMPACT_DATA_DIRECTORY/data_clinical.txt" --filter-criteria="$FILTER_CRITERIA" --subset-filename="$SUBSET_FILENAME"
+    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/merge.py -d $OUTPUT_DIRECTORY -i "$STUDY_ID" -s "$SUBSET_FILENAME" -x "true" -m "true" $MSK_IMPACT_DATA_DIRECTORY
 fi


### PR DESCRIPTION
* Updated subset code with datetime format in `seq_date.txt` file coming from CVR.
* Fixed a bug in the CVR pipeline that was erroneously trimming trailing tab-delimited fields in `seq_date.txt` records where we do not have the field populated yet (default is empty string).

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>