### PR TITLE
Check REDCap pipeline job execution exit status

### DIFF
--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/RedcapPipeline.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/RedcapPipeline.java
@@ -149,7 +149,11 @@ public class RedcapPipeline {
         }
         if (redcapJob != null) {
             JobExecution jobExecution = jobLauncher.run(redcapJob, builder.toJobParameters());
-        }
+            if (!jobExecution.getExitStatus().equals(ExitStatus.COMPLETED)) {
+                log.error("RedcapPipeline job failed with exit status: " + jobExecution.getExitStatus());
+                System.exit(1);
+            }
+        }        
     }
 
     public static char parseModeFromOptions(CommandLine commandLine)


### PR DESCRIPTION
If an import job fails w/an uncaught/unthrown exception then the pipeline will have an exit status `FAILED` but the exit code returned is still zero. This fix checks the job execution exit status and if it's not `COMPLETED`, meaning successful, then it will exit with a non-zero code

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>