### PR TITLE
Bugfixes to RedCap export modes

### DIFF
--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReader.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReader.java
@@ -188,7 +188,7 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
             }
             String existingValue = existingData.getOrDefault(attribute, "");
             String recordValue = record.getOrDefault(attribute, "");
-            if (!existingValue.isEmpty() && !recordValue.isEmpty()) {
+            if (!existingValue.isEmpty() && !recordValue.isEmpty() && !attribute.equals("SAMPLE_ID") && !attribute.equals("PATIENT_ID")) {
                 if (isSampleData) {
                     log.info("Clinical attribute " + attribute + " already loaded for sample " + record.get("SAMPLE_ID") + " - skipping.");
                 }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalPatientDataProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalPatientDataProcessor.java
@@ -50,8 +50,10 @@ public class ClinicalPatientDataProcessor implements ItemProcessor<ClinicalDataC
     public ClinicalDataComposite process(ClinicalDataComposite composite) throws Exception {
         List<String> record = new ArrayList<>();
         List<String> header = total_header.get("header");
-
-        record.add(composite.getData().get("PATIENT_ID"));
+        
+        if (header.contains("PATIENT_ID")) {
+            record.add(composite.getData().getOrDefault("PATIENT_ID", ""));
+        }
 
         for(String column : header) {
             if (!column.equals("PATIENT_ID")) {

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalPatientDataWriter.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalPatientDataWriter.java
@@ -33,7 +33,6 @@ package org.mskcc.cmo.ks.redcap.pipeline;
 
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -80,7 +79,7 @@ public class ClinicalPatientDataWriter implements ItemStreamWriter<ClinicalDataC
                 public void writeHeader(Writer writer) throws IOException {
                     writer.write("#" + getMetaLine(header.get("display_names")) + "\n");
                     writer.write("#" + getMetaLine(header.get("descriptions")) + "\n");
-                    writer.write("#" +getMetaLine(header.get("datatypes")) + "\n");
+                    writer.write("#" + getMetaLine(header.get("datatypes")) + "\n");
                     writer.write("#" + getMetaLine(header.get("priorities")) + "\n");
                     writer.write(getMetaLine(header.get("header")));
                 }
@@ -123,7 +122,15 @@ public class ClinicalPatientDataWriter implements ItemStreamWriter<ClinicalDataC
 
     private String getMetaLine(List<String> metaData) {
         int pidIndex = header.get("header").indexOf("PATIENT_ID");
-        return metaData.remove(pidIndex) + "\t" + StringUtils.join(metaData, "\t");
+        StringBuilder metaLine = new StringBuilder(metaData.get(pidIndex));
+        int index = 0;
+        for (String item : metaData) {
+            if (index != pidIndex) {
+                metaLine.append("\t").append(item);
+            }
+            index = index + 1;
+        }
+        return metaLine.toString();
     }
 
 }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalSampleDataProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalSampleDataProcessor.java
@@ -52,11 +52,15 @@ public class ClinicalSampleDataProcessor implements ItemProcessor<Map<String, St
         List<String> header = total_header.get("header");
 
         // get the sample and patient ids first before processing the other columns
-        record.add(i.get("SAMPLE_ID"));
-        record.add(i.get("PATIENT_ID"));
+        if (header.contains("SAMPLE_ID")) {
+            record.add(i.getOrDefault("SAMPLE_ID",""));
+        }
+        if (header.contains("PATIENT_ID")) {
+            record.add(i.getOrDefault("PATIENT_ID",""));
+        }
 
-        for(String column : header) {
-            if(!column.equals("SAMPLE_ID")) {
+        for (String column : header) {
+            if (!column.equals("SAMPLE_ID") && !column.equals("PATIENT_ID")) {
                 record.add(i.getOrDefault(column, ""));
             }
         }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataProcessor.java
@@ -47,8 +47,12 @@ public class RawClinicalDataProcessor implements ItemProcessor<Map<String, Strin
         List<String> record = new ArrayList();
 
         // get the sample and patient ids first before processing the other columns
-        record.add(i.get("SAMPLE_ID"));
-        record.add(i.get("PATIENT_ID"));
+        if (fullHeader.contains("SAMPLE_ID")) {
+            record.add(i.getOrDefault("SAMPLE_ID", ""));
+        }
+        if (fullHeader.contains("PATIENT_ID")) {
+            record.add(i.getOrDefault("PATIENT_ID", ""));
+        }
         for (String column : fullHeader) {
             if (!column.equals("SAMPLE_ID") && !column.equals("PATIENT_ID")) {
                 record.add(i.getOrDefault(column, ""));

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataWriter.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataWriter.java
@@ -76,7 +76,7 @@ public class RawClinicalDataWriter implements ItemStreamWriter<String> {
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
                 @Override
                 public void writeHeader(Writer writer) throws IOException {
-                    writer.write(StringUtils.join(fullHeader, "\t"));
+                    writer.write(getMetaLine(fullHeader));
                 }
             });
             flatFileItemWriter.open(ec);
@@ -99,6 +99,32 @@ public class RawClinicalDataWriter implements ItemStreamWriter<String> {
         if (writeRawClinicalData) {
             flatFileItemWriter.write(items);
         }        
+    }
+
+    private String getMetaLine(List<String> sampleMetadata) {
+        int sidIndex = sampleMetadata.indexOf("SAMPLE_ID");
+        int pidIndex = sampleMetadata.indexOf("PATIENT_ID");
+        StringBuilder metaLine = new StringBuilder();
+        if (sidIndex != -1) {
+            metaLine.append(sampleMetadata.get(sidIndex));
+        }
+        if (pidIndex != -1) {
+            if (metaLine.toString().length() != 0) {
+                metaLine.append("\t");
+            }
+            metaLine.append(sampleMetadata.get(pidIndex));
+        }
+        int index = 0;
+        for (String item : sampleMetadata) {
+            if (index != sidIndex && index != pidIndex) {
+                if (metaLine.toString().length() != 0) {
+                    metaLine.append("\t");
+                }
+                metaLine.append(item);
+            }
+            index = index + 1;
+        }
+        return metaLine.toString();
     }
 
 }


### PR DESCRIPTION
- mapping of field names to redcap_ids corrected (in MetaDataManager)
- override mappings of field names removed (hardcoded exceptions and missing values)
    (these are now available in the actual RedCap cbioportal_clinical_metadata project)
- rawData mode export now avoids empty columns (due to cases where PATIENT_ID or SAMPLE_ID are not present)
    - also reorders column headers and data to put SAMPLE_ID and PATIENT_ID first if they exist
- standard mode export now works correctly:
    - PATIENT_ID attribute is now added to both sampleAttributeMap and patientAttributeMap in ClinicalDataSource
    - ClinicalSampleWriter gets the metadata for PATIENT_ID attribute through the sampleHeader now (not patientHeader)
Reduce info messages for duplicated SAMPLE_ID and PATIENT_ID attribute values
Avoid modification of meta data objects in ClinicalPatientDataWriter and ClinicalSampleDataWriter
    - avoid use of List.remove() call ... this was modifying the members of a shared MetaData object