### PR TITLE
add cvrMasterListStep() to BatchConfig for JSON mode

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
@@ -97,7 +97,8 @@ public class BatchConfiguration {
     @Bean
     public Job jsonJob() {
         return jobBuilderFactory.get(JSON_JOB)
-                .start(clinicalStep())
+                .start(cvrMasterListStep())
+                .next(clinicalStep())
                 .next(mutationStep())
                 .next(unfilteredMutationStep())
                 .next(cnaStep())
@@ -146,7 +147,8 @@ public class BatchConfiguration {
     @Bean
     public Job gmlJsonJob() {
         return jobBuilderFactory.get(GML_JSON_JOB)
-                .start(gmlMutationStep())
+                .start(cvrMasterListStep())
+                .next(gmlMutationStep())
                 .next(gmlClinicalStep())
                 .build();
     }


### PR DESCRIPTION
adds the cvrMasterListStep so JSON mode can properly filter samples based on the masterlist. Without fetching the masterlist and setting maxNumSamplesToRemoved, a NPE was thrown during updateSampleList() in JSON mode. 