### PR TITLE
Unit tests and bugfix for redcap getPatientHeader() and getSampleHeader()

### DIFF
--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReader.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReader.java
@@ -102,16 +102,16 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
             }
             // associate patient data with their samples so that patient data for each sample is the same
             this.clinicalRecords = mergePatientSampleClinicalRecords();
-            // if sample header size is <= 1 then skip writing the sample clinical data file
+            // if sample header size is <= 2 then skip writing the sample clinical data file
             boolean writeClinicalSample = true;
-            if (fullSampleHeader.get("header").size() <= 1) {
-                log.warn("Sample header size for project <=1 - clinical sample data file will not be generated");
+            if (fullSampleHeader.get("header").size() <= 2) {
+                log.warn("Sample header size for project <= 2 - clinical sample data file will not be generated");
                 writeClinicalSample = false;
             }
             // if patient header size is <= 1 then skip writing the patient clinical data file
             boolean writeClinicalPatient = true;
             if (fullPatientHeader.get("header").size() <= 1) {
-                log.warn("Patient header size for project <=1 - clinical patient data file will not be generated");
+                log.warn("Patient header size for project <= 1 - clinical patient data file will not be generated");
                 writeClinicalPatient = false;
             }
             // add headers and booleans to execution context for processors and writers
@@ -122,10 +122,10 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
         }
         ec.put("projectTitle", projectTitle);
     }
-    
+
     /**
      * Associates patient data with each sample it's associated with.
-     * @return 
+     * @return
      */
     private List<Map<String,String>> mergePatientSampleClinicalRecords() {
         List<Map<String,String>> mergedClinicalRecords = new ArrayList();
@@ -172,13 +172,13 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
             }
         }
     }
-    
+
     private void updateClinicalData(Map<String, String> record, boolean isSampleData) {
-        Map<String, String> existingData = isSampleData ? 
-                compiledClinicalSampleRecords.getOrDefault(record.get("SAMPLE_ID"), new HashMap<>()) : 
+        Map<String, String> existingData = isSampleData ?
+                compiledClinicalSampleRecords.getOrDefault(record.get("SAMPLE_ID"), new HashMap<>()) :
                 compiledClinicalPatientRecords.getOrDefault(record.get("PATIENT_ID"), new HashMap<>());
         List<String> clinicalHeader = isSampleData ? fullSampleHeader.get("header") : fullPatientHeader.get("header");
-        
+
         if (isSampleData && !existingData.containsKey("PATIENT_ID")) {
             existingData.put("PATIENT_ID", record.get("PATIENT_ID"));
         }
@@ -194,7 +194,7 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
                 }
                 else {
                     log.info("Clinical attribute " + attribute + " already loaded for patient " + record.get("PATIENT_ID") + " - skipping.");
-                }                
+                }
                 continue;
             }
             String value = (!existingValue.isEmpty()) ? existingValue : recordValue;

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceRedcapImpl.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceRedcapImpl.java
@@ -32,10 +32,7 @@
 
 package org.mskcc.cmo.ks.redcap.source.internal;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.*;
-import java.net.*;
 import java.util.*;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.log4j.Logger;
@@ -43,9 +40,7 @@ import org.mskcc.cmo.ks.redcap.models.RedcapAttributeMetadata;
 import org.mskcc.cmo.ks.redcap.models.RedcapProjectAttribute;
 import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
 import org.springframework.beans.factory.annotation.*;
-import org.springframework.http.*;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.LinkedMultiValueMap;
 
 /**
  *
@@ -268,14 +263,11 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
                 //PATIENT_ID is both a sample and a patient attribute
                 sampleAttributeMap.put(attribute, meta);
                 patientAttributeMap.put(attribute, meta);
-                break;
-            }
-            if (meta.getAttributeType().equals("SAMPLE")) {
+                continue;
+            } else if (meta.getAttributeType().equals("SAMPLE")) {
                 sampleAttributeMap.put(attribute, meta);
-                break;
             } else {
                 patientAttributeMap.put(attribute, meta);
-                break;
             }
         }
         sampleHeader = makeHeader(sampleAttributeMap);

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepository.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepository.java
@@ -33,23 +33,12 @@
 package org.mskcc.cmo.ks.redcap.source.internal;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.*;
-import java.net.*;
 import java.util.*;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
-import org.mskcc.cmo.ks.redcap.models.ProjectInfoResponse;
 import org.mskcc.cmo.ks.redcap.models.RedcapAttributeMetadata;
 import org.mskcc.cmo.ks.redcap.models.RedcapProjectAttribute;
-import org.mskcc.cmo.ks.redcap.models.RedcapToken;
-import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
 import org.springframework.beans.factory.annotation.*;
-import org.springframework.http.*;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.web.client.RestTemplate;
 
 @Repository
 public class RedcapRepository {
@@ -63,7 +52,15 @@ public class RedcapRepository {
     private final Logger log = Logger.getLogger(RedcapRepository.class);
 
     public List<RedcapProjectAttribute> getAttributesByToken(String projectToken) {
-        return Arrays.asList(redcapSessionManager.getRedcapAttribteByToken(projectToken));
+        RedcapProjectAttribute[] redcapAttributeByToken = redcapSessionManager.getRedcapAttributeByToken(projectToken);
+        List<RedcapProjectAttribute> redcapProjectAttributeList = new ArrayList<>(redcapAttributeByToken.length);
+        String redcapInstrumentCompleteFieldName = redcapSessionManager.getRedcapInstrumentNameByToken(projectToken) + "_complete";
+        for (RedcapProjectAttribute redcapProjectAttribute : redcapAttributeByToken) {
+            if (!redcapInstrumentCompleteFieldName.equals(redcapProjectAttribute.getFieldName())) {
+                redcapProjectAttributeList.add(redcapProjectAttribute);
+            }
+        }
+        return redcapProjectAttributeList;
     }
 
     public List<Map<String, String>> getRedcapDataForProject(String projectToken) {

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapSessionManager.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapSessionManager.java
@@ -429,7 +429,7 @@ public class RedcapSessionManager {
     }
 
     public String getRedcapInstrumentNameByToken(String projectToken) {
-        RedcapProjectAttribute[] attributeArray = getRedcapAttribteByToken(projectToken);
+        RedcapProjectAttribute[] attributeArray = getRedcapAttributeByToken(projectToken);
         if (attributeArray == null || attributeArray.length < 1) {
             String errorMessage = "Error retrieving instrument name from project : no attributes available";
             log.error(errorMessage);
@@ -438,7 +438,7 @@ public class RedcapSessionManager {
         return attributeArray[0].getFormName();
     }
 
-    public RedcapProjectAttribute[] getRedcapAttribteByToken(String projectToken) {
+    public RedcapProjectAttribute[] getRedcapAttributeByToken(String projectToken) {
         LinkedMultiValueMap<String, String> uriVariables = new LinkedMultiValueMap<>();
         uriVariables.add("token", projectToken);
         uriVariables.add("content", "metadata");

--- a/redcap/redcap_source/src/test/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceTest.java
+++ b/redcap/redcap_source/src/test/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.redcap.source.internal;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.Test;
+import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
+import org.mskcc.cmo.ks.redcap.source.internal.RedcapSourceTestConfiguration;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes=RedcapSourceTestConfiguration.class)
+public class ClinicalDataSourceTest {
+
+    @Autowired
+    private ClinicalDataSource clinicalDataSource;
+
+    /* This test mocks the RedcapSessionManager to add a simple project with fields {SAMPLE_ID, PATIENT_ID, NECROSIS, ETHNICITY}
+     * NECROSIS is a sample attribute, ETHNICITY is a patient attribute. (See org.mskcc.cmo.ks.redcap.source.internal.RedcapSourceTestConfiguration)
+     * Also mocked is appropriate metadata for all these fields and the token-finding services.
+     * This test expects proper separation of the sample and patient headers and output of:
+     * Sample headers = ["SAMPLE_ID", "PATIENT_ID", "NECROSIS"]
+     * The same mock and setup is used in testGetPatientHeader()
+     */
+    @Test
+    public void testGetSampleHeader() {
+        if (clinicalDataSource == null) {
+            Assert.fail("clinicalDataSource was not initialized properly for testing");
+        }
+        clinicalDataSource.getNextClinicalProjectTitle(RedcapSourceTestConfiguration.SIMPLE_MIXED_TYPE_CLINICAL_STABLE_ID);
+        List<String> dataReturned = clinicalDataSource.getSampleHeader(RedcapSourceTestConfiguration.SIMPLE_MIXED_TYPE_CLINICAL_STABLE_ID);
+        String[] expectedReturnValueArray = { "SAMPLE_ID", "PATIENT_ID", "NECROSIS" };
+        Set<String> expectedReturnValueSet = new HashSet<>(Arrays.asList(expectedReturnValueArray));
+        String differenceBetweenReturnedAndExpected = getDifferenceBetweenReturnedAndExpected(dataReturned, expectedReturnValueSet);
+        if (differenceBetweenReturnedAndExpected != null && differenceBetweenReturnedAndExpected.length() > 0) {
+            Assert.fail("difference between returned and expected values: " + differenceBetweenReturnedAndExpected);
+        }
+    }
+
+    /* This test mocks the RedcapSessionManager to add a simple project with fields {SAMPLE_ID, PATIENT_ID, NECROSIS, ETHNICITY}
+     * NECROSIS is a sample attribute, ETHNICITY is a patient attribute. (See org.mskcc.cmo.ks.redcap.source.internal.RedcapSourceTestConfiguration)
+     * Also mocked is appropriate metadata for all these fields and the token-finding services.
+     * This test expects proper separation of the sample and patient headers and output of:
+     * Patient headers = ["PATIENT_ID", "ETHNICITY"]
+     */
+    @Test
+    public void testGetPatientHeader() {
+        if (clinicalDataSource == null) {
+            Assert.fail("clinicalDataSource was not initialized properly for testing");
+        }
+        clinicalDataSource.getNextClinicalProjectTitle(RedcapSourceTestConfiguration.SIMPLE_MIXED_TYPE_CLINICAL_STABLE_ID);
+        List<String> dataReturned = clinicalDataSource.getPatientHeader(RedcapSourceTestConfiguration.SIMPLE_MIXED_TYPE_CLINICAL_STABLE_ID);
+        String[] expectedReturnValueArray = { "PATIENT_ID", "ETHNICITY" };
+        Set<String> expectedReturnValueSet = new HashSet<>(Arrays.asList(expectedReturnValueArray));
+        String differenceBetweenReturnedAndExpected = getDifferenceBetweenReturnedAndExpected(dataReturned, expectedReturnValueSet);
+        if (differenceBetweenReturnedAndExpected != null && differenceBetweenReturnedAndExpected.length() > 0) {
+            Assert.fail("difference between returned and expected values: " + differenceBetweenReturnedAndExpected);
+        }
+    }
+
+    private String getDifferenceBetweenReturnedAndExpected(List<String> dataReturnedList, Set<String> expectedReturnValueSet) {
+        if (dataReturnedList == null) {
+            return "Data returned was null";
+        }
+        if (expectedReturnValueSet == null) {
+            return "Expected return value was null";
+        }
+        Set<String> dataReturnedSet = new HashSet<>(dataReturnedList);
+        if (dataReturnedSet.size() != expectedReturnValueSet.size()) {
+            return "Different number of records returned (" + Integer.toString(dataReturnedSet.size()) + ") versus expected (" + Integer.toString(expectedReturnValueSet.size()) + ")";
+        }
+        StringBuilder result = new StringBuilder();
+        for (String dataReturnedItem : dataReturnedSet) {
+            if (!expectedReturnValueSet.contains(dataReturnedItem)) {
+                result.append("Header field '" + dataReturnedItem + "' returned but expected value set does not contain that field name");
+            }
+        }
+        return result.toString();
+    }
+
+}

--- a/redcap/redcap_source/src/test/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepositoryTest.java
+++ b/redcap/redcap_source/src/test/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepositoryTest.java
@@ -32,31 +32,13 @@
 
 package org.mskcc.cmo.ks.redcap.source.internal;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.*;
-import java.net.*;
 import java.util.*;
-import org.apache.commons.text.StringEscapeUtils;
-import org.apache.log4j.Logger;
-//import org.junit.AfterClass;
-//import org.junit.BeforeClass;
-//import org.junit.runners.JUnit4;
 import org.junit.runner.RunWith;
 import org.junit.Test;
-import org.mockito.Mockito;
-import org.mskcc.cmo.ks.redcap.models.RedcapAttributeMetadata;
-import org.mskcc.cmo.ks.redcap.models.RedcapProjectAttribute;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.mskcc.cmo.ks.redcap.source.internal.RedcapSourceTestConfiguration;
 import org.mskcc.cmo.ks.redcap.source.internal.RedcapRepository;
 import org.springframework.beans.factory.annotation.*;
-import org.springframework.http.*;
-import org.springframework.stereotype.Repository;
-import org.springframework.util.LinkedMultiValueMap;
 import org.junit.Assert;
-import static org.mockito.Mockito.*;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -67,12 +49,16 @@ public class RedcapRepositoryTest {
     @Autowired
     private RedcapRepository redcapRepository;
 
+    /* This test mocks the RedcapSessionManager to add a project with fields {"PATIENT_ID", "CRDB_CONSENT_DATE_DAYS", "12_245_PARTA_CONSENTED"}.
+     * getRedcapDataForProject() is called to test whether the mocked data is returned for all fields, including fields which begin with a digit
+     * The proper resolution of redcap_id to EXTERNAL_COLUMN_HEADER should happen within this method.
+     */
     @Test
     public void testGetDataForRedcapProjectID() {
         if (redcapRepository == null) {
             Assert.fail("redcapRepository was not initialized properly for testing");
         }
-        List<Map<String, String>> dataReturned = redcapRepository.getRedcapDataForProject(RedcapSourceTestConfiguration.ONE_DIGIT_PROJECT_ID_TOKEN);
+        List<Map<String, String>> dataReturned = redcapRepository.getRedcapDataForProject(RedcapSourceTestConfiguration.ONE_DIGIT_PROJECT_TOKEN);
         List<Map<String, String>> expectedReturnValue = createExpectedReturnExportFromRedcapOneNumericAttributeName();
         String differenceBetweenReturnedAndExpected = getDifferenceBetweenReturnedAndExpected(dataReturned, expectedReturnValue);
         if (differenceBetweenReturnedAndExpected != null && differenceBetweenReturnedAndExpected.length() > 0) {


### PR DESCRIPTION
Unit tests added for ClinicalDataSource.getPatientHeader() and ClinicalDataSource.getSampleHeader()
- tests based on mock redcap project with two sample attributes and two patient attributes
Bug fix for error where loop which separated patient from sample attributes terminated prematurely.
