### PR TITLE
Prevent NPE in LinkedMskimpactCaseProcessor by setting default empty string when value is null

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/LinkedMskimpactCaseRecord.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/LinkedMskimpactCaseRecord.java
@@ -39,7 +39,7 @@ public class LinkedMskimpactCaseRecord {
      * @return the linkedMskImpactCase
      */
     public String getLINKED_MSKIMPACT_CASE() {
-        return linkedMskImpactCase;
+        return linkedMskImpactCase != null ? linkedMskImpactCase : "";
     }
 
     /**


### PR DESCRIPTION
If `linked_mskimpact_case` does not exist for sample data in CVR json then field is set to null in `LinkedMskimpactCaseRecord` model. This change returns an empty string when this field is null to prevent NPE from being thrown in `LinkedMskimpactCaseProcessor`.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>