### PR TITLE
fix issue : timeline output file has _null name

### DIFF
--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineReader.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineReader.java
@@ -60,7 +60,7 @@ public class TimelineReader implements ItemStreamReader<Map<String, String>> {
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
         String projectTitle = clinicalDataSource.getNextTimelineProjectTitle(stableId);
-        ec.put("projectId", projectTitle);
+        ec.put("projectTitle", projectTitle);
         log.info("Getting timeline header for project: " + projectTitle);
         ec.put("combinedHeader", clinicalDataSource.getTimelineHeader(stableId));
         records = clinicalDataSource.getTimelineData(stableId);

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceRedcapImpl.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceRedcapImpl.java
@@ -363,7 +363,6 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
             projectToken = clinicalTimelineTokens.remove(nextTimelineId);
         }
         else {
-            Set<String> keySet = clinicalDataTokens.keySet();
             projectToken = clinicalDataTokens.remove(nextClinicalId);
         }
 


### PR DESCRIPTION
- when outputting timeline data in a per-project (non-merge) way, store the proper attribute in the execution context.