### PR TITLE
Add unfiltered snp count to zero checked out snp warning email

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CvrSampleListUtil.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CvrSampleListUtil.java
@@ -60,6 +60,7 @@ public class CvrSampleListUtil {
     private Set<String> samplesRemovedList = new HashSet<>();
     private Map<String, String> sampleListStats = new HashMap<>();
     private Set<String> zeroVariantSamples = new HashSet<>();
+    private Map<String, Integer> unfilteredSampleSnpCounts = new HashMap<>();
 
     Logger log = Logger.getLogger(CvrSampleListUtil.class);
     
@@ -312,6 +313,21 @@ public class CvrSampleListUtil {
         Set<String> tmpzeroVariantSamples = new HashSet<>(zeroVariantSamples);
         tmpzeroVariantSamples.removeAll(whitelistedSamples);
         return tmpzeroVariantSamples;
+    }
+
+    /**
+     * @param sampleId the sampleId to add
+     * @param count the number of unfiltered snps for that sample
+     */
+    public void addUnfilteredSampleSnpCount(String sampleId, Integer count) {
+        this.unfilteredSampleSnpCounts.put(sampleId, count);
+    }
+
+    /**
+     * @return the count of unfiltered snps for every sample
+     */
+    public Map<String, Integer> getUnfilteredSampleSnpCounts() {
+        return this.unfilteredSampleSnpCounts;
     }
 
     private void saveSampleListStats() {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRUnfilteredMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRUnfilteredMutationDataReader.java
@@ -102,6 +102,7 @@ public class CVRUnfilteredMutationDataReader implements ItemStreamReader<Annotat
         log.info(String.valueOf(snpsToAnnotateCount) + " records to annotate");
         for (CVRMergedResult result : cvrData.getResults()) {
             String sampleId = result.getMetaData().getDmpSampleId();
+            int sampleSNPCount = 0;
             String somaticStatus = result.getMetaData().getSomaticStatus() != null ? result.getMetaData().getSomaticStatus() : "N/A";
             List<CVRSnp> snps = new ArrayList<>();
             snps.addAll(result.getSnpIndelExonic());
@@ -110,6 +111,7 @@ public class CVRUnfilteredMutationDataReader implements ItemStreamReader<Annotat
             snps.addAll(result.getSnpIndelSilentNp());
             for (CVRSnp snp : snps) {
                 annotatedSnpsCount++;
+                sampleSNPCount++;
                 if (annotatedSnpsCount % 500 == 0) {
                     log.info("\tOn record " + String.valueOf(annotatedSnpsCount) + " out of " + String.valueOf(snpsToAnnotateCount) + ", annotation " + String.valueOf((int)(((annotatedSnpsCount * 1.0)/snpsToAnnotateCount) * 100)) + "% complete");
                 }
@@ -127,6 +129,7 @@ public class CVRUnfilteredMutationDataReader implements ItemStreamReader<Annotat
                 additionalPropertyKeys.addAll(annotatedRecord.getAdditionalProperties().keySet());
                 mutationMap.getOrDefault(annotatedRecord.getTUMOR_SAMPLE_BARCODE(), new ArrayList()).add(annotatedRecord);
             }
+            cvrSampleListUtil.addUnfilteredSampleSnpCount(sampleId, new Integer(sampleSNPCount));
         }
 
         this.mutationFile = new File(stagingDirectory, cvrUtilities.UNFILTERED_MUTATION_FILE);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/requeue/CvrRequeueListener.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/requeue/CvrRequeueListener.java
@@ -79,6 +79,7 @@ public class CvrRequeueListener implements StepExecutionListener {
         Map<String, String> sampleListStats = (Map<String, String>) stepExecution.getJobExecution().getExecutionContext().get("sampleListStats");
         List<CVRRequeueRecord> failedToRequeueSamples = (List<CVRRequeueRecord>) stepExecution.getJobExecution().getExecutionContext().get("failedToRequeueSamples");
         Set<String> zeroVariantSamples = cvrSampleListUtil.getNonWhitelistedZeroVariantSamples();
+        Map<String, Integer> unfilteredSampleSnpCounts = cvrSampleListUtil.getUnfilteredSampleSnpCounts();
     
         String subject = "CVR pipeline master list errors: " +  studyId;
         StringBuilder body = new StringBuilder();
@@ -142,6 +143,13 @@ public class CvrRequeueListener implements StepExecutionListener {
                 if (count <= 30) {
                     body.append("\n\t");
                     body.append(sampleId);
+                    Integer unfilteredCount = unfilteredSampleSnpCounts.get(sampleId);
+                    if (unfilteredCount == null) {
+                        unfilteredCount = new Integer(0);
+                    }
+                    body.append(" (unfiltered snp count: ");
+                    body.append(unfilteredCount.toString());
+                    body.append(")");
                 } else {
                     break;
                 }


### PR DESCRIPTION
The email now looks like this:

Samples that have zero variants and are not whitelisted:

	P-0024168-T01-IM6 (unfiltered snp count: 4)

The "(unfiltered snp count: 4)" is new.