### PR TITLE
Zero variant sample warning

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
@@ -64,6 +64,7 @@ public class CVRPipeline {
             .addOption("c", "consume_samples", true, "Path to CVR json filename")
             .addOption("r", "max_samples_to_remove", true, "The max number of samples that can be removed from data")
             .addOption("f", "force_annotation", false, "Flag for forcing reannotation of samples")
+            .addOption("b", "block_zero_variant_warnings", false, "Flag to turn off warnings for samples with no variants")
             .addOption("n", "name_of_clinical_file", true, "Clinical filename.  Default is data_clinical.txt");
         return options;
     }
@@ -75,7 +76,8 @@ public class CVRPipeline {
     }
 
     private static void launchCvrPipelineJob(String[] args, String directory, String studyId, Boolean json, Boolean gml,
-            Boolean skipSeg, boolean testingMode, Integer maxNumSamplesToRemove, Boolean forceAnnotation, String clinicalFilename) throws Exception {
+            Boolean skipSeg, boolean testingMode, Integer maxNumSamplesToRemove, Boolean forceAnnotation, String clinicalFilename,
+            Boolean stopZeroVariantWarnings) throws Exception {
         // log wether in testing mode or not
         if (testingMode) {
             log.warn("CvrPipelineJob running in TESTING MODE - samples will NOT be requeued.");
@@ -95,7 +97,8 @@ public class CVRPipeline {
                 .addString("testingMode", String.valueOf(testingMode))
                 .addString("maxNumSamplesToRemove", String.valueOf(maxNumSamplesToRemove))
                 .addString("forceAnnotation", String.valueOf(forceAnnotation))
-                .addString("clinicalFilename", clinicalFilename);
+                .addString("clinicalFilename", clinicalFilename)
+                .addString("stopZeroVariantWarnings", String.valueOf(stopZeroVariantWarnings));
         if (json) {
             if (gml) {
                 jobName = BatchConfiguration.GML_JSON_JOB;
@@ -197,7 +200,7 @@ public class CVRPipeline {
             }
             launchCvrPipelineJob(args, commandLine.getOptionValue("d"), commandLine.getOptionValue("i"),
                 commandLine.hasOption("j"), commandLine.hasOption("g"), commandLine.hasOption("s"),
-                commandLine.hasOption("t"), maxNumSamplesToRemove, commandLine.hasOption("f"), clinicalFilename);
+                commandLine.hasOption("t"), maxNumSamplesToRemove, commandLine.hasOption("f"), clinicalFilename, commandLine.hasOption("b"));
         }
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CvrSampleListUtil.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CvrSampleListUtil.java
@@ -36,6 +36,7 @@ import org.apache.log4j.Logger;
 import java.util.*;
 import org.cbioportal.cmo.pipelines.cvr.model.CvrResponse;
 import org.springframework.context.annotation.*;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  *
@@ -43,6 +44,9 @@ import org.springframework.context.annotation.*;
  */
 @Configuration
 public class CvrSampleListUtil {
+
+    @Value("#{'${whitelisted_samples:}'.split(',')}")
+    public List<String> whitelistedSamples;
 
     private CvrResponse cvrResponse;
     private Set<String> dmpMasterList = new HashSet<>();
@@ -55,6 +59,7 @@ public class CvrSampleListUtil {
     private Integer maxNumSamplesToRemove;
     private Set<String> samplesRemovedList = new HashSet<>();
     private Map<String, String> sampleListStats = new HashMap<>();
+    private Set<String> zeroVariantSamples = new HashSet<>();
 
     Logger log = Logger.getLogger(CvrSampleListUtil.class);
     
@@ -292,6 +297,23 @@ public class CvrSampleListUtil {
     public void addSampleRemoved(String sampleId) {
         this.samplesRemovedList.add(sampleId);
     }    
+
+    /**
+     * @param sampleId the sampleId to add
+     */
+    public void addZeroVariantSample(String sampleId) {
+        this.zeroVariantSamples.add(sampleId);
+    }
+
+    /**
+     * @return the non whitelisted sample ids of samples that have zero variants
+     */
+    public Set<String> getNonWhitelistedZeroVariantSamples() {
+        Set<String> tmpzeroVariantSamples = new HashSet<>(zeroVariantSamples);
+        tmpzeroVariantSamples.removeAll(whitelistedSamples);
+        return tmpzeroVariantSamples;
+    }
+
     private void saveSampleListStats() {
         Map<String, String> sampleListStats = new HashMap<>();
         sampleListStats.put("dmpMasterList", String.valueOf(dmpMasterList.size()));

--- a/cvr/src/main/resources/application.properties.EXAMPLE
+++ b/cvr/src/main/resources/application.properties.EXAMPLE
@@ -44,3 +44,5 @@ email.subject=Failure in CVR Pipeline
 # for emails that dmp should be included on
 dmp.email.sender=
 dmp.email.recipient=
+
+whitelisted_samples=


### PR DESCRIPTION
This tracks all samples with zero variants and sends them as a list in the summary email.  Samples can be excluded (whitelisted) from this list by adding them to the "whitelisted_samples" application.properties parameter.

This includes an optional command line flag "b" or "block_zero_variant_warnings" which turns off warnings for samples with zero variants (to be used with the Archer study).

We plan on having an endpoint with the whitelisted samples replace the "whitelisted_samples" parameter.