### PR TITLE
Use set instead of list for reference list of sample ids 

### DIFF
--- a/import-scripts/merge.py
+++ b/import-scripts/merge.py
@@ -132,7 +132,7 @@ PATIENT_SAMPLE_MAP = {}
 # ------------------------------------------------------------------------------
 # Functions
 
-def merge_studies(file_types, reference_list, keep_match, output_directory, study_id, cancer_type, exclude_supp_data, merge_clinical):
+def merge_studies(file_types, reference_set, keep_match, output_directory, study_id, cancer_type, exclude_supp_data, merge_clinical):
     """
         Goes through all the potential file types and calls correct function for those types.
         Normal merge, profile merge, and straight copy are the possibilities
@@ -161,7 +161,7 @@ def merge_studies(file_types, reference_list, keep_match, output_directory, stud
                 else:
                     merge_style = MERGE_STYLES[PROFILE]
 
-                merge_files(file_types[META_FILE_MAP[file_type][0]], file_type, reference_list, keep_match, output_directory, merge_style, study_id)
+                merge_files(file_types[META_FILE_MAP[file_type][0]], file_type, reference_set, keep_match, output_directory, merge_style, study_id)
             elif file_type == SUPP_DATA and not exclude_supp_data:
                 # multiple studies may have the same file basename for other filetypes i.e., data_mutations_unfiltered.txt
                 # we need to figure out which files to pair
@@ -184,7 +184,7 @@ def merge_studies(file_types, reference_list, keep_match, output_directory, stud
                             supp_file_type = CLINICAL_META_PATTERN
                         else:
                             supp_file_type = file_type
-                        merge_files(other_files, file_type, reference_list, keep_match, output_directory, MERGE_STYLES[NORMAL], study_id)
+                        merge_files(other_files, file_type, reference_set, keep_match, output_directory, MERGE_STYLES[NORMAL], study_id)
 
                 # copy files over to output directory if list not empty
                 if len(files_to_copy) == 0:
@@ -192,16 +192,16 @@ def merge_studies(file_types, reference_list, keep_match, output_directory, stud
                 print >> OUTPUT_FILE, 'Copying supplemental files meeting criteria from:'
                 for f in files_to_copy:
                     print >> OUTPUT_FILE, '\t' + f
-                copy_files(file_type, files_to_copy, reference_list, keep_match, output_directory, study_id, cancer_type)
+                copy_files(file_type, files_to_copy, reference_set, keep_match, output_directory, study_id, cancer_type)
     print >> OUTPUT_FILE, '\nMerge complete!'
 
-def merge_files(data_filenames, file_type, reference_list, keep_match, output_directory, merge_style, study_id):
+def merge_files(data_filenames, file_type, reference_set, keep_match, output_directory, merge_style, study_id):
     """
         Merges files together by adding data from each file to a dictionary/list that contains all
         of the information. After all data from every file from a type is accumulated, it gets written
         out to a file.
     """
-    new_header = process_header(data_filenames, reference_list, keep_match, merge_style)
+    new_header = process_header(data_filenames, reference_set, keep_match, merge_style)
 
     if file_type in [SEG_HG18_META_PATTERN, SEG_HG19_META_PATTERN]:
         output_filename = os.path.join(output_directory, study_id + META_FILE_MAP[file_type][0])
@@ -220,7 +220,7 @@ def merge_files(data_filenames, file_type, reference_list, keep_match, output_di
     for f in data_filenames:
         # update sequenced samples tag if data_mutations* file
         if MUTATION_FILE_PREFIX in f:
-            update_sequenced_samples(f, reference_list, keep_match)
+            update_sequenced_samples(f, reference_set, keep_match)
 
         # now merge data from file
         file_header = get_header(f)
@@ -239,7 +239,7 @@ def merge_files(data_filenames, file_type, reference_list, keep_match, output_di
                     profile_row(key,data, new_header, gene_sample_dict)
             elif merge_style is MERGE_STYLES[NORMAL]:
                 data_values = map(lambda x: data.get(x, ''), file_header)
-                if data_okay_to_add(is_clinical_or_timeline_file, file_header, reference_list, data_values, keep_match):
+                if data_okay_to_add(is_clinical_or_timeline_file, file_header, reference_set, data_values, keep_match):
                     rows.append(normal_row(data, new_header))
                     
         is_first_profile_datafile = False
@@ -256,11 +256,11 @@ def merge_files(data_filenames, file_type, reference_list, keep_match, output_di
         write_normal(rows, output_filename, new_header)
 
     print >> OUTPUT_FILE, 'Validating merge for: ' + output_filename
-    validate_merge(file_type, data_filenames, output_filename, reference_list, keep_match, merge_style)
+    validate_merge(file_type, data_filenames, output_filename, reference_set, keep_match, merge_style)
 
-def validate_merge(file_type, data_filenames, merged_filename, reference_list, keep_match, merge_style):
-    merged_file_summary = get_datafile_counts_summary(file_type, merged_filename, reference_list, keep_match, merge_style)
-    merged_header = process_header(data_filenames, reference_list, keep_match, merge_style)
+def validate_merge(file_type, data_filenames, merged_filename, reference_set, keep_match, merge_style):
+    merged_file_summary = get_datafile_counts_summary(file_type, merged_filename, reference_set, keep_match, merge_style)
+    merged_header = process_header(data_filenames, reference_set, keep_match, merge_style)
 
     # check that the merged header constructed from the data files matches the length of the header written to the merged file
     if len(merged_header) != merged_file_summary['num_cols']:
@@ -272,7 +272,7 @@ def validate_merge(file_type, data_filenames, merged_filename, reference_list, k
     total_rows = 0
     merged_gene_ids = []
     for filename in data_filenames:
-        datafile_summaries[filename] = get_datafile_counts_summary(file_type, filename, reference_list, keep_match, merge_style)
+        datafile_summaries[filename] = get_datafile_counts_summary(file_type, filename, reference_set, keep_match, merge_style)
         if merge_style is MERGE_STYLES[PROFILE]:
             new_gene_keys = [gene for gene in datafile_summaries[filename]['gene_ids'] if not gene in merged_gene_ids]
             merged_gene_ids.extend(new_gene_keys)
@@ -290,12 +290,12 @@ def validate_merge(file_type, data_filenames, merged_filename, reference_list, k
     print >> OUTPUT_FILE, 'Validation succeeded!\n'
 
 
-def data_okay_to_add(is_clinical_or_timeline_file, file_header, reference_list, data_values, keep_match):
+def data_okay_to_add(is_clinical_or_timeline_file, file_header, reference_set, data_values, keep_match):
     """ 
         Checks reference list (either 'sublist' or 'excluded_samples_list') if any matches found in data values. 
         If keeping match then True is returned for positive match, otherwise False is returned. P-0013956-T01-IM5
     """
-    if len(reference_list) == 0:
+    if len(reference_set) == 0:
         return True
     found = False
     if is_clinical_or_timeline_file and not 'SAMPLE_ID' in file_header:
@@ -303,12 +303,12 @@ def data_okay_to_add(is_clinical_or_timeline_file, file_header, reference_list, 
         if len([True for val in data_values if val in PATIENT_SAMPLE_MAP.keys()]) > 0:
             found = True
     else:
-        if len([True for val in data_values if val in reference_list]) > 0:
+        if len([True for val in data_values if val in reference_set]) > 0:
             found = True
     return (keep_match == found)
 
 
-def get_datafile_counts_summary(file_type, filename, reference_list, keep_match, merge_style):
+def get_datafile_counts_summary(file_type, filename, reference_set, keep_match, merge_style):
     """ Summarizes the basic data file info (num cols, num rows, gene ids). """
     file_header = get_header(filename)
     data_file = open(filename, 'rU')
@@ -316,11 +316,11 @@ def get_datafile_counts_summary(file_type, filename, reference_list, keep_match,
     is_clinical_or_timeline_file = is_clinical_or_timeline(filename)
 
     # filter header if necessary
-    if merge_style is MERGE_STYLES[PROFILE] and len(reference_list) > 0:
+    if merge_style is MERGE_STYLES[PROFILE] and len(reference_set) > 0:
         if keep_match:
-            file_header = [hdr for hdr in file_header if hdr.upper() in NON_CASE_IDS or hdr in reference_list]
+            file_header = [hdr for hdr in file_header if hdr.upper() in NON_CASE_IDS or hdr in reference_set]
         else:
-            file_header = [hdr for hdr in file_header if hdr not in reference_list]
+            file_header = [hdr for hdr in file_header if hdr not in reference_set]
 
     # figure out relevant row count
     # if no sublist then number of rows is the total rows minus the header
@@ -329,11 +329,11 @@ def get_datafile_counts_summary(file_type, filename, reference_list, keep_match,
         gene_ids = map(lambda x: process_datum(x.split('\t')[0]), filedata[1:])
         num_rows = len(filedata) - 1
     else:
-        if len(reference_list) > 0:
+        if len(reference_set) > 0:
             num_rows = 0
             for row in filedata[1:]:
                 data_values = map(lambda x: process_datum(x), row.split('\t'))
-                if data_okay_to_add(is_clinical_or_timeline_file, file_header, reference_list, data_values, keep_match):
+                if data_okay_to_add(is_clinical_or_timeline_file, file_header, reference_set, data_values, keep_match):
                     num_rows += 1
         else:
             num_rows = len(filedata) - 1
@@ -343,7 +343,7 @@ def get_datafile_counts_summary(file_type, filename, reference_list, keep_match,
     summary_info = {'num_cols':len(file_header), 'num_rows':num_rows, 'gene_ids':gene_ids}
     return summary_info
 
-def update_sequenced_samples(filename, reference_list, keep_match):
+def update_sequenced_samples(filename, reference_set, keep_match):
     """ Updates the SEQUENCED_SAMPLES list. """
     data_file = open(filename, 'rU')
     comments = [x for x in data_file.readlines() if x.startswith('#')]
@@ -353,9 +353,9 @@ def update_sequenced_samples(filename, reference_list, keep_match):
 
         # split sequenced sample tag by all : and spaces, sample ids begin at index 1
         sequenced_samples = map(lambda x: process_datum(x), re.split('[: ]', c)[1:])
-        if len(reference_list) > 0: 
+        if len(reference_set) > 0: 
             for sample_id in sequenced_samples:
-                add_seq_sample = (keep_match == (sample_id in reference_list))
+                add_seq_sample = (keep_match == (sample_id in reference_set))
                 if add_seq_sample:
                     SEQUENCED_SAMPLES.append(sample_id)
         else:
@@ -378,7 +378,7 @@ def get_header(filename):
     header = map(str.strip, filedata[0].split('\t'))
     return header
 
-def process_header(data_filenames, reference_list, keep_match, merge_style):
+def process_header(data_filenames, reference_set, keep_match, merge_style):
     """ Handles header merging, accumulating all column names """
     
     if merge_style is MERGE_STYLES[PROFILE]:
@@ -394,8 +394,8 @@ def process_header(data_filenames, reference_list, keep_match, merge_style):
                     if not hdr in non_case_ids:
                         non_case_ids.append(hdr)
                     continue
-                if len(reference_list) > 0:
-                    if (keep_match == (hdr in reference_list)) and not hdr in case_ids:
+                if len(reference_set) > 0:
+                    if (keep_match == (hdr in reference_set)) and not hdr in case_ids:
                         case_ids.append(hdr)
                 else:
                     case_ids.append(hdr)
@@ -461,7 +461,7 @@ def write_normal(rows, output_filename, new_header):
         output_file.write('\t'.join(row) + '\n')
     output_file.close()
 
-def copy_files(file_type, filenames, reference_list, keep_match, output_directory, study_id, cancer_type):
+def copy_files(file_type, filenames, reference_set, keep_match, output_directory, study_id, cancer_type):
     """
         Copies over files that aren't explicitly handled by this script (clinical, timeline, etc.).
         If there are subsets involved, only copy those rows. Else just copy the file.
@@ -486,22 +486,22 @@ def copy_files(file_type, filenames, reference_list, keep_match, output_director
                 file_ok_to_copy = False
 
         if file_ok_to_copy:
-            if 'clinical' in fname and len(reference_list) > 0:
+            if 'clinical' in fname and len(reference_set) > 0:
                 count += 1
                 if not 'SAMPLE_ID' in get_header(f):
                     make_subset(supp_file_type, f, newfilename, PATIENT_SAMPLE_MAP.keys(), keep_match)
                 else:
-                    make_subset(supp_file_type, f, newfilename, reference_list, keep_match)
-            elif 'timeline' in fname and len(reference_list) > 0:
+                    make_subset(supp_file_type, f, newfilename, reference_set, keep_match)
+            elif 'timeline' in fname and len(reference_set) > 0:
                 count += 1
                 make_subset(supp_file_type, f, newfilename, PATIENT_SAMPLE_MAP.keys(), keep_match)
-            elif len(reference_list) > 0:
+            elif len(reference_set) > 0:
                 count += 1
-                make_subset(supp_file_type, f, newfilename, reference_list, keep_match)
+                make_subset(supp_file_type, f, newfilename, reference_set, keep_match)
             else:
                 shutil.copy(f, newfilename)
 
-def make_subset(file_type, filename, output_filename, reference_list, keep_match):
+def make_subset(file_type, filename, output_filename, reference_set, keep_match):
     """ Makes subset on files that are in normal format (sample per line) """
     try:
         subfile = open(filename, 'rU')
@@ -518,7 +518,7 @@ def make_subset(file_type, filename, output_filename, reference_list, keep_match
 
     for line in filedata:
         data_values = map(lambda x: process_datum(x), line.split('\t'))
-        if data_okay_to_add(is_clinical_or_timeline_file, file_header, reference_list, data_values, keep_match):
+        if data_okay_to_add(is_clinical_or_timeline_file, file_header, reference_set, data_values, keep_match):
             output_file.write(line)
     subfile.close()
     output_file.close()
@@ -526,7 +526,7 @@ def make_subset(file_type, filename, output_filename, reference_list, keep_match
     # only write output file if number rows is greater than 1
     output_data = [line for line in open(output_filename, 'rU').readlines() if not line.startswith('#')]
     if len(output_data) <= 1:
-        if len(reference_list) > 0:
+        if len(reference_set) > 0:
             print >> OUTPUT_FILE, 'Samples in reference list not found in file: ' + filename
             os.remove(output_filename)
         else:
@@ -563,10 +563,10 @@ def generate_patient_sample_mapping(file_types, sublist, excluded_samples_list):
     if PATIENT_SAMPLE_MAP == {}: 
         print >> ERROR_FILE, 'ERROR! generate_patient_sample_mapping(),  Did not load any patient sample mapping from clinical files'
         sys.exit(2)
-    return reference_list,keep_match
+    return set(reference_list),keep_match
 
 
-def load_patient_sample_mapping(data_filenames, reference_list, keep_match):
+def load_patient_sample_mapping(data_filenames, reference_set, keep_match):
     """
         Loads patient - sample mapping from given clinical file(s). 
     """
@@ -583,10 +583,10 @@ def load_patient_sample_mapping(data_filenames, reference_list, keep_match):
             # always update patient sample map if no reference list to check against
             # otherwise only update patient sample map if (1) we want to keep matches and a sample was found in reference list
             # or (2) we do not want to keep matches and sample was not found in reference list
-            if len(reference_list) == 0:
+            if len(reference_set) == 0:
                 update_patient_sample_map(data['PATIENT_ID'], data['SAMPLE_ID'])
             else:
-                update_map = (keep_match == (data['SAMPLE_ID'] in reference_list))
+                update_map = (keep_match == (data['SAMPLE_ID'] in reference_set))
                 update_patient_sample_map(data['PATIENT_ID'], data['SAMPLE_ID'])
         data_file.close()
     print >> OUTPUT_FILE, 'Finished loading patient - sample mapping!\n'
@@ -800,10 +800,10 @@ def main():
         sys.exit(2)
 
     # load patient sample mapping from clinical files
-    reference_list,keep_match = generate_patient_sample_mapping(file_types, sublist, excluded_samples_list)
+    reference_set,keep_match = generate_patient_sample_mapping(file_types, sublist, excluded_samples_list)
 
     # merge the studies
-    merge_studies(file_types, reference_list, keep_match, output_directory, study_id, cancer_type, exclude_supp_data, merge_clinical)
+    merge_studies(file_types, reference_set, keep_match, output_directory, study_id, cancer_type, exclude_supp_data, merge_clinical)
 
 # do the main
 if __name__ == '__main__':


### PR DESCRIPTION
By using a set, the search of each record in the incoming data file against the reference list of sample id's will be based on a hash, not a linear search.  This may resulted in a significant speedup of GENIE processing from ~4.5 hours (per Ritika) to ~2 minutes (per Ben).

Further optimization (which is probably unnecessary) is an update to  data_okay_to_add(...) with a precomputed index to sample_id column instead of iterating through all the fields looking for the sample_id value.

Note, the following (looks to be benign/existing) script error occurs when running these scripts:

subset-impact-data.sh: line 80: /meta_clinical.txt: No such file or directory
subset-impact-data.sh: line 80: [: -eq: unary operator expected