### PR TITLE
Reverting field set mapper due to case issues

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationFieldSetMapper.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationFieldSetMapper.java
@@ -37,62 +37,30 @@ import java.util.*;
 import org.springframework.batch.item.file.mapping.FieldSetMapper;
 import org.springframework.batch.item.file.transform.FieldSet;
 import org.springframework.validation.BindException;
-import org.springframework.cglib.beans.BeanMap;
-import com.google.common.collect.Sets;
-import com.google.common.base.Strings;
-import java.util.stream.Collectors;
+import org.apache.log4j.Logger;
 
 /**
  *
  * @author heinsz
  */
 public class CVRMutationFieldSetMapper implements  FieldSetMapper<MutationRecord> {
+    Logger log = Logger.getLogger(CVRMutationFieldSetMapper.class);
     @Override
     public MutationRecord mapFieldSet(FieldSet fs) throws BindException {
-        MutationRecord mr = new MutationRecord();
-        BeanMap recordBeanMap = BeanMap.create(new MutationRecord());
-        Set<String> fieldSetNames = new HashSet(Arrays.asList(fs.getNames()));
-        Set<String> mutationRecordFields = new HashSet(mr.getHeader());
-        
-        // We need to intersect these two sets ignoring case, and then use this
-        // intersection to filter the original set for data accession
-        Set<String> intersection = Sets.intersection(
-            mutationRecordFields.stream()
-                .map(field -> field.toUpperCase())
-                .collect(Collectors.toSet()),
-            fieldSetNames.stream()
-                .map(field -> field.toUpperCase())
-                .collect(Collectors.toSet()));
-        
-        // Here we make sure that the field is in our intersection
-        Set<String> fields = fieldSetNames.stream()
-                .filter(line -> intersection.contains(line.toUpperCase()))
-                .collect(Collectors.toSet());
-        
-        // In this we actually set the value in our bean map
-        fields.stream().forEach(column -> 
-            {
-                recordBeanMap.put(column.toUpperCase(),Strings.isNullOrEmpty(fs.readRawString(column)) ? "" : fs.readRawString(column));
-            });
-        
-        // Now access the bean from the map and set the additional propertes 
-        // (the difference of the field set and mutation record header)
-        MutationRecord record = (MutationRecord) recordBeanMap.getBean();
-        Set<String> additionalColumns = Sets.difference(
-            fieldSetNames.stream()
-                .map(field -> field.toUpperCase())
-                .collect(Collectors.toSet()),
-            mutationRecordFields.stream()
-                .map(field -> field.toUpperCase())
-                .collect(Collectors.toSet()));
-        Set<String> additionalColumnsWithCase = fieldSetNames.stream()
-                .filter(field -> additionalColumns.contains(field.toUpperCase()))
-                .collect(Collectors.toSet());
-        
-        // Actually set the values
-        additionalColumnsWithCase.stream().forEach((additionalField) -> {
-            record.addAdditionalProperty(additionalField, fs.readRawString(additionalField));
-        });
+        MutationRecord record = new MutationRecord();
+        Set<String> names = new HashSet(Arrays.asList(fs.getNames()));
+        names.addAll(record.getHeader());
+        for (String field : names) {
+            try {
+                record.getClass().getMethod("set" + field.toUpperCase(), String.class).invoke(record, fs.readRawString(field));
+            } catch (Exception e) {
+                if (e.getClass().equals(NoSuchMethodException.class)) {
+                    record.addAdditionalProperty(field, fs.readRawString(field));
+                } else {
+                    log.error("Something went wrong reading field " + field);
+                }
+            }
+         }
         return record;
     }
 }


### PR DESCRIPTION
fields for t_alt_count, n_alt_count, etc were not being properly mapped by the BeanMap. The key the bean map had was not all uppercase for some reason (t_ALT_COUNT).

Signed-off-by: Zack Heins <zackheins@gmail.com>