### PR TITLE
"removed additional information in requeue error message"

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/requeue/CvrRequeueListener.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/requeue/CvrRequeueListener.java
@@ -85,11 +85,6 @@ public class CvrRequeueListener implements StepExecutionListener {
             for (CVRRequeueRecord requeueRecord : failedToRequeueSamples) {
                 body.append("\n\t");
                 body.append(requeueRecord.getSampleId());
-                body.append(": ");
-                body.append(requeueRecord.getResult());
-                body.append(" result; '");
-                body.append(requeueRecord.getInformation());
-                body.append("'");
             }
             body.append("\n");
         }


### PR DESCRIPTION
Removed .getResult() & .getInformation() from the email body. 
.getResult() will always print 0 since that's how they are filtered as failed requeues 
.getInformation() prints the long string that Aijaz asked to be removed. 

