### PR TITLE
Restrict cvr cmdline arguments

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
@@ -168,6 +168,14 @@ public class CVRPipeline {
             help(options, 0);
         }
         if (commandLine.hasOption("c")) {
+            for (Option option : commandLine.getOptions()) {
+                if (!option.getOpt().equals("t") && !option.getOpt().equals("c")) {
+                    String error_message = "The --consume_samples option is only compatible with the --test option. " +
+                                    "You used an incompatible option (--" + option.getLongOpt() + "/-" + option.getOpt() + ")";
+                    log.error(error_message);
+                    help(options,1);
+                }
+            }
             launchConsumeSamplesJob(args, commandLine.getOptionValue("c"), commandLine.hasOption("t"));
         }
         else {


### PR DESCRIPTION
Added checks for CVR command line arguments when using --consume_samples option. 
All other arguments are invalid and return an error and exit except for --test argument. 