### PR TITLE
catch google worksheet service error when adding metadata headers

### DIFF
--- a/import-scripts/add_clinical_attribute_metadata_headers.py
+++ b/import-scripts/add_clinical_attribute_metadata_headers.py
@@ -212,7 +212,11 @@ def main():
     # get a set of attributes used across all input files
     for clinical_file in clinical_files:
         all_attributes = all_attributes.union(get_header(clinical_file))
-    metadata_dictionary = get_clinical_attribute_metadata_map(portal_properties.google_spreadsheet, client, all_attributes)
+    try:
+        metadata_dictionary = get_clinical_attribute_metadata_map(portal_properties.google_spreadsheet, client, all_attributes)
+    except gdata.service.RequestError:
+        print >> ERROR_FILE, 'Unable to construct metadata_dictionary, metadata headers will not be added. Could not access google sheet.'
+        sys.exit(2)
     # check metadata is defined for all attributes in google spreadsheet
     if len(metadata_dictionary.keys()) != len(all_attributes):
         print >> ERROR_FILE, 'Error, metadata not found for attribute(s): ' + ', '.join(all_attributes.difference(metadata_dictionary.keys()))

--- a/import-scripts/import-dmp-impact-data.sh
+++ b/import-scripts/import-dmp-impact-data.sh
@@ -321,15 +321,25 @@ MSK_LEHIGH_SUBSET_FAIL=0
 MSK_MCI_SUBSET_FAIL=0
 MSK_HARTFORD_SUBSET_FAIL=0
 SCLC_MSKIMPACT_SUBSET_FAIL=0
+LYMPHOMA_SUPER_COHORT_SUBSET_FAIL=0
+
+MIXEDPACT_ADD_HEADER_FAIL=0
+MSK_KINGS_ADD_HEADER_FAIL=0
+MSK_QUEENS_ADD_HEADER_FAIL=0
+MSK_LEHIGH_ADD_HEADER_FAIL=0
+MSK_MCI_ADD_HEADER_FAIL=0
+MSK_HARTFORD_ADD_HEADER_FAIL=0
+SCLC_MSKIMPACT_ADD_HEADER_FAIL=0
+LYMPHOMA_SUPER_COHORT_ADD_HEADER_FAIL=0
+
 IMPORT_FAIL_MIXEDPACT=0
 IMPORT_FAIL_KINGS=0
 IMPORT_FAIL_LEHIGH=0
 IMPORT_FAIL_QUEENS=0
 IMPORT_FAIL_MCI=0
 IMPORT_FAIL_HARTFORD=0
-IMPORT_FAIL_LYMPHOMA=0
 IMPORT_FAIL_SCLC_MSKIMPACT=0
-LYMPHOMA_SUPER_COHORT_SUBSET_FAIL=0
+IMPORT_FAIL_LYMPHOMA=0
 GENERATE_MASTERLIST_FAIL=0
 
 # export data_clinical and data_clinical_supp_date for each project from redcap (starting point)
@@ -957,7 +967,12 @@ else
     echo $(date)
     # add metadata headers and overrides before importing
     $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s $PORTAL_DATA_HOME/portal-configuration/google-docs/client_secrets.json -c $PORTAL_DATA_HOME/portal-configuration/google-docs/creds.dat -p $PORTAL_DATA_HOME/portal-configuration/properties/clinical-metadata/metadata.google.properties -f $MSK_MIXEDPACT_DATA_HOME/data_clinical*
-    $PYTHON_BINARY $PORTAL_HOME/scripts/set_custom_overrides.py -s mixedpact -f $MSK_MIXEDPACT_DATA_HOME/data_clinical*
+    if [ $? -gt 0 ] ; then
+        MIXEDPACT_ADD_HEADER_FAIL=1
+        echo "Something went wrong while adding metadata headers for MIXEDPACT."
+    else
+        $PYTHON_BINARY $PORTAL_HOME/scripts/set_custom_overrides.py -s mixedpact -f $MSK_MIXEDPACT_DATA_HOME/data_clinical*
+    fi
     addCancerTypeCaseLists $MSK_MIXEDPACT_DATA_HOME "mixedpact" "data_clinical_sample.txt" "data_clinical_patient.txt"
 fi
 
@@ -970,8 +985,8 @@ if [ $(wc -l < $MSK_HEMEPACT_DATA_HOME/meta_SV.txt) -eq 0 ] ; then
     rm $MSK_HEMEPACT_DATA_HOME/meta_SV.txt
 fi
 
-# update MIXEDPACT in portal only if merge and case list updates were succesful
-if [ $MIXEDPACT_MERGE_FAIL -eq 0 ] ; then
+# update MIXEDPACT in portal only if merge and case list updates were succesful and metadata headers were added
+if [ $MIXEDPACT_MERGE_FAIL -eq 0 ] && [ $MIXEDPACT_ADD_HEADER_FAIL -eq 0 ] ; then
     echo "Importing MIXEDPACT study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mixedpact" --temp-study-id="temporary_mixedpact" --backup-study-id="yesterday_mixedpact" --portal-name="mixedpact-portal" --study-path="$MSK_MIXEDPACT_DATA_HOME" --notification-file="$mixedpact_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1023,6 +1038,10 @@ else
     addCancerTypeCaseLists $MSK_KINGS_DATA_HOME "msk_kingscounty" "data_clinical_sample.txt" "data_clinical_patient.txt"
     # add metadata headers before importing
     $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s $PORTAL_DATA_HOME/portal-configuration/google-docs/client_secrets.json -c $PORTAL_DATA_HOME/portal-configuration/google-docs/creds.dat -p $PORTAL_DATA_HOME/portal-configuration/properties/clinical-metadata/metadata.google.properties -f $MSK_KINGS_DATA_HOME/data_clinical*
+    if [ $? -gt 0 ] ; then
+        MSK_KINGS_ADD_HEADER_FAIL=1
+        echo "Something went wrong while adding metadata headers for KINGSCOUNTY."
+    fi
 fi
 
 bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_lehighvalley -o=$MSK_LEHIGH_DATA_HOME -m=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Lehigh Valley Health Network" -s=$JAVA_TMPDIR/lehigh_subset.txt -c=data_clinical_sample.txt
@@ -1035,6 +1054,10 @@ else
     addCancerTypeCaseLists $MSK_LEHIGH_DATA_HOME "msk_lehighvalley" "data_clinical_sample.txt" "data_clinical_patient.txt"
     # add metadata headers before importing
     $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s $PORTAL_DATA_HOME/portal-configuration/google-docs/client_secrets.json -c $PORTAL_DATA_HOME/portal-configuration/google-docs/creds.dat -p $PORTAL_DATA_HOME/portal-configuration/properties/clinical-metadata/metadata.google.properties -f $MSK_LEHIGH_DATA_HOME/data_clinical*
+    if [ $? -gt 0 ] ; then
+        MSK_LEHIGH_ADD_HEADER_FAIL=1
+        echo "Something went wrong while adding metadata headers for LEHIGHVALLEY."
+    fi
 fi
 
 bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_queenscancercenter -o=$MSK_QUEENS_DATA_HOME -m=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Queens Cancer Center,Queens Hospital Cancer Center" -s=$JAVA_TMPDIR/queens_subset.txt -c=data_clinical_sample.txt
@@ -1047,6 +1070,10 @@ else
     addCancerTypeCaseLists $MSK_QUEENS_DATA_HOME "msk_queenscancercenter" "data_clinical_sample.txt" "data_clinical_patient.txt"
     # add metadata headers before importing
     $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s $PORTAL_DATA_HOME/portal-configuration/google-docs/client_secrets.json -c $PORTAL_DATA_HOME/portal-configuration/google-docs/creds.dat -p $PORTAL_DATA_HOME/portal-configuration/properties/clinical-metadata/metadata.google.properties -f $MSK_QUEENS_DATA_HOME/data_clinical*
+    if [ $? -gt 0 ] ; then
+        MSK_QUEENS_ADD_HEADER_FAIL=1
+        echo "Something went wrong while adding metadata headers for QUEENSCANCERCENTER."
+    fi
 fi
 
 bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_miamicancerinstitute -o=$MSK_MCI_DATA_HOME -m=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Miami Cancer Institute" -s=$JAVA_TMPDIR/mci_subset.txt -c=data_clinical_sample.txt
@@ -1059,6 +1086,10 @@ else
     addCancerTypeCaseLists $MSK_MCI_DATA_HOME "msk_miamicancerinstitute" "data_clinical_sample.txt" "data_clinical_patient.txt"
     # add metadata headers before importing
     $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s $PORTAL_DATA_HOME/portal-configuration/google-docs/client_secrets.json -c $PORTAL_DATA_HOME/portal-configuration/google-docs/creds.dat -p $PORTAL_DATA_HOME/portal-configuration/properties/clinical-metadata/metadata.google.properties -f $MSK_MCI_DATA_HOME/data_clinical*
+    if [ $? -gt 0 ] ; then
+        MSK_MCI_ADD_HEADER_FAIL=1
+        echo "Something went wrong while adding metadata headers for MIAMICANCERINSTITUTE."
+    fi
 fi
 
 bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_hartfordhealthcare -o=$MSK_HARTFORD_DATA_HOME -m=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Hartford Healthcare" -s=$JAVA_TMPDIR/hartford_subset.txt -c=data_clinical_sample.txt
@@ -1071,12 +1102,16 @@ else
     addCancerTypeCaseLists $MSK_HARTFORD_DATA_HOME "msk_hartfordhealthcare" "data_clinical_sample.txt" "data_clinical_patient.txt"
     # add metadata headers before importing
     $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s $PORTAL_DATA_HOME/portal-configuration/google-docs/client_secrets.json -c $PORTAL_DATA_HOME/portal-configuration/google-docs/creds.dat -p $PORTAL_DATA_HOME/portal-configuration/properties/clinical-metadata/metadata.google.properties -f $MSK_HARTFORD_DATA_HOME/data_clinical*
+    if [ $? -gt 0 ] ; then
+        MSK_HARTFORD_ADD_HEADER_FAIL=1
+        echo "Something went wrong while adding metadata headers for HARTFORDHEALTHCARE."
+    fi
 fi
 
 # set 'RESTART_AFTER_MSK_AFFILIATE_IMPORT' flag to 1 if Kings County, Lehigh Valley, Queens Cancer Center, Miami Cancer Institute, or Lymphoma super cohort succesfully update
 RESTART_AFTER_MSK_AFFILIATE_IMPORT=0
-# update msk_kingscounty in portal only if subset was successful
-if [ $MSK_KINGS_SUBSET_FAIL -eq 0 ] ; then
+# update msk_kingscounty in portal only if subset was successful and metadata headers were added
+if [ $MSK_KINGS_SUBSET_FAIL -eq 0 ] && [ $MSK_KINGS_ADD_HEADER_FAIL -eq 0 ] ; then
     echo "Importing msk_kingscounty study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_kingscounty" --temp-study-id="temporary_msk_kingscounty" --backup-study-id="yesterday_msk_kingscounty" --portal-name="msk-kingscounty-portal" --study-path="$MSK_KINGS_DATA_HOME" --notification-file="$kingscounty_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1100,8 +1135,8 @@ else
     cd $MSK_KINGS_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest KINGSCOUNTY dataset"
 fi
 
-# update msk_lehighvalley in portal only if subset was successful
-if [ $MSK_LEHIGH_SUBSET_FAIL -eq 0 ] ; then
+# update msk_lehighvalley in portal only if subset was successful and metadata headers were added
+if [ $MSK_LEHIGH_SUBSET_FAIL -eq 0 ] && [ $MSK_LEHIGH_ADD_HEADER_FAIL -eq 0 ] ; then
     echo "Importing msk_lehighvalley study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_lehighvalley" --temp-study-id="temporary_msk_lehighvalley" --backup-study-id="yesterday_msk_lehighvalley" --portal-name="msk-lehighvalley-portal" --study-path="$MSK_LEHIGH_DATA_HOME" --notification-file="$lehighvalley_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1125,8 +1160,8 @@ else
     cd $MSK_LEHIGH_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest LEHIGHVALLEY dataset"
 fi
 
-# update msk_queenscancercenter in portal only if subset was successful
-if [ $MSK_QUEENS_SUBSET_FAIL -eq 0 ] ; then
+# update msk_queenscancercenter in portal only if subset was successful and metadata headers were added
+if [ $MSK_QUEENS_SUBSET_FAIL -eq 0 ] && [ $MSK_QUEENS_ADD_HEADER_FAIL -eq 0 ] ; then
     echo "Importing msk_queenscancercenter study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_queenscancercenter" --temp-study-id="temporary_msk_queenscancercenter" --backup-study-id="yesterday_msk_queenscancercenter" --portal-name="msk-queenscancercenter-portal" --study-path="$MSK_QUEENS_DATA_HOME" --notification-file="$queenscancercenter_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1150,8 +1185,8 @@ else
     cd $MSK_QUEENS_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest QUEENSCANCERCENTER dataset"
 fi
 
-# update msk_miamicancerinstitute in portal only if subset was successful
-if [ $MSK_MCI_SUBSET_FAIL -eq 0 ] ; then
+# update msk_miamicancerinstitute in portal only if subset was successful and metadata headers were added
+if [ $MSK_MCI_SUBSET_FAIL -eq 0 ] && [ $MSK_MCI_ADD_HEADER_FAIL -eq 0 ] ; then
     echo "Importing msk_miamicancerinstitute study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_miamicancerinstitute" --temp-study-id="temporary_msk_miamicancerinstitute" --backup-study-id="yesterday_msk_miamicancerinstitute" --portal-name="msk-mci-portal" --study-path="$MSK_MCI_DATA_HOME" --notification-file="$miamicancerinstitute_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1175,8 +1210,8 @@ else
     cd $MSK_MCI_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest MIAMICANCERINSTITUTE dataset"
 fi
 
-# update msk_hartfordhealthcare in portal only if subset was successful
-if [ $MSK_HARTFORD_SUBSET_FAIL -eq 0 ] ; then
+# update msk_hartfordhealthcare in portal only if subset was successful and metadata headers were added
+if [ $MSK_HARTFORD_SUBSET_FAIL -eq 0 ] && [ $MSK_HARTFORD_ADD_HEADER_FAIL -eq 0 ] ; then
     echo "Importing msk_hartfordhealthcare study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_hartfordhealthcare" --temp-study-id="temporary_msk_hartfordhealthcare" --backup-study-id="yesterday_msk_hartfordhealthcare" --portal-name="msk-hartford-portal" --study-path="$MSK_HARTFORD_DATA_HOME" --notification-file="$hartfordhealthcare_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1215,10 +1250,14 @@ else
     addCancerTypeCaseLists $MSK_SCLC_DATA_HOME "sclc_mskimpact_2017" "data_clinical_sample.txt" "data_clinical_patient.txt"
     # add metadata headers before importing
     $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s $PORTAL_DATA_HOME/portal-configuration/google-docs/client_secrets.json -c $PORTAL_DATA_HOME/portal-configuration/google-docs/creds.dat -p $PORTAL_DATA_HOME/portal-configuration/properties/clinical-metadata/metadata.google.properties -f $MSK_SCLC_DATA_HOME/data_clinical*
+    if [ $? -gt 0 ] ; then
+        SCLC_MSKIMPACT_ADD_HEADER_FAIL=1
+        echo "Something went wrong while adding metadata headers for MSKIMPACT SCLC."
+    fi
 fi
 
-# update sclc_mskimpact_2017 in portal only if subset was successful
-if [ $SCLC_MSKIMPACT_SUBSET_FAIL -eq 0 ] ; then
+# update sclc_mskimpact_2017 in portal only if subset was successful and metadata headers were added
+if [ $SCLC_MSKIMPACT_SUBSET_FAIL -eq 0 ] && [ $SCLC_MSKIMPACT_ADD_HEADER_FAIL -eq 0 ] ; then
     echo "Importing sclc_mskimpact_2017 study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="sclc_mskimpact_2017" --temp-study-id="temporary_sclc_mskimpact_2017" --backup-study-id="yesterday_sclc_mskimpact_2017" --portal-name="msk-sclc-portal" --study-path="$MSK_SCLC_DATA_HOME" --notification-file="$sclc_mskimpact_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1302,6 +1341,13 @@ if [ $LYMPHOMA_SUPER_COHORT_SUBSET_FAIL -eq 0 ] ; then
         echo "Lymphoma super cohort subset failed! Lymphoma super cohort study will not be updated in the portal."
         sendFailureMessageMskPipelineLogsSlack "LYMPHOMASUPERCOHORT merge"
         LYMPHOMA_SUPER_COHORT_SUBSET_FAIL=1
+    else
+        # add metadata headers before importing
+        $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s $PORTAL_DATA_HOME/portal-configuration/google-docs/client_secrets.json -c $PORTAL_DATA_HOME/portal-configuration/google-docs/creds.dat -p $PORTAL_DATA_HOME/portal-configuration/properties/clinical-metadata/metadata.google.properties -f $LYMPHOMA_SUPER_COHORT_DATA_HOME/data_clinical*
+        if [ $? -gt 0 ] ; then
+            LYMPHOMA_SUPER_COHORT_ADD_HEADER_FAIL=1
+            echo "Something went wrong while adding metadata headers for LYMPHOMASUPERCOHORT."
+        fi
     fi
     # remove files we don't need for lymphoma super cohort
     rm $LYMPHOMA_SUPER_COHORT_DATA_HOME/*genie*
@@ -1317,10 +1363,8 @@ if [ $(wc -l < $MSK_HEMEPACT_DATA_HOME/meta_SV.txt) -eq 0 ] ; then
     rm $MSK_HEMEPACT_DATA_HOME/meta_SV.txt
 fi
 
-# attempt to import if merge and subset successful
-if [ $LYMPHOMA_SUPER_COHORT_SUBSET_FAIL -eq 0 ] ; then
-    # add metadata headers before importing
-    $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s $PORTAL_DATA_HOME/portal-configuration/google-docs/client_secrets.json -c $PORTAL_DATA_HOME/portal-configuration/google-docs/creds.dat -p $PORTAL_DATA_HOME/portal-configuration/properties/clinical-metadata/metadata.google.properties -f $LYMPHOMA_SUPER_COHORT_DATA_HOME/data_clinical*
+# attempt to import if merge and subset successful and metadata headers were added
+if [ $LYMPHOMA_SUPER_COHORT_SUBSET_FAIL -eq 0 ] && [ $LYMPHOMA_SUPER_COHORT_ADD_HEADER_FAIL -eq 0 ] ; then
     echo "Importing lymphoma 'super' cohort study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="lymphoma_super_cohort_fmi_msk" --temp-study-id="temporary_lymphoma_super_cohort_fmi_msk" --backup-study-id="yesterday_lymphoma_super_cohort_fmi_msk" --portal-name="msk-fmi-lymphoma-portal" --study-path="$LYMPHOMA_SUPER_COHORT_DATA_HOME" --notification-file="$lymphoma_super_cohort_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"


### PR DESCRIPTION
error will cause exit with nonzero exit status
(metadata headers will not be added at all and will be handled with automatic importer behavior)
import-dmp-impact-data.sh script will catch nonzero exit status and add an error message to logs