### PR TITLE
Import script logic changes

### DIFF
--- a/import-scripts/import-cmo-data-msk.sh
+++ b/import-scripts/import-cmo-data-msk.sh
@@ -25,11 +25,20 @@ if [ $DB_VERSION_FAIL -eq 0 ]; then
     echo "importing cancer type updates into msk portal database..."
     $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27184 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-cmo-importer.jar org.mskcc.cbio.importer.Admin --import-types-of-cancer --oncotree-version ${ONCOTREE_VERSION_TO_USE}
     echo "importing study data into msk portal database..."
+    IMPORT_FAIL=0
     $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27184 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/msk-cmo-importer.jar org.mskcc.cbio.importer.Admin --update-study-data --portal msk-automation-portal --update-worksheet --notification-file "$msk_automation_notification_file" --use-never-import --oncotree-version ${ONCOTREE_VERSION_TO_USE} --transcript-overrides-source mskcc
+    if [ $? -gt 0 ]; then
+        echo "MSK CMO import failed!"
+        IMPORT_FAIL=1
+        EMAIL_BODY="MSK CMO import failed"
+        echo -e "Sending email $EMAIL_BODY"
+        echo -e "$EMAIL_BODY" | mail -s "Import failure: MSK CMO" $pipelines_email_list
+    fi
+
     num_studies_updated=`cat $tmp/num_studies_updated.txt`
 
     # redeploy war
-    if [ $num_studies_updated -gt 0 ]; then
+    if [[ $IMPORT_FAIL -eq 0 && $num_studies_updated -gt 0 ]]; then
 	    echo "'$num_studies_updated' studies have been updated, requesting redeployment of msk portal war..."
         ssh -i $HOME/.ssh/id_rsa_msk_tomcat_restarts_key cbioportal_importer@dashi.cbio.mskcc.org touch /srv/data/portal-cron/msk-tomcat-restart
         ssh -i $HOME/.ssh/id_rsa_msk_tomcat_restarts_key cbioportal_importer@dashi2.cbio.mskcc.org touch /srv/data/portal-cron/msk-tomcat-restart

--- a/import-scripts/import-cmo-data-triage.sh
+++ b/import-scripts/import-cmo-data-triage.sh
@@ -7,37 +7,94 @@ tmp=$PORTAL_HOME/tmp/import-cron-cmo-triage
 if [[ -d "$tmp" && "$tmp" != "/" ]]; then
 	rm -rf "$tmp"/*
 fi
-email_list="cbioportal-cmo-importer@cbio.mskcc.org"
+cmo_email_list="cbioportal-cmo-importer@cbio.mskcc.org"
+pipeline_email_list="cbioportal-pipelines@cbio.mskcc.org"
 now=$(date "+%Y-%m-%d-%H-%M-%S")
 triage_notification_file=$(mktemp $tmp/triage-portal-update-notification.$now.XXXXXX)
 ONCOTREE_VERSION_TO_USE=oncotree_candidate_release
 
 # fetch updates in CMO repository
 echo "fetching updates from bic-mskcc..."
+CMO_FETCH_FAIL=0
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --fetch-data --data-source bic-mskcc --run-date latest --update-worksheet
+if [ $? -gt 0 ]; then
+    echo "CMO (bic-mskcc) fetch failed!"
+    CMO_FETCH_FAIL=1
+    EMAIL_BODY="The CMO (bic-mskcc) data fetch failed.  Imports into Triage and production WILL NOT HAVE UP-TO-DATE DATA until this is resolved.\n\n*** DO NOT MARK STUDIES FOR IMPORT INTO msk-automation-portal. ***\n\n*** DO NOT MERGE ANY STUDIES until this has been resolved. Please uncheck any merged studies in the cBio Portal Google document. ***\n\nYou may keep projects marked for import into Triage in the cBio Portal Google document.  Triage studies will be reimported once there has been a successful data fetch.\n\nPlease don't hesitate to ask if you have any questions."
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: CMO (bic-mskcc)" $cmo_email_list
+fi
 
 # fetch updates in private repository
 echo "fetching updates from private..."
+PRIVATE_FETCH_FAIL=0
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --fetch-data --data-source private --run-date latest --update-worksheet
+if [ $? -gt 0 ]; then
+    echo "private fetch failed!"
+    PRIVATE_FETCH_FAIL=1
+    EMAIL_BODY="The private data fetch failed."
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: private" $pipeline_email_list
+fi
 
 # fetch updates in genie repository
 echo "fetching updates from genie..."
+GENIE_FETCH_FAIL=0
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --fetch-data --data-source genie --run-date latest
+if [ $? -gt 0 ]; then
+    echo "genie fetch failed!"
+    GENIE_FETCH_FAIL=1
+    EMAIL_BODY="The genie data fetch failed."
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: genie" $pipeline_email_list
+fi
 
 # fetch updates in CMO impact
 echo "fetching updates from impact..."
+CMO_IMPACT_FETCH_FAIL=0
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --fetch-data --data-source impact --run-date latest --update-worksheet
+if [ $? -gt 0 ]; then
+    echo "impact fetch failed!"
+    CMO_IMPACT_FETCH_FAIL=1
+    EMAIL_BODY="The impact data fetch failed."
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: impact" $pipeline_email_list
+fi
 
 echo "fetching updates from impact-MERGED..."
+IMPACT_MERGED_FETCH_FAIL=0
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183-Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --fetch-data --data-source impact-MERGED --run-date latest --update-worksheet
+if [ $? -gt 0 ]; then
+    echo "impact-MERGED fetch failed!"
+    IMPACT_MERGED_FETCH_FAIL=1
+    EMAIL_BODY="The impact-MERGED data fetch failed."
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: impact-MERGED" $pipeline_email_list
+fi
 
 # fetch updates in studies repository
 echo "fetching updates from cbio-portal-data..."
+CBIO_PORTAL_DATA_FETCH_FAIL=0
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --fetch-data --data-source knowledge-systems-curated-studies --run-date latest
+if [ $? -gt 0 ]; then
+    echo "cbio-portal-data fetch failed!"
+    CBIO_PORTAL_DATA_FETCH_FAIL=1
+    EMAIL_BODY="The cbio-portal-data data fetch failed."
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: cbio-portal-data" $pipeline_email_list
+fi
 
 # fetch updates in immunotherapy repository
 echo "fetching updates from immunotherapy..."
+IMMUNOTHERAPY_FETCH_FAIL=0
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --fetch-data --data-source immunotherapy --run-date latest
+if [ $? -gt 0 ]; then
+    echo "immunotherapy fetch failed!"
+    IMMUNOTHERAPY_FETCH_FAIL=1
+    EMAIL_BODY="The immunotherapy data fetch failed."
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: immunotherapy" $pipeline_email_list
+fi
 
 # import data that requires QC into triage portal
 echo "importing cancer type updates into triage portal database..."
@@ -55,15 +112,23 @@ then
     DB_VERSION_FAIL=1
 fi
 
-if [ $DB_VERSION_FAIL -eq 0 ]
+# if the database version is correct and ALL fetches succeed, then import
+if [[ $DB_VERSION_FAIL -eq 0 && $CMO_FETCH_FAIL -eq 0 && $PRIVATE_FETCH_FAIL -eq 0 && $GENIE_FETCH_FAIL -eq 0 && $CMO_IMPACT_FETCH_FAIL -eq 0 && $IMPACT_MERGED_FETCH_FAIL -eq 0 && $CBIO_PORTAL_DATA_FETCH_FAIL -eq 0 && $IMMUNOTHERAPY_FETCH_FAIL -eq 0 ]]
 then
     echo "importing study data into triage portal database..."
+    IMPORT_FAIL=0
     $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183 -Xmx32G -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --update-study-data --portal triage-portal --use-never-import --update-worksheet --notification-file "$triage_notification_file" --oncotree-version ${ONCOTREE_VERSION_TO_USE} --transcript-overrides-source mskcc
+    if [ $? -gt 0 ]; then
+        echo "Triage import failed!"
+        IMPORT_FAIL=1
+        EMAIL_BODY="Triage import failed"
+        echo -e "Sending email $EMAIL_BODY"
+        echo -e "$EMAIL_BODY" | mail -s "Import failure: triage" $pipelines_email_list
+    fi
     num_studies_updated=`cat $tmp/num_studies_updated.txt`
 
     # redeploy war
-    if [ $num_studies_updated -gt 0 ]
-    then
+    if [[ $IMPORT_FAIL -eq 0 && $num_studies_updated -gt 0 ]]; then
 	    #echo "'$num_studies_updated' studies have been updated, redeploying triage-portal war..."
     	echo "'$num_studies_updated' studies have been updated.  Restarting triage-tomcat server..."
 	    /usr/bin/sudo /etc/init.d/triage-tomcat7 restart
@@ -71,6 +136,10 @@ then
     else
 	    echo "No studies have been updated, skipping redeploy of triage-portal war..."
     fi
+
+    # import ran and either failed or succeeded
+    echo "sending notification email.."
+    $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --send-update-notification --portal triage-portal --notification-file "$triage_notification_file"
 fi
 
 EMAIL_BODY="The Triage database version is incompatible. Imports will be skipped until database is updated."
@@ -78,11 +147,8 @@ EMAIL_BODY="The Triage database version is incompatible. Imports will be skipped
 if [ $DB_VERSION_FAIL -gt 0 ]
 then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "Triage Update Failure: DB version is incompatible" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "Triage Update Failure: DB version is incompatible" $cmo_email_list
 fi
-
-echo "sending notification email.."
-$JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --send-update-notification --portal triage-portal --notification-file "$triage_notification_file"
 
 if [[ -d "$tmp" && "$tmp" != "/" ]]; then
 	rm -rf "$tmp"/*

--- a/import-scripts/import-genie-data.sh
+++ b/import-scripts/import-genie-data.sh
@@ -25,11 +25,19 @@ if [ $DB_VERSION_FAIL -eq 0 ]; then
     echo "importing cancer type updates into genie portal database..."
     $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27186 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/genie-importer.jar org.mskcc.cbio.importer.Admin --import-types-of-cancer --oncotree-version ${ONCOTREE_VERSION_TO_USE}
     echo "importing study data into genie portal database..."
+    IMPORT_FAIL=0
     $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27186 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/genie-importer.jar org.mskcc.cbio.importer.Admin --update-study-data --portal genie-portal --update-worksheet --notification-file "$genie_portal_notification_file" --oncotree-version ${ONCOTREE_VERSION_TO_USE} --transcript-overrides-source mskcc
+    if [ $? -gt 0 ]; then
+        echo "Genie import failed!"
+        IMPORT_FAIL=1
+        EMAIL_BODY="Genie import failed"
+        echo -e "Sending email $EMAIL_BODY"
+        echo -e "$EMAIL_BODY" | mail -s "Import failure: Genie" $pipelines_email_list
+    fi
     num_studies_updated=`cat $tmp/num_studies_updated.txt`
 
     # redeploy war
-    if [ $num_studies_updated -gt 0 ]; then
+    if [[ $IMPORT_FAIL -eq 0 && $num_studies_updated -gt 0 ]]; then
         echo "'$num_studies_updated' studies have been updated, requesting redeployment of genie portal war..."
         ssh -i $HOME/.ssh/id_rsa_schultz_tomcat_restarts_key cbioportal_importer@dashi.cbio.mskcc.org touch /srv/data/portal-cron/schultz-tomcat-restart
         ssh -i $HOME/.ssh/id_rsa_schultz_tomcat_restarts_key cbioportal_importer@dashi2.cbio.mskcc.org touch /srv/data/portal-cron/schultz-tomcat-restart

--- a/import-scripts/import-public-data.sh
+++ b/import-scripts/import-public-data.sh
@@ -25,11 +25,19 @@ if [ $DB_VERSION_FAIL -eq 0 ]; then
     echo "importing cancer type updates into public portal database..."
     $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27185 -Xmx16g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/public-importer.jar org.mskcc.cbio.importer.Admin --import-types-of-cancer --oncotree-version ${ONCOTREE_VERSION_TO_USE}
     echo "importing study data into public portal database..."
+    IMPORT_FAIL=0
     $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27185 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/public-importer.jar org.mskcc.cbio.importer.Admin --update-study-data --portal public-portal --update-worksheet --notification-file "$public_portal_notification_file" --oncotree-version ${ONCOTREE_VERSION_TO_USE} --transcript-overrides-source uniprot
+    if [ $? -gt 0 ]; then
+        echo "Public import failed!"
+        IMPORT_FAIL=1
+        EMAIL_BODY="Public import failed"
+        echo -e "Sending email $EMAIL_BODY"
+        echo -e "$EMAIL_BODY" | mail -s "Import failure: public" $pipelines_email_list
+    fi
     num_studies_updated=`cat $tmp/num_studies_updated.txt`
 
     # redeploy war
-    if [ $num_studies_updated -gt 0 ]; then
+    if [[ $IMPORT_FAIL -eq 0 && $num_studies_updated -gt 0 ]]; then
         echo "'$num_studies_updated' studies have been updated, requesting redeployment of public portal war..."
         ssh -i $HOME/.ssh/id_rsa_public_tomcat_restarts_key cbioportal_importer@dashi.cbio.mskcc.org touch /srv/data/portal-cron/public-tomcat-restart
         ssh -i $HOME/.ssh/id_rsa_public_tomcat_restarts_key cbioportal_importer@dashi2.cbio.mskcc.org touch /srv/data/portal-cron/public-tomcat-restart

--- a/import-scripts/import-temp-study.sh
+++ b/import-scripts/import-temp-study.sh
@@ -129,6 +129,7 @@ fi
 # import study using temp id
 echo "Importing study '$CANCER_STUDY_IDENTIFIER' as temporary study '$TEMP_CANCER_STUDY_IDENTIFIER'"
 $JAVA_HOME/bin/java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182 -Xmx64g -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$TMP_DIRECTORY" -cp $IMPORTER_JAR org.mskcc.cbio.importer.Admin --update-study-data --portal "$PORTAL_NAME" --notification-file "$NOTIFICATION_FILE" --temporary-id "$TEMP_CANCER_STUDY_IDENTIFIER" ${ONCOTREE_VERSION_TERM} --transcript-overrides-source "$TRANCRIPT_OVERRIDES_SOURCE"
+# we don't have to check the exit status here because if num_studies_updated != 1 we consider the import to have failed (we check num_studies_updated next)
 
 # check number of studies updated before continuing
 if [ -f "$TMP_DIRECTORY/num_studies_updated.txt" ]; then 


### PR DESCRIPTION
import-temp-study.sh:
  * Send import notification email only on import failure or if ALL steps succeed (previously import would succeed, a later step would fail and revert the import, and then a successful import email would go out, confusing everyone).

import-cmo-data-triage.sh
  * On any fetch failure send an email
  * Only import if all fetchs succeeded

Also checks exit code of all import script calls from the import*data*.sh files.