### PR TITLE
Script to add metadata headers to clinical files 

### DIFF
--- a/import-scripts/add_clinical_attribute_metadata_headers.py
+++ b/import-scripts/add_clinical_attribute_metadata_headers.py
@@ -138,7 +138,7 @@ def get_clinical_attribute_metadata_map(google_spreadsheet, client, header):
                 'PRIORITY' : priority}
     return metadata_mapping
 # ------------------------------------------------------------------------------
-def write_headers(header, metadata_dictionary, output_file, is_new_format):
+def write_headers(header, metadata_dictionary, output_file, is_mixed_attribute_types_format):
     name_line = []
     description_line = []
     datatype_line = []
@@ -162,7 +162,7 @@ def write_headers(header, metadata_dictionary, output_file, is_new_format):
     write_header_line(description_line, output_file)
     write_header_line(datatype_line, output_file)
     # if patient and sample attributes are in file, print attribute type metadata header
-    if len(set(attribute_type_line)) > 0 and not is_new_format:
+    if len(set(attribute_type_line)) > 0 and is_mixed_attribute_types_format:
         write_header_line(attribute_type_line, output_file)
     write_header_line(priority_line, output_file)
 # -----------------------------------------------------------------------------
@@ -172,10 +172,10 @@ def main():
     parser.add_argument("-c", "--creds-file", help = "credentials file", required = True)
     parser.add_argument("-p", "--properties-file", help = "properties file", required = True)
     parser.add_argument("-f", "--files", nargs = "+", help = "file(s) to add metadata headers", required = True)
-    parser.add_argument("-n", "--new-format", help = "flag for whether file is new/old format -- whether patient/sample attributes are seperated", action = "store_true")
+    parser.add_argument("-m", "--mixed-attribute-types", help = "flag for whether file is new/old format -- whether patient/sample attributes are seperated", action = "store_true")
     args = parser.parse_args()
 
-    is_new_format = args.new_format
+    is_mixed_attribute_types_format = args.mixed_attribute_types
     secrets_filename = args.secrets_file
     creds_filename = args.creds_file
     properties_filename = args.properties_file
@@ -219,7 +219,7 @@ def main():
         # create temp file to write to
         temp_file, temp_file_name = tempfile.mkstemp()
         header = get_header(clinical_file)
-        write_headers(header, metadata_dictionary, temp_file, is_new_format)
+        write_headers(header, metadata_dictionary, temp_file, is_mixed_attribute_types_format)
         write_data(clinical_file, temp_file)
         os.close(temp_file)
         # replace original file with new file

--- a/import-scripts/clinicalfile_utils.py
+++ b/import-scripts/clinicalfile_utils.py
@@ -3,12 +3,12 @@ import linecache
 
 # returns header as list of attributes
 def get_header(file):
-    header_source = open(file, "r")
-    for line in header_source:
-        if not line.startswith("#"):
-            header = line.rstrip().split('\t')
-            break
-    header_source.close()
+    header = []
+    with open(file, "r") as header_source:
+        for line in header_source:
+            if not line.startswith("#"):
+                header = line.rstrip().split('\t')
+                break
     return header
 
 # old format is defined as a file containing 5 header lines (PATIENT and SAMPLE attributes in same file)

--- a/import-scripts/set_custom_priorities.py
+++ b/import-scripts/set_custom_priorities.py
@@ -23,8 +23,16 @@ def createCBCustomPrioritiesMap():
         "DFS_STATUS" : "0",
         "OS_MONTHS" : "0",
         "OS_STATUS" : "9",
-        "SEX" : "69",
         "SAMPLE_TYPE" : "9"
+    }
+    return custom_priorities_map
+
+def createDefaultMskimpactPrioritiesMap():
+    custom_priorities_map = {
+        "12_245_PARTC_CONSENTED" : "1",
+        "OS_STATUS" : "1",
+        "SAMPLE_TYPE" : "1",
+        "SEX" : "1",
     }
     return custom_priorities_map
 
@@ -95,11 +103,12 @@ def createMelCell2016CustomPrioritiesMap():
 
 def initialize_custom_priority_maps():
     custom_priorities_map = {
-        'mskimpact' : createCBCustomPrioritiesMap(),
+        'mskimpact' : createDefaultMskimpactPrioritiesMap(),
+        'mel_cell_2016' : createMelCell2016CustomPrioritiesMap(),
         'mixedpact' : createCBCustomPrioritiesMap(),
+        #'mskimpact' : createCBCustomPrioritiesMap(),
         'skcm_mskcc_2014' : createSKCMCustomPrioritiesMap(),
-        'skcm_mskcc_2015' : createSKCMCustomPrioritiesMap(),
-        'mel_cell_2016' : createMelCell2016CustomPrioritiesMap()
+        'skcm_mskcc_2015' : createSKCMCustomPrioritiesMap()
     }
     return custom_priorities_map
 #-------------------------------------------------------------
@@ -152,14 +161,18 @@ def main():
     if len(missing_metadata_header_files) > 0:
         print >> ERROR_FILE, 'File(s) incorrectly formatted (missing metadata headers): ' + ', '.join(missing_metadata_header_files)
         sys.exit(2)
+    missing_column_header_files = [clinical_file for clinical_file in clinical_files if len(get_header(clinical_file)) == 0]
+    if len(missing_column_header_files) > 0:
+        print >> ERROR_FILE, 'File(s) incorrectly formatted (missing column headers): ' + ', '.join(missing_column_header_files)
+        sys.exit(2)
     for clinical_file in clinical_files:
         header = get_header(clinical_file)
         #get existing priority mappings - replace with provided overrides
         priority_mapping = get_priority_mapping(clinical_file)
         if reset:
             reset_priorities(priority_mapping)
-        for attribute, priority in priority_mapping.items():
-            if attribute in custom_map.keys():
+        for attribute in custom_map:
+            if attribute in priority_mapping.keys():
                 priority_mapping[attribute] = custom_map[attribute]
         # create and write to temp file
         temp_file, temp_file_name = tempfile.mkstemp()


### PR DESCRIPTION
**add_clinical_attribute_metadata_headers.py**
metadata is taken from google spreadsheets
authorization/spreadsheet information must be provided through properties file
makes changes in a temp file, which replaces original file at the end
based off of importUsers.py

**add_custom_priorities.py**
seperate script to add predefined custom metadata overrides
only supports overwriting priority metadata
metadata override set chosen through command-line argument (study-id)
script adds overrides to existing metadata headers, headers must be present in input file