### PR TITLE
made data clinical filename a command line parameter

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
@@ -63,7 +63,8 @@ public class CVRPipeline {
             .addOption("t", "test", false, "Flag for running pipeline in testing mode so that samples are not consumed")
             .addOption("c", "consume_samples", true, "Path to CVR json filename")
             .addOption("r", "max_samples_to_remove", true, "The max number of samples that can be removed from data")
-            .addOption("f", "force_annotation", false, "Flag for forcing reannotation of samples");
+            .addOption("f", "force_annotation", false, "Flag for forcing reannotation of samples")
+            .addOption("n", "name_of_clinical_file", true, "Clinical filename.  Default is data_clinical.txt");
         return options;
     }
 
@@ -74,7 +75,7 @@ public class CVRPipeline {
     }
 
     private static void launchCvrPipelineJob(String[] args, String directory, String studyId, Boolean json, Boolean gml,
-            Boolean skipSeg, boolean testingMode, Integer maxNumSamplesToRemove, Boolean forceAnnotation) throws Exception {
+            Boolean skipSeg, boolean testingMode, Integer maxNumSamplesToRemove, Boolean forceAnnotation, String clinicalFilename) throws Exception {
         // log wether in testing mode or not
         if (testingMode) {
             log.warn("CvrPipelineJob running in TESTING MODE - samples will NOT be requeued.");
@@ -93,7 +94,8 @@ public class CVRPipeline {
                 .addString("studyId", studyId)
                 .addString("testingMode", String.valueOf(testingMode))
                 .addString("maxNumSamplesToRemove", String.valueOf(maxNumSamplesToRemove))
-                .addString("forceAnnotation", String.valueOf(forceAnnotation));
+                .addString("forceAnnotation", String.valueOf(forceAnnotation))
+                .addString("clinicalFilename", clinicalFilename);
         if (json) {
             if (gml) {
                 jobName = BatchConfiguration.GML_JSON_JOB;
@@ -189,9 +191,13 @@ public class CVRPipeline {
                 e.printStackTrace();
                 throw new RuntimeException("Cannot parse argument as integer: " + commandLine.getOptionValue("r"));
             }
+            String clinicalFilename = CVRUtilities.DEFAULT_CLINICAL_FILE;
+            if (commandLine.hasOption("n")) {
+                clinicalFilename = commandLine.getOptionValue("n");
+            }
             launchCvrPipelineJob(args, commandLine.getOptionValue("d"), commandLine.getOptionValue("i"),
                 commandLine.hasOption("j"), commandLine.hasOption("g"), commandLine.hasOption("s"),
-                commandLine.hasOption("t"), maxNumSamplesToRemove, commandLine.hasOption("f"));
+                commandLine.hasOption("t"), maxNumSamplesToRemove, commandLine.hasOption("f"), clinicalFilename);
         }
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -54,7 +54,7 @@ public class CVRUtilities {
     public static final String CVR_FILE = "cvr_data.json";
     public final String MUTATION_FILE = "data_mutations_extended.txt";
     public final String UNFILTERED_MUTATION_FILE = "data_mutations_unfiltered.txt";
-    public final String CLINICAL_FILE = "data_clinical.txt";
+    public static final String DEFAULT_CLINICAL_FILE = "data_clinical.txt";
     public final String SEQ_DATE_CLINICAL_FILE = "seq_date.txt";
     public final String DARWIN_AGE_FILE = "darwin_age.txt";
     public final String CORRESPONDING_ID_FILE = "linked_mskimpact_cases.txt";

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
@@ -58,6 +58,9 @@ public class CVRClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
     @Value("#{jobParameters[studyId]}")
     private String studyId;
 
+    @Value("#{jobParameters[clinicalFilename]}")
+    private String clinicalFilename;
+
     @Autowired
     public CVRUtilities cvrUtilities;
     
@@ -107,7 +110,7 @@ public class CVRClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
     }
     
     private void processClinicalFile(ExecutionContext ec) {
-        File mskimpactClinicalFile = new File(stagingDirectory, cvrUtilities.CLINICAL_FILE);
+        File mskimpactClinicalFile = new File(stagingDirectory, clinicalFilename);
         if (!mskimpactClinicalFile.exists()) {
             log.error("File does not exist - skipping data loading from clinical file: " + mskimpactClinicalFile.getName());
             return;

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataWriter.java
@@ -54,6 +54,9 @@ public class CVRClinicalDataWriter implements ItemStreamWriter<CompositeClinical
     @Value("#{jobParameters[stagingDirectory]}")
     private String stagingDirectory;
 
+    @Value("#{jobParameters[clinicalFilename]}")
+    private String clinicalFilename;
+
     @Autowired
     public CVRUtilities cvrUtilities;
 
@@ -62,7 +65,7 @@ public class CVRClinicalDataWriter implements ItemStreamWriter<CompositeClinical
     // Set up the writer and print the json from CVR to a file
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
-        File stagingFile = new File(stagingDirectory, cvrUtilities.CLINICAL_FILE);
+        File stagingFile = new File(stagingDirectory, clinicalFilename);
         PassThroughLineAggregator aggr = new PassThroughLineAggregator();
         flatFileItemWriter.setLineAggregator(aggr);
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRNewClinicalDataWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRNewClinicalDataWriter.java
@@ -54,6 +54,9 @@ public class CVRNewClinicalDataWriter implements ItemStreamWriter<CompositeClini
     @Value("${tmpdir}")
     private String stagingDirectory;
 
+    @Value("#{jobParameters[clinicalFilename]}")
+    private String clinicalFilename;
+
     @Autowired
     public CVRUtilities cvrUtilities;
 
@@ -62,7 +65,7 @@ public class CVRNewClinicalDataWriter implements ItemStreamWriter<CompositeClini
     // Set up the writer and print the json from CVR to a file
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
-        File stagingFile = new File(stagingDirectory, cvrUtilities.CLINICAL_FILE);
+        File stagingFile = new File(stagingDirectory, clinicalFilename);
         PassThroughLineAggregator aggr = new PassThroughLineAggregator();
         flatFileItemWriter.setLineAggregator(aggr);
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/GMLClinicalDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/GMLClinicalDataReader.java
@@ -55,6 +55,9 @@ public class GMLClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
     @Value("#{jobParameters[stagingDirectory]}")
     private String stagingDirectory;
 
+    @Value("#{jobParameters[clinicalFilename]}")
+    private String clinicalFilename;
+
     @Autowired
     public CVRUtilities cvrUtilities;
 
@@ -77,7 +80,7 @@ public class GMLClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
             ex.printStackTrace();
         }
         
-        File clinicalFile = new File(stagingDirectory, cvrUtilities.CLINICAL_FILE);
+        File clinicalFile = new File(stagingDirectory, clinicalFilename);
         if (!clinicalFile.exists()) {
             log.error("Could not find clinical file: " + clinicalFile.getName());
         }


### PR DESCRIPTION
Added option -n or --name_of_clinical_file so that we can override the default of "data_clinical.txt".