### PR TITLE
Adjust RedCap overwrite function for erasing project data

### DIFF
--- a/redcap/redcap_pipeline/src/main/resources/application.properties.EXAMPLE
+++ b/redcap/redcap_pipeline/src/main/resources/application.properties.EXAMPLE
@@ -4,8 +4,12 @@ chunk=10
 # Absoulte URL to the redcap web application
 redcap_base_url=
 redcap_api_url_path=
-# Relative URL path to the erase_project_data php module
+# Relative URL path to the erase_project_data php module and project setup page.
 redcap_erase_project_data_url_path=
+redcap_project_setup_url_path=
+# If http method is POST (redcap_v7), a token is first obtained from project setup page, when GET (redcap_v6) the request goes only to the erase data module
+redcap_erase_project_data_http_method=POST
+# Superuser login is needed to get a session id to set cookie headers for the request to erase project data to succeed
 redcap_username=
 redcap_password=
 redcap_login_hidden_input_name=


### PR DESCRIPTION
This was jointly developed by @mandawilson and @sheridancbio
- redcap v7.4.22 uses POST requests (was previously GET request) for erasing project data
- now use POST request to erase project data : this requires scanning a page for a CSFR token