### PR TITLE
All caps calls for annotator getters/setters

### DIFF
--- a/cvr/pom.xml
+++ b/cvr/pom.xml
@@ -56,6 +56,18 @@
       <artifactId>activation</artifactId>
       <version>1.1.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.collections</groupId>
+      <artifactId>google-collections</artifactId>
+      <version>1.0</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
+      <type>jar</type>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -176,12 +176,12 @@ public class CVRUtilities {
         }
 
         for (AnnotatedRecord record : annotatedRecords) {
-            if (record.getChromosome().equals(snp.getChromosome()) &&
-                    record.getStart_Position().equals(snp.getStart_Position()) &&
-                    record.getEnd_Position().equals(snp.getEnd_Position()) &&
-                    record.getReference_Allele().equals(snp.getReference_Allele()) &&
-                    record.getTumor_Seq_Allele2().equals(snp.getTumor_Seq_Allele2()) &&
-                    record.getHugo_Symbol().equals(snp.getHugo_Symbol())) {
+            if (record.getCHROMOSOME().equals(snp.getCHROMOSOME()) &&
+                    record.getSTART_POSITION().equals(snp.getSTART_POSITION()) &&
+                    record.getEND_POSITION().equals(snp.getEND_POSITION()) &&
+                    record.getREFERENCE_ALLELE().equals(snp.getREFERENCE_ALLELE()) &&
+                    record.getTUMOR_SEQ_ALLELE2().equals(snp.getTUMOR_SEQ_ALLELE2()) &&
+                    record.getHUGO_SYMBOL().equals(snp.getHUGO_SYMBOL())) {
                 return true;
             }
         }
@@ -189,44 +189,44 @@ public class CVRUtilities {
     }
 
     public AnnotatedRecord buildCVRAnnotatedRecord(MutationRecord record) {
-        String hugoSymbol = record.getHugo_Symbol();
-        String entrezGeneId = record.getEntrez_Gene_Id();
-        String center = record.getCenter();
-        String ncbiBuild = record.getNCBI_Build();
-        String chromosome = record.getChromosome();
-        String startPosition = record.getStart_Position();
-        String strand = record.getStrand();
-        String variantClassification = record.getVariant_Classification();
-        String variantType = record.getVariant_Type();
-        String referenceAllele = record.getReference_Allele();
-        String endPosition = record.getEnd_Position();
-        String tumorSeqAllele1 = record.getTumor_Seq_Allele1();
-        String tumorSeqAllele2 = record.getTumor_Seq_Allele2();
-        String dbSnpRs = record.getdbSNP_RS();
-        String dbSnpValStatus = record.getdbSNP_Val_Status();
-        String tumorSampleBarcode = record.getTumor_Sample_Barcode();
-        String matchedNormSampleBarcode = record.getMatched_Norm_Sample_Barcode();
-        String matchedNormSeqAllele1 = record.getMatch_Norm_Seq_Allele1();
-        String matchedNormSeqAllele2 = record.getMatch_Norm_Seq_Allele2();
-        String tumorValidationAllele1 = record.getTumor_Validation_Allele1();
-        String tumorValidationAllele2 = record.getTumor_Validation_Allele2();
-        String matchNormValidationAllele1 = record.getMatch_Norm_Validation_Allele1();
-        String matchNormValidationAllele2 = record.getMatch_Norm_Validation_Allele2();
-        String verificationStatus = record.getVerification_Status();
-        String validationStatus = record.getValidation_Status();
-        String mutationStatus = record.getMutation_Status();
-        String sequencingPhase = record.getSequencing_Phase();
-        String sequencingSource = record.getSequence_Source();
-        String validationMethod = record.getValidation_Method();
-        String score = record.getScore();
-        String bamFile = record.getBAM_File();
-        String sequencer = record.getSequencer();
-        String tumorSampleUUID = record.getTumor_Sample_UUID();
-        String matchedNormSampleUUID = record.getMatched_Norm_Sample_UUID();
-        String tRefCount = record.gett_ref_count();
-        String nRefCount = record.getn_ref_count();
-        String tAltCount = record.gett_alt_count();
-        String nAltCount = record.getn_alt_count();
+        String hugoSymbol = record.getHUGO_SYMBOL();
+        String entrezGeneId = record.getENTREZ_GENE_ID();
+        String center = record.getCENTER();
+        String ncbiBuild = record.getNCBI_BUILD();
+        String chromosome = record.getCHROMOSOME();
+        String startPosition = record.getSTART_POSITION();
+        String strand = record.getSTRAND();
+        String variantClassification = record.getVARIANT_CLASSIFICATION();
+        String variantType = record.getVARIANT_TYPE();
+        String referenceAllele = record.getREFERENCE_ALLELE();
+        String endPosition = record.getEND_POSITION();
+        String tumorSeqAllele1 = record.getTUMOR_SEQ_ALLELE1();
+        String tumorSeqAllele2 = record.getTUMOR_SEQ_ALLELE2();
+        String dbSnpRs = record.getDBSNP_RS();
+        String dbSnpValStatus = record.getDBSNP_VAL_STATUS();
+        String tumorSampleBarcode = record.getTUMOR_SAMPLE_BARCODE();
+        String matchedNormSampleBarcode = record.getMATCHED_NORM_SAMPLE_BARCODE();
+        String matchedNormSeqAllele1 = record.getMATCH_NORM_SEQ_ALLELE1();
+        String matchedNormSeqAllele2 = record.getMATCH_NORM_SEQ_ALLELE2();
+        String tumorValidationAllele1 = record.getTUMOR_VALIDATION_ALLELE1();
+        String tumorValidationAllele2 = record.getTUMOR_VALIDATION_ALLELE2();
+        String matchNormValidationAllele1 = record.getMATCH_NORM_VALIDATION_ALLELE1();
+        String matchNormValidationAllele2 = record.getMATCH_NORM_VALIDATION_ALLELE2();
+        String verificationStatus = record.getVERIFICATION_STATUS();
+        String validationStatus = record.getVALIDATION_STATUS();
+        String mutationStatus = record.getMUTATION_STATUS();
+        String sequencingPhase = record.getSEQUENCING_PHASE();
+        String sequencingSource = record.getSEQUENCE_SOURCE();
+        String validationMethod = record.getVALIDATION_METHOD();
+        String score = record.getSCORE();
+        String bamFile = record.getBAM_FILE();
+        String sequencer = record.getSEQUENCER();
+        String tumorSampleUUID = record.getTUMOR_SAMPLE_UUID();
+        String matchedNormSampleUUID = record.getMATCHED_NORM_SAMPLE_UUID();
+        String tRefCount = record.getT_REF_COUNT();
+        String nRefCount = record.getN_REF_COUNT();
+        String tAltCount = record.getT_ALT_COUNT();
+        String nAltCount = record.getN_ALT_COUNT();
         Map<String ,String> additionalProperties = record.getAdditionalProperties();
         return new AnnotatedRecord(hugoSymbol, entrezGeneId, center, ncbiBuild, chromosome,
                 startPosition, endPosition, strand, variantClassification, variantType, referenceAllele,

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataProcessor.java
@@ -54,7 +54,7 @@ public class CVRMutationDataProcessor implements ItemProcessor<AnnotatedRecord, 
             try {
                 record.add(i.getClass().getMethod("get" + field).invoke(i).toString().replaceAll("[\\t\\n\\r]+"," "));
             } catch (Exception e) {
-                record.add(i.getAdditionalProperties().get(field).replace("\r\n", " ").replaceAll("[\\t\\n\\r]+"," "));
+                record.add(i.getAdditionalProperties().getOrDefault(field, "").replace("\r\n", " ").replaceAll("[\\t\\n\\r]+"," "));
             }
         }
         return StringUtils.join(record, "\t");

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
@@ -105,13 +105,13 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                     try {
                         annotatedRecord = annotator.annotateRecord(record, false, "mskcc", forceAnnotation);
                     } catch (HttpServerErrorException e) {
-                        log.warn("Failed to annotate a record from json! Sample: " + sampleId + " Variant: " + record.getChromosome() + ":" + record.getStart_Position() + record.getReference_Allele() + ">" + record.getTumor_Seq_Allele2());
+                        log.warn("Failed to annotate a record from json! Sample: " + sampleId + " Variant: " + record.getCHROMOSOME() + ":" + record.getSTART_POSITION() + record.getREFERENCE_ALLELE() + ">" + record.getTUMOR_SEQ_ALLELE2());
                         annotatedRecord = cvrUtilities.buildCVRAnnotatedRecord(record);
                     }
                     mutationRecords.add(annotatedRecord);
                     header.addAll(annotatedRecord.getHeaderWithAdditionalFields());
                     additionalPropertyKeys.addAll(annotatedRecord.getAdditionalProperties().keySet());
-                    mutationMap.getOrDefault(annotatedRecord.getTumor_Sample_Barcode(), new ArrayList()).add(annotatedRecord);
+                    mutationMap.getOrDefault(annotatedRecord.getTUMOR_SAMPLE_BARCODE(), new ArrayList()).add(annotatedRecord);
                 }
             }
         }
@@ -141,18 +141,18 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
 
             try {
                 MutationRecord to_add;
-                while ((to_add = reader.read()) != null && to_add.getTumor_Sample_Barcode() != null) {
-                    if (!cvrSampleListUtil.getNewDmpSamples().contains(to_add.getTumor_Sample_Barcode()) && 
-                            !cvrUtilities.isDuplicateRecord(to_add, mutationMap.get(to_add.getTumor_Sample_Barcode()))) {
+                while ((to_add = reader.read()) != null && to_add.getTUMOR_SAMPLE_BARCODE() != null) {
+                    if (!cvrSampleListUtil.getNewDmpSamples().contains(to_add.getTUMOR_SAMPLE_BARCODE()) && 
+                            !cvrUtilities.isDuplicateRecord(to_add, mutationMap.get(to_add.getTUMOR_SAMPLE_BARCODE()))) {
                         AnnotatedRecord to_add_annotated;
                         try {
                             to_add_annotated = annotator.annotateRecord(to_add, false, "mskcc", forceAnnotation);
                         } catch (HttpServerErrorException e) {
-                            log.warn("Failed to annotate a record from existing file! Sample: " + to_add.getTumor_Sample_Barcode() + " Variant: " + to_add.getChromosome() + ":" + to_add.getStart_Position() + to_add.getReference_Allele() + ">" + to_add.getTumor_Seq_Allele2());
+                            log.warn("Failed to annotate a record from existing file! Sample: " + to_add.getTUMOR_SAMPLE_BARCODE() + " Variant: " + to_add.getCHROMOSOME() + ":" + to_add.getSTART_POSITION() + to_add.getREFERENCE_ALLELE() + ">" + to_add.getTUMOR_SEQ_ALLELE2());
                             to_add_annotated = cvrUtilities.buildCVRAnnotatedRecord(to_add);
                         }
                         mutationRecords.add(to_add_annotated);
-                        mutationMap.getOrDefault(to_add_annotated.getTumor_Sample_Barcode(), new ArrayList()).add(to_add_annotated);
+                        mutationMap.getOrDefault(to_add_annotated.getTUMOR_SAMPLE_BARCODE(), new ArrayList()).add(to_add_annotated);
                         header.addAll(to_add_annotated.getHeaderWithAdditionalFields());
                         additionalPropertyKeys.addAll(to_add_annotated.getAdditionalProperties().keySet());
                     }
@@ -179,8 +179,8 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
     public AnnotatedRecord read() throws Exception {
         if (!mutationRecords.isEmpty()) {
             AnnotatedRecord annotatedRecord = mutationRecords.remove(0);
-            if (!cvrSampleListUtil.getPortalSamples().contains(annotatedRecord.getTumor_Sample_Barcode())) {
-                cvrSampleListUtil.addSampleRemoved(annotatedRecord.getTumor_Sample_Barcode());
+            if (!cvrSampleListUtil.getPortalSamples().contains(annotatedRecord.getTUMOR_SAMPLE_BARCODE())) {
+                cvrSampleListUtil.addSampleRemoved(annotatedRecord.getTUMOR_SAMPLE_BARCODE());
                 return read();
             }
             for (String additionalProperty : additionalPropertyKeys) {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationFieldSetMapper.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationFieldSetMapper.java
@@ -37,30 +37,62 @@ import java.util.*;
 import org.springframework.batch.item.file.mapping.FieldSetMapper;
 import org.springframework.batch.item.file.transform.FieldSet;
 import org.springframework.validation.BindException;
-import org.apache.log4j.Logger;
+import org.springframework.cglib.beans.BeanMap;
+import com.google.common.collect.Sets;
+import com.google.common.base.Strings;
+import java.util.stream.Collectors;
 
 /**
  *
  * @author heinsz
  */
 public class CVRMutationFieldSetMapper implements  FieldSetMapper<MutationRecord> {
-    Logger log = Logger.getLogger(CVRMutationFieldSetMapper.class);
     @Override
     public MutationRecord mapFieldSet(FieldSet fs) throws BindException {
-        MutationRecord record = new MutationRecord();
-        Set<String> names = new HashSet(Arrays.asList(fs.getNames()));
-        names.addAll(record.getHeader());
-        for (String field : names) {
-            try {
-                record.getClass().getMethod("set" + field, String.class).invoke(record, fs.readRawString(field));
-            } catch (Exception e) {
-                if (e.getClass().equals(NoSuchMethodException.class)) {
-                    record.addAdditionalProperty(field, fs.readRawString(field));
-                } else {
-                    log.error("Something went wrong reading field " + field);
-                }
-            }
-         }
+        MutationRecord mr = new MutationRecord();
+        BeanMap recordBeanMap = BeanMap.create(new MutationRecord());
+        Set<String> fieldSetNames = new HashSet(Arrays.asList(fs.getNames()));
+        Set<String> mutationRecordFields = new HashSet(mr.getHeader());
+        
+        // We need to intersect these two sets ignoring case, and then use this
+        // intersection to filter the original set for data accession
+        Set<String> intersection = Sets.intersection(
+            mutationRecordFields.stream()
+                .map(field -> field.toUpperCase())
+                .collect(Collectors.toSet()),
+            fieldSetNames.stream()
+                .map(field -> field.toUpperCase())
+                .collect(Collectors.toSet()));
+        
+        // Here we make sure that the field is in our intersection
+        Set<String> fields = fieldSetNames.stream()
+                .filter(line -> intersection.contains(line.toUpperCase()))
+                .collect(Collectors.toSet());
+        
+        // In this we actually set the value in our bean map
+        fields.stream().forEach(column -> 
+            {
+                recordBeanMap.put(column.toUpperCase(),Strings.isNullOrEmpty(fs.readRawString(column)) ? "" : fs.readRawString(column));
+            });
+        
+        // Now access the bean from the map and set the additional propertes 
+        // (the difference of the field set and mutation record header)
+        MutationRecord record = (MutationRecord) recordBeanMap.getBean();
+        Set<String> additionalColumns = Sets.difference(
+            fieldSetNames.stream()
+                .map(field -> field.toUpperCase())
+                .collect(Collectors.toSet()),
+            mutationRecordFields.stream()
+                .map(field -> field.toUpperCase())
+                .collect(Collectors.toSet()));
+        Set<String> additionalColumnsWithCase = fieldSetNames.stream()
+                .filter(field -> additionalColumns.contains(field.toUpperCase()))
+                .collect(Collectors.toSet());
+        
+        // Actually set the values
+        additionalColumnsWithCase.stream().forEach((additionalField) -> {
+            record.addAdditionalProperty(additionalField, fs.readRawString(additionalField));
+        });
         return record;
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRUnfilteredMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRUnfilteredMutationDataReader.java
@@ -104,14 +104,14 @@ public class CVRUnfilteredMutationDataReader implements ItemStreamReader<Annotat
                 try {
                     annotatedRecord = annotator.annotateRecord(record, false, "mskcc", forceAnnotation);
                 } catch (HttpServerErrorException e) {
-                    log.warn("Failed to annotate a record from json! Sample: " + sampleId + " Variant: " + record.getChromosome() + ":" + record.getStart_Position() + record.getReference_Allele() + ">" + record.getTumor_Seq_Allele2());
+                    log.warn("Failed to annotate a record from json! Sample: " + sampleId + " Variant: " + record.getCHROMOSOME() + ":" + record.getSTART_POSITION() + record.getREFERENCE_ALLELE() + ">" + record.getTUMOR_SEQ_ALLELE2());
                     annotatedRecord = cvrUtilities.buildCVRAnnotatedRecord(record);
                 }
                 annotatedRecord.getAdditionalProperties().put("IS_NEW", cvrUtilities.IS_NEW);
                 mutationRecords.add(annotatedRecord);
                 header.addAll(annotatedRecord.getHeaderWithAdditionalFields());
                 additionalPropertyKeys.addAll(annotatedRecord.getAdditionalProperties().keySet());
-                mutationMap.getOrDefault(annotatedRecord.getTumor_Sample_Barcode(), new ArrayList()).add(annotatedRecord);
+                mutationMap.getOrDefault(annotatedRecord.getTUMOR_SAMPLE_BARCODE(), new ArrayList()).add(annotatedRecord);
             }
         }
 
@@ -140,18 +140,18 @@ public class CVRUnfilteredMutationDataReader implements ItemStreamReader<Annotat
 
             try {
                 MutationRecord to_add;
-                while ((to_add = reader.read()) != null && to_add.getTumor_Sample_Barcode() != null) {
-                    if (!cvrSampleListUtil.getNewDmpSamples().contains(to_add.getTumor_Sample_Barcode()) &&
-                            !cvrUtilities.isDuplicateRecord(to_add, mutationMap.get(to_add.getTumor_Sample_Barcode()))) {
+                while ((to_add = reader.read()) != null && to_add.getTUMOR_SAMPLE_BARCODE() != null) {
+                    if (!cvrSampleListUtil.getNewDmpSamples().contains(to_add.getTUMOR_SAMPLE_BARCODE()) &&
+                            !cvrUtilities.isDuplicateRecord(to_add, mutationMap.get(to_add.getTUMOR_SAMPLE_BARCODE()))) {
                         AnnotatedRecord to_add_annotated;
                         try {
                             to_add_annotated = annotator.annotateRecord(to_add, false, "mskcc", forceAnnotation);
                         } catch (HttpServerErrorException e) {
-                            log.warn("Failed to annotate a record from existing file! Sample: " + to_add.getTumor_Sample_Barcode() + " Variant: " + to_add.getChromosome() + ":" + to_add.getStart_Position() + to_add.getReference_Allele() + ">" + to_add.getTumor_Seq_Allele2());
+                            log.warn("Failed to annotate a record from existing file! Sample: " + to_add.getTUMOR_SAMPLE_BARCODE() + " Variant: " + to_add.getCHROMOSOME() + ":" + to_add.getSTART_POSITION() + to_add.getREFERENCE_ALLELE() + ">" + to_add.getTUMOR_SEQ_ALLELE2());
                             to_add_annotated = cvrUtilities.buildCVRAnnotatedRecord(to_add);
                         }
                         mutationRecords.add(to_add_annotated);
-                        mutationMap.getOrDefault(to_add_annotated.getTumor_Sample_Barcode(), new ArrayList()).add(to_add_annotated);
+                        mutationMap.getOrDefault(to_add_annotated.getTUMOR_SAMPLE_BARCODE(), new ArrayList()).add(to_add_annotated);
                         header.addAll(to_add_annotated.getHeaderWithAdditionalFields());
                         additionalPropertyKeys.addAll(to_add_annotated.getAdditionalProperties().keySet());
                     }
@@ -179,8 +179,8 @@ public class CVRUnfilteredMutationDataReader implements ItemStreamReader<Annotat
     public AnnotatedRecord read() throws Exception {
         if (!mutationRecords.isEmpty()) {
             AnnotatedRecord annotatedRecord = mutationRecords.remove(0);
-            if (!cvrSampleListUtil.getPortalSamples().contains(annotatedRecord.getTumor_Sample_Barcode())) {
-                cvrSampleListUtil.addSampleRemoved(annotatedRecord.getTumor_Sample_Barcode());
+            if (!cvrSampleListUtil.getPortalSamples().contains(annotatedRecord.getTUMOR_SAMPLE_BARCODE())) {
+                cvrSampleListUtil.addSampleRemoved(annotatedRecord.getTUMOR_SAMPLE_BARCODE());
                 return read();
             }
             for (String additionalProperty : additionalPropertyKeys) {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/GMLMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/GMLMutationDataReader.java
@@ -109,13 +109,13 @@ public class GMLMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                             annotatedRecord = annotator.annotateRecord(record, false, "mskcc", forceAnnotation);
                         }
                         catch (HttpServerErrorException e) {
-                            log.warn("Failed to annotate a record from json! Sample: " + sampleId + " Variant: " + record.getChromosome() + ":" + record.getStart_Position() + record.getReference_Allele() + ">" + record.getTumor_Seq_Allele2());
+                            log.warn("Failed to annotate a record from json! Sample: " + sampleId + " Variant: " + record.getCHROMOSOME() + ":" + record.getSTART_POSITION() + record.getREFERENCE_ALLELE() + ">" + record.getTUMOR_SEQ_ALLELE2());
                             annotatedRecord = cvrUtilities.buildCVRAnnotatedRecord(record);
                         }
                         mutationRecords.add(annotatedRecord);
                         header.addAll(record.getHeaderWithAdditionalFields());
                         additionalPropertyKeys.addAll(record.getAdditionalProperties().keySet());
-                        mutationMap.getOrDefault(annotatedRecord.getTumor_Sample_Barcode(), new ArrayList()).add(annotatedRecord);
+                        mutationMap.getOrDefault(annotatedRecord.getTUMOR_SAMPLE_BARCODE(), new ArrayList()).add(annotatedRecord);
                         germlineSamples.add(sampleId);
                     }
                 }
@@ -146,20 +146,20 @@ public class GMLMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
             reader.open(ec);
             try {
                 MutationRecord to_add;
-                while ((to_add = reader.read()) != null && to_add.getTumor_Sample_Barcode() != null) {
+                while ((to_add = reader.read()) != null && to_add.getTUMOR_SAMPLE_BARCODE() != null) {
                     AnnotatedRecord to_add_annotated;
                     try {
                         to_add_annotated = annotator.annotateRecord(to_add, false, "mskcc", forceAnnotation);
                     }
                     catch (HttpServerErrorException e) {
-                        log.warn("Failed to annotate a record from existing file! Sample: " + to_add.getTumor_Sample_Barcode() + " Variant: " + to_add.getChromosome() + ":" + to_add.getStart_Position() + to_add.getReference_Allele() + ">" + to_add.getTumor_Seq_Allele2());
+                        log.warn("Failed to annotate a record from existing file! Sample: " + to_add.getTUMOR_SAMPLE_BARCODE() + " Variant: " + to_add.getCHROMOSOME() + ":" + to_add.getSTART_POSITION() + to_add.getREFERENCE_ALLELE() + ">" + to_add.getTUMOR_SEQ_ALLELE2());
                         to_add_annotated = cvrUtilities.buildCVRAnnotatedRecord(to_add);
                     }
-                    if (!cvrUtilities.isDuplicateRecord(to_add, mutationMap.get(to_add.getTumor_Sample_Barcode())) && !(germlineSamples.contains(to_add.getTumor_Sample_Barcode()) && to_add.getMutation_Status().equals("GERMLINE"))) {
+                    if (!cvrUtilities.isDuplicateRecord(to_add, mutationMap.get(to_add.getTUMOR_SAMPLE_BARCODE())) && !(germlineSamples.contains(to_add.getTUMOR_SAMPLE_BARCODE()) && to_add.getMUTATION_STATUS().equals("GERMLINE"))) {
                         mutationRecords.add(to_add_annotated);
                         header.addAll(to_add_annotated.getHeaderWithAdditionalFields());
                         additionalPropertyKeys.addAll(to_add_annotated.getAdditionalProperties().keySet());
-                        mutationMap.getOrDefault(to_add_annotated.getTumor_Sample_Barcode(), new ArrayList()).add(to_add_annotated);
+                        mutationMap.getOrDefault(to_add_annotated.getTUMOR_SAMPLE_BARCODE(), new ArrayList()).add(to_add_annotated);
                     }
                 }
                 ec.put("commentLines", cvrUtilities.processFileComments(mutationFile));
@@ -184,8 +184,8 @@ public class GMLMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
     public AnnotatedRecord read() throws Exception {
         if (!mutationRecords.isEmpty()) {
             AnnotatedRecord annotatedRecord = mutationRecords.remove(0);
-            if (!cvrSampleListUtil.getPortalSamples().contains(annotatedRecord.getTumor_Sample_Barcode())) {
-                cvrSampleListUtil.addSampleRemoved(annotatedRecord.getTumor_Sample_Barcode());
+            if (!cvrSampleListUtil.getPortalSamples().contains(annotatedRecord.getTUMOR_SAMPLE_BARCODE())) {
+                cvrSampleListUtil.addSampleRemoved(annotatedRecord.getTUMOR_SAMPLE_BARCODE());
                 return read();
             }
             for (String additionalProperty : additionalPropertyKeys) {


### PR DESCRIPTION
Making function/headers case insensitive required changing getters and setters. Also updated the field set mapper for mutations to be case insensitive.