### PR TITLE
Fixing email error: BAD HEADER SECTION, Duplicate header field: 'To'

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/EmailUtil.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/EmailUtil.java
@@ -85,9 +85,11 @@ public class EmailUtil {
             properties.setProperty("mail.smtp.host", server);
             MimeMessage message = new MimeMessage(session);
             message.setFrom(new InternetAddress(sender));
-            for (String nextRecipient : recipients) {
-                message.addRecipient(Message.RecipientType.TO, new InternetAddress(nextRecipient));
+            InternetAddress[] recipientEmails = new InternetAddress[recipients.length];
+            for (int i = 0; i < recipients.length; i++) {
+                recipientEmails[i] = new InternetAddress(recipients[i]);
             }
+            message.addRecipients(Message.RecipientType.TO, recipientEmails);
             message.setSubject(subject);
             message.setText(body);
             Transport.send(message);


### PR DESCRIPTION
"CVR pipeline master list errors" email contained the following in the header:

"X-Amavis-Alert: BAD HEADER SECTION, Duplicate header field: "To""
...
To: <wilsonm2@mskcc.org>
To: <wilson@cbio.mskcc.org>

Now it has no error To field looks like this:

To: <wilsonm2@mskcc.org>, <wilson@cbio.mskcc.org>

