### PR TITLE
Disable cvr pipeline json mode

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
@@ -168,6 +168,11 @@ public class CVRPipeline {
         Options options = CVRPipeline.getOptions(args);
         CommandLineParser parser = new DefaultParser();
         CommandLine commandLine = parser.parse(options, args);
+        if (commandLine.hasOption("j")) {
+            String error_message = "The --json argument is not currently functioning correctly (data_clinical.txt is not propeprly updated with clinical information from cvr_data.json)";
+            log.error(error_message);
+            throw new UnsupportedOperationException(error_message);
+        }
         if (commandLine.hasOption("h") ||
                 ((!commandLine.hasOption("d") || !commandLine.hasOption("i")) && !commandLine.hasOption("c"))) {
             help(options, 0);


### PR DESCRIPTION
the cvr pipeline currently fails to update data_clinical.txt when run in .json mode
(because the sample to patient mapping is created during the skipped dmp pipeline read)
- send explanation of problem to log and exit with exception