### PR TITLE
Darwin and REDCap pipeline bug fix for study skcm_mskcc_2015_chant

### DIFF
--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/BatchConfiguration.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/BatchConfiguration.java
@@ -60,6 +60,7 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
  */
 @Configuration
 @EnableBatchProcessing
+@ComponentScan(basePackages="org.mskcc.cmo.ks.redcap.source.internal")
 public class BatchConfiguration {
 
     public static final String MSKIMPACT_JOB = "mskimpactJob";

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceRedcapImpl.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceRedcapImpl.java
@@ -69,8 +69,8 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
     private List<String> sampleHeader;
     private List<String> patientHeader;
     private List<String> combinedHeader;
-    private Map<String, List<String>> fullPatientHeader = null;
-    private Map<String, List<String>> fullSampleHeader = null;
+    private Map<String, List<String>> fullPatientHeader = new HashMap<>();
+    private Map<String, List<String>> fullSampleHeader = new HashMap<>();
     private String nextClinicalId;
     private String nextTimelineId;
 


### PR DESCRIPTION
- Darwin pipeline could not resolve MetadataManager bean since BatchConfiguration was missing the component scan configuration.
- Bug fix in REDCap ClinicalDataSourceRedcapImpl prevents NPE from being thrown when full patient header or full sample header are populated.