### PR TITLE
added check to compare headers in redcap project and imported file

### DIFF
--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ImportRedcapProjectDataTasklet.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ImportRedcapProjectDataTasklet.java
@@ -62,7 +62,11 @@ public class ImportRedcapProjectDataTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        clinicalDataSource.importClinicalDataFile(redcapProjectTitle, filename, overwriteProjectData);
+        try {
+            clinicalDataSource.importClinicalDataFile(redcapProjectTitle, filename, overwriteProjectData);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
         return RepeatStatus.FINISHED;
     }
 

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineReader.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineReader.java
@@ -66,7 +66,10 @@ public class TimelineReader implements ItemStreamReader<Map<String, String>> {
 
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
-        boolean writeTimelineData = clinicalDataSource.hasMoreTimelineData(stableId);        
+        boolean writeTimelineData = true;
+        if (redcapProjectTitle == null) {
+            writeTimelineData = clinicalDataSource.hasMoreTimelineData(stableId);
+        }
         if (writeTimelineData) {
             String projectTitle = (redcapProjectTitle == null) ? clinicalDataSource.getNextTimelineProjectTitle(stableId) : redcapProjectTitle;
             log.info("Getting timeline header for project: " + projectTitle);

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/ClinicalDataSource.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/ClinicalDataSource.java
@@ -41,7 +41,7 @@ import java.util.*;
 public interface ClinicalDataSource {
     boolean projectExists(String projectTitle);
     boolean redcapDataTypeIsTimeline(String projectTitle);
-    void importClinicalDataFile(String projectTitle, String filename, boolean overwriteProjectData);
+    void importClinicalDataFile(String projectTitle, String filename, boolean overwriteProjectData) throws Exception;
     List<String> getProjectHeader(String projectTitle);
     List<Map<String, String>> exportRawDataForProjectTitle(String projectTitle);
 


### PR DESCRIPTION
check happens during import call - failed check stops import
    checks that number of attributes in header is equal
    checks that attributes in header are the same (based on redcap id)
    special exception: record_id and my_first_instrument ignored in project

rearranged checks/calls so that project deletion happens at the end
    if any check fails, project will not be deleted

TimelineReader fixed so that single timeline projects can be exported in raw mode
writeTimelineData originally defaulted to false (because check was based on stable id)
writeTimelineData now defaulted as true so code is called for single projects
If no project title is provided (stable id is present), same check as before is used