### PR TITLE
Bug fix for impact_timeline.py

### DIFF
--- a/import-scripts/impact_timeline.py
+++ b/import-scripts/impact_timeline.py
@@ -89,7 +89,7 @@ def write_map_to_file(filtered_samples, hgrepo):
 
     fieldnames = ['PATIENT_ID', 'SAMPLE_ID', 'DATE_ADDED', 'MONTH_ADDED', 'WEEK_ADDED']
     output_file = open(os.path.join(hgrepo,'data_clinical_supp_date.txt'), 'wb')
-    writer = csv.DictWriter(output_file, fieldnames = fieldnames, dialect = 'excel-tab')
+    writer = csv.DictWriter(output_file, fieldnames = fieldnames, dialect = 'excel-tab', lineterminator = '\n')
     writer.writeheader()
     for k, v in filtered_samples.iteritems():
         if k in current_sample_list:

--- a/import-scripts/import-dmp-impact-data.sh
+++ b/import-scripts/import-dmp-impact-data.sh
@@ -62,7 +62,6 @@ function addDateAddedData {
 
     # add "date added" to clinical data file
     $PYTHON_BINARY $PORTAL_HOME/scripts/impact_timeline.py --hgrepo=$STUDY_DATA_DIRECTORY
-    sed -i '/^\s*$/d' $STUDY_DATA_DIRECTORY/data_clinical_supp_date.txt
     cd $STUDY_DATA_DIRECTORY; rm *.orig
     rm $STUDY_DATA_DIRECTORY/case_lists/*.orig
 }


### PR DESCRIPTION
Default line terminator for csv.DictWriter() will double space output file. Just defined which line terminator to use fixed the double spacing issue.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>