### PR TITLE
Replace redcap metadata project with google spreadsheet

### DIFF
--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBDatasetWriter.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBDatasetWriter.java
@@ -93,7 +93,7 @@ public class CRDBDatasetWriter implements ItemStreamWriter<String>
                 normColumns.add("CRDB_BASIC_"+col);
             }
             else if (col.equals("PARTA_CONSENTED")) {
-                normColumns.add("12_245_PARTA_CONSENTED");
+                normColumns.add("PARTA_CONSENTED_12_245");
             }
             else {
                 normColumns.add("CRDB_"+col);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/GMLClinicalDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/GMLClinicalDataReader.java
@@ -105,7 +105,7 @@ public class GMLClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
                     
                     for (String id : cvrSampleListUtil.getNewDmpGmlPatients()) {
                         if (id.contains(to_add.getPATIENT_ID())) {
-                            to_add.set12_245_PARTC_CONSENTED("YES");
+                            to_add.setPARTC_CONSENTED_12_245("YES");
                             break;
                         }
                     }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRClinicalRecord.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRClinicalRecord.java
@@ -230,11 +230,11 @@ public class CVRClinicalRecord {
         this.oncotreeCode = oncotreeCode;
     }
 
-    public String get12_245_PARTC_CONSENTED() {
+    public String getPARTC_CONSENTED_12_245() {
         return this.partCConsented != null ? this.partCConsented : "";
     }
 
-    public void set12_245_PARTC_CONSENTED(String partCConsented) {
+    public void setPARTC_CONSENTED_12_245(String partCConsented) {
         this.partCConsented = partCConsented;
     }
 
@@ -329,7 +329,7 @@ public class CVRClinicalRecord {
         fieldNames.add("SAMPLE_COVERAGE");
         fieldNames.add("TUMOR_PURITY");
         fieldNames.add("ONCOTREE_CODE");
-        fieldNames.add("12_245_PARTC_CONSENTED");
+        fieldNames.add("PARTC_CONSENTED_12_245");
         fieldNames.add("MSI_COMMENT");
         fieldNames.add("MSI_SCORE");
         fieldNames.add("MSI_TYPE");

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/DarwinPipeline.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/DarwinPipeline.java
@@ -65,7 +65,7 @@ public class DarwinPipeline {
 
     private static void launchJob(String[] args, String outputDirectory, String studyID) throws Exception{
         SpringApplication app = new SpringApplication(DarwinPipeline.class);
-
+        app.setWebEnvironment(false);
         ConfigurableApplicationContext ctx = app.run(args);
         JobLauncher jobLauncher = ctx.getBean(JobLauncher.class);
 

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/BatchConfiguration.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/BatchConfiguration.java
@@ -152,7 +152,7 @@ public class BatchConfiguration {
     @Bean
     public Step skcm_mskcc_2015_chantClinicalStep() {
         return stepBuilderFactory.get("skcm_mskcc_2015_chantClinicalStep")
-                .<Skcm_mskcc_2015_chantClinicalRecord, String> chunk(chunkSize)
+                .<Skcm_mskcc_2015_chantNormalizedClinicalRecord, String> chunk(chunkSize)
                 .reader(skcm_mskcc_2015_chantClinicalReader())
                 .processor(skcm_mskcc_2015_chantClinicalCompositeProcessor())
                 .writer(skcm_mskcc_2015_chantClinicalCompositeWriter())

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantClinicalCompositeRecord.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantClinicalCompositeRecord.java
@@ -11,20 +11,20 @@ package org.mskcc.cmo.ks.darwin.pipeline.model;
  */
 public class Skcm_mskcc_2015_chantClinicalCompositeRecord {
     
-    private Skcm_mskcc_2015_chantClinicalRecord record;
+    private Skcm_mskcc_2015_chantNormalizedClinicalRecord record;
     private String sampleRecord;
     private String patientRecord;
     
     public Skcm_mskcc_2015_chantClinicalCompositeRecord() {}
-    public Skcm_mskcc_2015_chantClinicalCompositeRecord(Skcm_mskcc_2015_chantClinicalRecord record) {
+    public Skcm_mskcc_2015_chantClinicalCompositeRecord(Skcm_mskcc_2015_chantNormalizedClinicalRecord record) {
         this.record = record;
     }
     
-    public Skcm_mskcc_2015_chantClinicalRecord getRecord() {
+    public Skcm_mskcc_2015_chantNormalizedClinicalRecord getRecord() {
         return this.record;
     }
     
-    public void setRecord(Skcm_mskcc_2015_chantClinicalRecord record) {
+    public void setRecord(Skcm_mskcc_2015_chantNormalizedClinicalRecord record) {
         this.record = record;
     }
     

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantClinicalRecord.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantClinicalRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 - 2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -29,6 +29,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.*;
@@ -40,11 +41,10 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * @author heinsz
  */
 public class Skcm_mskcc_2015_chantClinicalRecord {
-    
     private String patientId;
     private String sampleId;
     private String melspcPtid;
-    private String  melspcStageYear;
+    private String melspcStageYear;
     private String melspcStgGrpName;
     private String melgPtid;
     private String melgStsDesc;
@@ -115,10 +115,10 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     private String melmsSiteDesc;
     private String melmsSiteYear;
     
-    
     private Map<String, Object> additionalProperties;    
     
-    public Skcm_mskcc_2015_chantClinicalRecord() {}
+    public Skcm_mskcc_2015_chantClinicalRecord() {
+    }
     
     public Skcm_mskcc_2015_chantClinicalRecord(String melspcPtid,
             String  melspcStageYear,
@@ -191,95 +191,93 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
             String melmsSiteTypeDesc,
             String melmsSiteDesc,
             String melmsSiteYear) {
-this.melspcPtid = StringUtils.isNotEmpty(melspcPtid) ? melspcPtid : "NA";
-this.melspcStageYear = StringUtils.isNotEmpty(melspcStageYear) ? melspcStageYear : "NA";
-this.melspcStgGrpName = StringUtils.isNotEmpty(melspcStgGrpName) ? melspcStgGrpName : "NA";
-this.melgPtid = StringUtils.isNotEmpty(melgPtid) ? melgPtid : "NA";
-this.melgStsDesc = StringUtils.isNotEmpty(melgStsDesc) ? melgStsDesc : "NA";
-this.melgStsSrcDesc = StringUtils.isNotEmpty(melgStsSrcDesc) ? melgStsSrcDesc : "NA";
-this.melgActvStsDesc = StringUtils.isNotEmpty(melgActvStsDesc) ? melgActvStsDesc : "NA";
-this.melgDermagrphxDesc = StringUtils.isNotEmpty(melgDermagrphxDesc) ? melgDermagrphxDesc : "NA";
-this.melgPresStgYear = StringUtils.isNotEmpty(melgPresStgYear) ? melgPresStgYear : "NA";
-this.melgFamilyHxDesc = StringUtils.isNotEmpty(melgFamilyHxDesc) ? melgFamilyHxDesc : "NA";
-this.melg1stRecurYear = StringUtils.isNotEmpty(melg1stRecurYear) ? melg1stRecurYear : "NA";
-this.melgLocalDesc = StringUtils.isNotEmpty(melgLocalDesc) ? melgLocalDesc : "NA";
-this.melgNodalDesc = StringUtils.isNotEmpty(melgNodalDesc) ? melgNodalDesc : "NA";
-this.melgIntransitDesc = StringUtils.isNotEmpty(melgIntransitDesc) ? melgIntransitDesc : "NA";
-this.melgSysDesc = StringUtils.isNotEmpty(melgSysDesc) ? melgSysDesc : "NA";
-this.melgRecurNdszDesc = StringUtils.isNotEmpty(melgRecurNdszDesc) ? melgRecurNdszDesc : "NA";
-this.melgRecurNodalNo = StringUtils.isNotEmpty(melgRecurNodalNo) ? melgRecurNodalNo : "NA";
-this.melgLdh = StringUtils.isNotEmpty(melgLdh) ? melgLdh : "NA";
-this.melgLdhYear = StringUtils.isNotEmpty(melgLdhYear) ? melgLdhYear : "NA";
-this.melgMetsDesc = StringUtils.isNotEmpty(melgMetsDesc) ? melgMetsDesc : "NA";
-this.melgAdjvntTxDesc = StringUtils.isNotEmpty(melgAdjvntTxDesc) ? melgAdjvntTxDesc : "NA";
-this.melgSysTxDesc = StringUtils.isNotEmpty(melgSysTxDesc) ? melgSysTxDesc : "NA";
-this.melgRadTxDesc = StringUtils.isNotEmpty(melgRadTxDesc) ? melgRadTxDesc : "NA";
-this.melgSurgDesc = StringUtils.isNotEmpty(melgSurgDesc) ? melgSurgDesc : "NA";
-this.melgTissueBankAvail = StringUtils.isNotEmpty(melgTissueBankAvail) ? melgTissueBankAvail : "NA";
-this.melpPtid = StringUtils.isNotEmpty(melpPtid) ? melpPtid : "NA";
-this.melpPrimSeq = StringUtils.isNotEmpty(melpPrimSeq) ? melpPrimSeq : "NA";
-this.melpDxYear = StringUtils.isNotEmpty(melpDxYear) ? melpDxYear : "NA";
-this.melpMskReviewDesc = StringUtils.isNotEmpty(melpMskReviewDesc) ? melpMskReviewDesc : "NA";
-this.melpThicknessMm = StringUtils.isNotEmpty(melpThicknessMm) ? melpThicknessMm : "NA";
-this.melpClarkLvlDesc = StringUtils.isNotEmpty(melpClarkLvlDesc) ? melpClarkLvlDesc : "NA";
-this.melpUlcerationDesc = StringUtils.isNotEmpty(melpUlcerationDesc) ? melpUlcerationDesc : "NA";
-this.melpSiteDesc = StringUtils.isNotEmpty(melpSiteDesc) ? melpSiteDesc : "NA";
-this.melpSubSiteDesc = StringUtils.isNotEmpty(melpSubSiteDesc) ? melpSubSiteDesc : "NA";
-this.melpTilsDesc = StringUtils.isNotEmpty(melpTilsDesc) ? melpTilsDesc : "NA";
-this.melpRegressionDesc = StringUtils.isNotEmpty(melpRegressionDesc) ? melpRegressionDesc : "NA";
-this.melpMarginsDesc = StringUtils.isNotEmpty(melpMarginsDesc) ? melpMarginsDesc : "NA";
-this.melpMitidxUnkDesc = StringUtils.isNotEmpty(melpMitidxUnkDesc) ? melpMitidxUnkDesc : "NA";
-this.melpHistTypeDesc = StringUtils.isNotEmpty(melpHistTypeDesc) ? melpHistTypeDesc : "NA";
-this.melpSatellitesDesc = StringUtils.isNotEmpty(melpSatellitesDesc) ? melpSatellitesDesc : "NA";
-this.melpExtSlidesDesc = StringUtils.isNotEmpty(melpExtSlidesDesc) ? melpExtSlidesDesc : "NA";
-this.melpLnorgDxDesc = StringUtils.isNotEmpty(melpLnorgDxDesc) ? melpLnorgDxDesc : "NA";
-this.melpLnclinStsDesc = StringUtils.isNotEmpty(melpLnclinStsDesc) ? melpLnclinStsDesc : "NA";
-this.melpLnsentinbxDesx = StringUtils.isNotEmpty(melpLnsentinbxDesx) ? melpLnsentinbxDesx : "NA";
-this.melpLnsentinbxYear = StringUtils.isNotEmpty(melpLnsentinbxYear) ? melpLnsentinbxYear : "NA";
-this.melpLnprolysctDesc = StringUtils.isNotEmpty(melpLnprolysctDesc) ? melpLnprolysctDesc : "NA";
-this.melpLnprosuccDesc = StringUtils.isNotEmpty(melpLnprosuccDesc) ? melpLnprosuccDesc : "NA";
-this.melpLndsctCmpDesc = StringUtils.isNotEmpty(melpLndsctCmpDesc) ? melpLndsctCmpDesc : "NA";
-this.melpLndsctYear = StringUtils.isNotEmpty(melpLndsctYear) ? melpLndsctYear : "NA";
-this.melpLnmattedDesc = StringUtils.isNotEmpty(melpLnmattedDesc) ? melpLnmattedDesc : "NA";
-this.LnextnodstDesc = StringUtils.isNotEmpty(LnextnodstDesc) ? LnextnodstDesc : "NA";
-this.LnintrmetsDesc = StringUtils.isNotEmpty(LnintrmetsDesc) ? LnintrmetsDesc : "NA";
-this.melpLnsize = StringUtils.isNotEmpty(melpLnsize) ? melpLnsize : "NA";
-this.melpLnsizeUnkDesc = StringUtils.isNotEmpty(melpLnsizeUnkDesc) ? melpLnsizeUnkDesc : "NA";
-this.melpLnslnlargSize = StringUtils.isNotEmpty(melpLnslnlargSize) ? melpLnslnlargSize : "NA";
-this.melpLnihcDesc = StringUtils.isNotEmpty(melpLnihcDesc) ? melpLnihcDesc : "NA";
-this.melpLnimmS100Desc = StringUtils.isNotEmpty(melpLnimmS100Desc) ? melpLnimmS100Desc : "NA";
-this.melpLnimmhmb45Desc = StringUtils.isNotEmpty(melpLnimmhmb45Desc) ? melpLnimmhmb45Desc : "NA";
-this.melpLnimmMelaDesc = StringUtils.isNotEmpty(melpLnimmMelaDesc) ? melpLnimmMelaDesc : "NA";
-this.meliPtid = StringUtils.isNotEmpty(meliPtid) ? meliPtid : "NA";
-this.meliDmpPatientId = StringUtils.isNotEmpty(meliDmpPatientId) ? meliDmpPatientId : "NA";
-this.meliDmpSampleId = StringUtils.isNotEmpty(meliDmpSampleId) ? meliDmpSampleId : "NA";
-this.meliReportYear = StringUtils.isNotEmpty(meliReportYear)  ? meliReportYear : "NA";
-this.meliProcedureYear = StringUtils.isNotEmpty(meliProcedureYear) ? meliProcedureYear : "NA";
-this.meliTumorType = StringUtils.isNotEmpty(meliTumorType) ? meliTumorType : "NA";
-this.meliPrimarySite = StringUtils.isNotEmpty(meliPrimarySite) ? meliPrimarySite : "NA";
-this.meliMetSite = StringUtils.isNotEmpty(meliMetSite) ? meliMetSite : "NA";
-this.melmsPtid = StringUtils.isNotEmpty(melmsPtid) ? melmsPtid : "NA";
-this.melmsSiteTypeDesc = StringUtils.isNotEmpty(melmsSiteTypeDesc) ? melmsSiteTypeDesc : "NA";
-this.melmsSiteDesc = StringUtils.isNotEmpty(melmsSiteDesc) ? melmsSiteDesc : "NA";
-this.melmsSiteYear = StringUtils.isNotEmpty(melmsSiteYear) ? melmsSiteYear : "NA";
+        this.melspcPtid = StringUtils.isNotEmpty(melspcPtid) ? melspcPtid : "NA";
+        this.melspcStageYear = StringUtils.isNotEmpty(melspcStageYear) ? melspcStageYear : "NA";
+        this.melspcStgGrpName = StringUtils.isNotEmpty(melspcStgGrpName) ? melspcStgGrpName : "NA";
+        this.melgPtid = StringUtils.isNotEmpty(melgPtid) ? melgPtid : "NA";
+        this.melgStsDesc = StringUtils.isNotEmpty(melgStsDesc) ? melgStsDesc : "NA";
+        this.melgStsSrcDesc = StringUtils.isNotEmpty(melgStsSrcDesc) ? melgStsSrcDesc : "NA";
+        this.melgActvStsDesc = StringUtils.isNotEmpty(melgActvStsDesc) ? melgActvStsDesc : "NA";
+        this.melgDermagrphxDesc = StringUtils.isNotEmpty(melgDermagrphxDesc) ? melgDermagrphxDesc : "NA";
+        this.melgPresStgYear = StringUtils.isNotEmpty(melgPresStgYear) ? melgPresStgYear : "NA";
+        this.melgFamilyHxDesc = StringUtils.isNotEmpty(melgFamilyHxDesc) ? melgFamilyHxDesc : "NA";
+        this.melg1stRecurYear = StringUtils.isNotEmpty(melg1stRecurYear) ? melg1stRecurYear : "NA";
+        this.melgLocalDesc = StringUtils.isNotEmpty(melgLocalDesc) ? melgLocalDesc : "NA";
+        this.melgNodalDesc = StringUtils.isNotEmpty(melgNodalDesc) ? melgNodalDesc : "NA";
+        this.melgIntransitDesc = StringUtils.isNotEmpty(melgIntransitDesc) ? melgIntransitDesc : "NA";
+        this.melgSysDesc = StringUtils.isNotEmpty(melgSysDesc) ? melgSysDesc : "NA";
+        this.melgRecurNdszDesc = StringUtils.isNotEmpty(melgRecurNdszDesc) ? melgRecurNdszDesc : "NA";
+        this.melgRecurNodalNo = StringUtils.isNotEmpty(melgRecurNodalNo) ? melgRecurNodalNo : "NA";
+        this.melgLdh = StringUtils.isNotEmpty(melgLdh) ? melgLdh : "NA";
+        this.melgLdhYear = StringUtils.isNotEmpty(melgLdhYear) ? melgLdhYear : "NA";
+        this.melgMetsDesc = StringUtils.isNotEmpty(melgMetsDesc) ? melgMetsDesc : "NA";
+        this.melgAdjvntTxDesc = StringUtils.isNotEmpty(melgAdjvntTxDesc) ? melgAdjvntTxDesc : "NA";
+        this.melgSysTxDesc = StringUtils.isNotEmpty(melgSysTxDesc) ? melgSysTxDesc : "NA";
+        this.melgRadTxDesc = StringUtils.isNotEmpty(melgRadTxDesc) ? melgRadTxDesc : "NA";
+        this.melgSurgDesc = StringUtils.isNotEmpty(melgSurgDesc) ? melgSurgDesc : "NA";
+        this.melgTissueBankAvail = StringUtils.isNotEmpty(melgTissueBankAvail) ? melgTissueBankAvail : "NA";
+        this.melpPtid = StringUtils.isNotEmpty(melpPtid) ? melpPtid : "NA";
+        this.melpPrimSeq = StringUtils.isNotEmpty(melpPrimSeq) ? melpPrimSeq : "NA";
+        this.melpDxYear = StringUtils.isNotEmpty(melpDxYear) ? melpDxYear : "NA";
+        this.melpMskReviewDesc = StringUtils.isNotEmpty(melpMskReviewDesc) ? melpMskReviewDesc : "NA";
+        this.melpThicknessMm = StringUtils.isNotEmpty(melpThicknessMm) ? melpThicknessMm : "NA";
+        this.melpClarkLvlDesc = StringUtils.isNotEmpty(melpClarkLvlDesc) ? melpClarkLvlDesc : "NA";
+        this.melpUlcerationDesc = StringUtils.isNotEmpty(melpUlcerationDesc) ? melpUlcerationDesc : "NA";
+        this.melpSiteDesc = StringUtils.isNotEmpty(melpSiteDesc) ? melpSiteDesc : "NA";
+        this.melpSubSiteDesc = StringUtils.isNotEmpty(melpSubSiteDesc) ? melpSubSiteDesc : "NA";
+        this.melpTilsDesc = StringUtils.isNotEmpty(melpTilsDesc) ? melpTilsDesc : "NA";
+        this.melpRegressionDesc = StringUtils.isNotEmpty(melpRegressionDesc) ? melpRegressionDesc : "NA";
+        this.melpMarginsDesc = StringUtils.isNotEmpty(melpMarginsDesc) ? melpMarginsDesc : "NA";
+        this.melpMitidxUnkDesc = StringUtils.isNotEmpty(melpMitidxUnkDesc) ? melpMitidxUnkDesc : "NA";
+        this.melpHistTypeDesc = StringUtils.isNotEmpty(melpHistTypeDesc) ? melpHistTypeDesc : "NA";
+        this.melpSatellitesDesc = StringUtils.isNotEmpty(melpSatellitesDesc) ? melpSatellitesDesc : "NA";
+        this.melpExtSlidesDesc = StringUtils.isNotEmpty(melpExtSlidesDesc) ? melpExtSlidesDesc : "NA";
+        this.melpLnorgDxDesc = StringUtils.isNotEmpty(melpLnorgDxDesc) ? melpLnorgDxDesc : "NA";
+        this.melpLnclinStsDesc = StringUtils.isNotEmpty(melpLnclinStsDesc) ? melpLnclinStsDesc : "NA";
+        this.melpLnsentinbxDesx = StringUtils.isNotEmpty(melpLnsentinbxDesx) ? melpLnsentinbxDesx : "NA";
+        this.melpLnsentinbxYear = StringUtils.isNotEmpty(melpLnsentinbxYear) ? melpLnsentinbxYear : "NA";
+        this.melpLnprolysctDesc = StringUtils.isNotEmpty(melpLnprolysctDesc) ? melpLnprolysctDesc : "NA";
+        this.melpLnprosuccDesc = StringUtils.isNotEmpty(melpLnprosuccDesc) ? melpLnprosuccDesc : "NA";
+        this.melpLndsctCmpDesc = StringUtils.isNotEmpty(melpLndsctCmpDesc) ? melpLndsctCmpDesc : "NA";
+        this.melpLndsctYear = StringUtils.isNotEmpty(melpLndsctYear) ? melpLndsctYear : "NA";
+        this.melpLnmattedDesc = StringUtils.isNotEmpty(melpLnmattedDesc) ? melpLnmattedDesc : "NA";
+        this.LnextnodstDesc = StringUtils.isNotEmpty(LnextnodstDesc) ? LnextnodstDesc : "NA";
+        this.LnintrmetsDesc = StringUtils.isNotEmpty(LnintrmetsDesc) ? LnintrmetsDesc : "NA";
+        this.melpLnsize = StringUtils.isNotEmpty(melpLnsize) ? melpLnsize : "NA";
+        this.melpLnsizeUnkDesc = StringUtils.isNotEmpty(melpLnsizeUnkDesc) ? melpLnsizeUnkDesc : "NA";
+        this.melpLnslnlargSize = StringUtils.isNotEmpty(melpLnslnlargSize) ? melpLnslnlargSize : "NA";
+        this.melpLnihcDesc = StringUtils.isNotEmpty(melpLnihcDesc) ? melpLnihcDesc : "NA";
+        this.melpLnimmS100Desc = StringUtils.isNotEmpty(melpLnimmS100Desc) ? melpLnimmS100Desc : "NA";
+        this.melpLnimmhmb45Desc = StringUtils.isNotEmpty(melpLnimmhmb45Desc) ? melpLnimmhmb45Desc : "NA";
+        this.melpLnimmMelaDesc = StringUtils.isNotEmpty(melpLnimmMelaDesc) ? melpLnimmMelaDesc : "NA";
+        this.meliPtid = StringUtils.isNotEmpty(meliPtid) ? meliPtid : "NA";
+        this.meliDmpPatientId = StringUtils.isNotEmpty(meliDmpPatientId) ? meliDmpPatientId : "NA";
+        this.meliDmpSampleId = StringUtils.isNotEmpty(meliDmpSampleId) ? meliDmpSampleId : "NA";
+        this.meliReportYear = StringUtils.isNotEmpty(meliReportYear)  ? meliReportYear : "NA";
+        this.meliProcedureYear = StringUtils.isNotEmpty(meliProcedureYear) ? meliProcedureYear : "NA";
+        this.meliTumorType = StringUtils.isNotEmpty(meliTumorType) ? meliTumorType : "NA";
+        this.meliPrimarySite = StringUtils.isNotEmpty(meliPrimarySite) ? meliPrimarySite : "NA";
+        this.meliMetSite = StringUtils.isNotEmpty(meliMetSite) ? meliMetSite : "NA";
+        this.melmsPtid = StringUtils.isNotEmpty(melmsPtid) ? melmsPtid : "NA";
+        this.melmsSiteTypeDesc = StringUtils.isNotEmpty(melmsSiteTypeDesc) ? melmsSiteTypeDesc : "NA";
+        this.melmsSiteDesc = StringUtils.isNotEmpty(melmsSiteDesc) ? melmsSiteDesc : "NA";
+        this.melmsSiteYear = StringUtils.isNotEmpty(melmsSiteYear) ? melmsSiteYear : "NA";
     }
     
     public String getPATIENT_ID() {
         if (patientId != null) {
             return patientId;
         }
-        else if (!melspcPtid.equals("NA")) {
+        if (!melspcPtid.equals("NA")) {
             return melspcPtid;
         }
-        else if (!melgPtid.equals("NA")) {
+        if (!melgPtid.equals("NA")) {
             return melgPtid;
-        }        
-        else if (!melpPtid.equals("NA")) {
+        }
+        if (!melpPtid.equals("NA")) {
             return melpPtid;
         }
-        else {
-            return melmsPtid;
-        }
+        return melmsPtid;
     }
     
     public void setPATIENT_ID(String patientId) {
@@ -290,21 +288,19 @@ this.melmsSiteYear = StringUtils.isNotEmpty(melmsSiteYear) ? melmsSiteYear : "NA
         if (sampleId != null) {
             return sampleId;
         }
-        else if (!meliDmpSampleId.equals("NA")) {
+        if (!meliDmpSampleId.equals("NA")) {
             return meliDmpSampleId;
         }        
-        else if (!melpPrimSeq.equals("NA")) {
+        if (!melpPrimSeq.equals("NA")) {
             return melpPtid + "_" + melpPrimSeq;
         }        
-        else if (!melspcPtid.equals("NA")) {
+        if (!melspcPtid.equals("NA")) {
             return melspcPtid;
         }
-        else if (!melgPtid.equals("NA")) {
+        if (!melgPtid.equals("NA")) {
             return melgPtid;
         }
-        else {
-            return melmsPtid;
-        }
+        return melmsPtid;
     }
     
     public void setSAMPLE_ID(String sampleId) {

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantNormalizedClinicalRecord.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantNormalizedClinicalRecord.java
@@ -1,0 +1,859 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.darwin.pipeline.model;
+
+import java.util.*;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+public class Skcm_mskcc_2015_chantNormalizedClinicalRecord {
+    private String patientId;
+    private String sampleId;
+    private String stageYear;
+    private String stgGrpName;
+    private String vitalStatus;
+    private String stsSrcDesc;
+    private String lastStatus;
+    private String dermagrphxDes;
+    private String presStgYear;
+    private String familyHistory;
+    private String timeToFirstRecurrence;
+    private String localDesc;
+    private String nodalDesc;
+    private String intransitDesc;
+    private String sysDesc;
+    private String recurNdszDes;
+    private String recurNodalNo;
+    private String ldh;
+    private String ldhYear;
+    private String metastasis;
+    private String adjvntTx;
+    private String systemicTreatment;
+    private String treatmentRadiation;
+    private String surgery;
+    private String tissueBankAvail;
+    private String primSeq;
+    private String yearOfDiagnosis;
+    private String mskReviewDes;
+    private String tumorThicknessMeasurement;
+    private String clarkLevelAtDiagnosis;
+    private String primaryMelanomaTumorUlceration;
+    private String tumorTissueSite;
+    private String detailedPrimarySite;
+    private String lymphocyteInfiltration;
+    private String regressionDes;
+    private String marginStatus;
+    private String mitoticIndex;
+    private String histologicalType;
+    private String satellitesDes;
+    private String extSlidesDes;
+    private String primaryLymphNodePresentationAssessment;
+    private String lnclinStsDes;
+    private String lnsentinbxDes;
+    private String lnsentinbxYea;
+    private String lnprolysctDes;
+    private String lnprosuccDesc;
+    private String lndsctCmpDes;
+    private String lndsctYear;
+    private String lnmattedDesc;
+    private String lnextnodstDes;
+    private String lnintrmetsDes;
+    private String lnsize;
+    private String lnsizeUnkDes;
+    private String lnslnlargSize;
+    private String lnihcDesc;
+    private String s100Stain;
+    private String lnimmhmb45Des;
+    private String lnimmMelaDes;
+    private String reportYear;
+    private String procedureYear;
+    private String tumorType;
+    private String primarySite;
+    private String metastaticSite;
+    private String initialMetDisease;
+    private String otherSitesOfMets;
+    private String yearMetDiseaseIdentified;
+    
+    private Map<String, Object> additionalProperties;    
+    
+    public Skcm_mskcc_2015_chantNormalizedClinicalRecord() {
+    }
+    
+    public Skcm_mskcc_2015_chantNormalizedClinicalRecord(
+             String patientId,
+             String sampleId,
+             String stageYear,
+             String stgGrpName,
+             String vitalStatus,
+             String stsSrcDesc,
+             String lastStatus,
+             String dermagrphxDes,
+             String presStgYear,
+             String familyHistory,
+             String timeToFirstRecurrence,
+             String localDesc,
+             String nodalDesc,
+             String intransitDesc,
+             String sysDesc,
+             String recurNdszDes,
+             String recurNodalNo,
+             String ldh,
+             String ldhYear,
+             String metastasis,
+             String adjvntTx,
+             String systemicTreatment,
+             String treatmentRadiation,
+             String surgery,
+             String tissueBankAvail,
+             String primSeq,
+             String yearOfDiagnosis,
+             String mskReviewDes,
+             String tumorThicknessMeasurement,
+             String clarkLevelAtDiagnosis,
+             String primaryMelanomaTumorUlceration,
+             String tumorTissueSite,
+             String detailedPrimarySite,
+             String lymphocyteInfiltration,
+             String regressionDes,
+             String marginStatus,
+             String mitoticIndex,
+             String histologicalType,
+             String satellitesDes,
+             String extSlidesDes,
+             String primaryLymphNodePresentationAssessment,
+             String lnclinStsDes,
+             String lnsentinbxDes,
+             String lnsentinbxYea,
+             String lnprolysctDes,
+             String lnprosuccDesc,
+             String lndsctCmpDes,
+             String lndsctYear,
+             String lnmattedDesc,
+             String lnextnodstDes,
+             String lnintrmetsDes,
+             String lnsize,
+             String lnsizeUnkDes,
+             String lnslnlargSize,
+             String lnihcDesc,
+             String s100Stain,
+             String lnimmhmb45Des,
+             String lnimmMelaDes,
+             String reportYear,
+             String procedureYear,
+             String tumorType,
+             String primarySite,
+             String metastaticSite,
+             String initialMetDisease,
+             String otherSitesOfMets,
+             String yearMetDiseaseIdentified) {
+        this.patientId = StringUtils.isNotEmpty(patientId) ? patientId : "NA";
+        this.sampleId = StringUtils.isNotEmpty(sampleId) ? sampleId : "NA";
+        this.stageYear = StringUtils.isNotEmpty(stageYear) ? stageYear : "NA";
+        this.stgGrpName = StringUtils.isNotEmpty(stgGrpName) ? stgGrpName : "NA";
+        this.vitalStatus = StringUtils.isNotEmpty(vitalStatus) ? vitalStatus : "NA";
+        this.stsSrcDesc = StringUtils.isNotEmpty(stsSrcDesc) ? stsSrcDesc : "NA";
+        this.lastStatus = StringUtils.isNotEmpty(lastStatus) ? lastStatus : "NA";
+        this.dermagrphxDes = StringUtils.isNotEmpty(dermagrphxDes) ? dermagrphxDes : "NA";
+        this.presStgYear = StringUtils.isNotEmpty(presStgYear) ? presStgYear : "NA";
+        this.familyHistory = StringUtils.isNotEmpty(familyHistory) ? familyHistory : "NA";
+        this.timeToFirstRecurrence = StringUtils.isNotEmpty(timeToFirstRecurrence) ? timeToFirstRecurrence : "NA";
+        this.localDesc = StringUtils.isNotEmpty(localDesc) ? localDesc : "NA";
+        this.nodalDesc = StringUtils.isNotEmpty(nodalDesc) ? nodalDesc : "NA";
+        this.intransitDesc = StringUtils.isNotEmpty(intransitDesc) ? intransitDesc : "NA";
+        this.sysDesc = StringUtils.isNotEmpty(sysDesc) ? sysDesc : "NA";
+        this.recurNdszDes = StringUtils.isNotEmpty(recurNdszDes) ? recurNdszDes : "NA";
+        this.recurNodalNo = StringUtils.isNotEmpty(recurNodalNo) ? recurNodalNo : "NA";
+        this.ldh = StringUtils.isNotEmpty(ldh) ? ldh : "NA";
+        this.ldhYear = StringUtils.isNotEmpty(ldhYear) ? ldhYear : "NA";
+        this.metastasis = StringUtils.isNotEmpty(metastasis) ? metastasis : "NA";
+        this.adjvntTx = StringUtils.isNotEmpty(adjvntTx) ? adjvntTx : "NA";
+        this.systemicTreatment = StringUtils.isNotEmpty(systemicTreatment) ? systemicTreatment : "NA";
+        this.treatmentRadiation = StringUtils.isNotEmpty(treatmentRadiation) ? treatmentRadiation : "NA";
+        this.surgery = StringUtils.isNotEmpty(surgery) ? surgery : "NA";
+        this.tissueBankAvail = StringUtils.isNotEmpty(tissueBankAvail) ? tissueBankAvail : "NA";
+        this.primSeq = StringUtils.isNotEmpty(primSeq) ? primSeq : "NA";
+        this.yearOfDiagnosis = StringUtils.isNotEmpty(yearOfDiagnosis) ? yearOfDiagnosis : "NA";
+        this.mskReviewDes = StringUtils.isNotEmpty(mskReviewDes) ? mskReviewDes : "NA";
+        this.tumorThicknessMeasurement = StringUtils.isNotEmpty(tumorThicknessMeasurement) ? tumorThicknessMeasurement : "NA";
+        this.clarkLevelAtDiagnosis = StringUtils.isNotEmpty(clarkLevelAtDiagnosis) ? clarkLevelAtDiagnosis : "NA";
+        this.primaryMelanomaTumorUlceration = StringUtils.isNotEmpty(primaryMelanomaTumorUlceration) ? primaryMelanomaTumorUlceration : "NA";
+        this.tumorTissueSite = StringUtils.isNotEmpty(tumorTissueSite) ? tumorTissueSite : "NA";
+        this.detailedPrimarySite = StringUtils.isNotEmpty(detailedPrimarySite) ? detailedPrimarySite : "NA";
+        this.lymphocyteInfiltration = StringUtils.isNotEmpty(lymphocyteInfiltration) ? lymphocyteInfiltration : "NA";
+        this.regressionDes = StringUtils.isNotEmpty(regressionDes) ? regressionDes : "NA";
+        this.marginStatus = StringUtils.isNotEmpty(marginStatus) ? marginStatus : "NA";
+        this.mitoticIndex = StringUtils.isNotEmpty(mitoticIndex) ? mitoticIndex : "NA";
+        this.histologicalType = StringUtils.isNotEmpty(histologicalType) ? histologicalType : "NA";
+        this.satellitesDes = StringUtils.isNotEmpty(satellitesDes) ? satellitesDes : "NA";
+        this.extSlidesDes = StringUtils.isNotEmpty(extSlidesDes) ? extSlidesDes : "NA";
+        this.primaryLymphNodePresentationAssessment = StringUtils.isNotEmpty(primaryLymphNodePresentationAssessment) ? primaryLymphNodePresentationAssessment : "NA";
+        this.lnclinStsDes = StringUtils.isNotEmpty(lnclinStsDes) ? lnclinStsDes : "NA";
+        this.lnsentinbxDes = StringUtils.isNotEmpty(lnsentinbxDes) ? lnsentinbxDes : "NA";
+        this.lnsentinbxYea = StringUtils.isNotEmpty(lnsentinbxYea) ? lnsentinbxYea : "NA";
+        this.lnprolysctDes = StringUtils.isNotEmpty(lnprolysctDes) ? lnprolysctDes : "NA";
+        this.lnprosuccDesc = StringUtils.isNotEmpty(lnprosuccDesc) ? lnprosuccDesc : "NA";
+        this.lndsctCmpDes = StringUtils.isNotEmpty(lndsctCmpDes) ? lndsctCmpDes : "NA";
+        this.lndsctYear = StringUtils.isNotEmpty(lndsctYear) ? lndsctYear : "NA";
+        this.lnmattedDesc = StringUtils.isNotEmpty(lnmattedDesc) ? lnmattedDesc : "NA";
+        this.lnextnodstDes = StringUtils.isNotEmpty(lnextnodstDes) ? lnextnodstDes : "NA";
+        this.lnintrmetsDes = StringUtils.isNotEmpty(lnintrmetsDes) ? lnintrmetsDes : "NA";
+        this.lnsize = StringUtils.isNotEmpty(lnsize) ? lnsize : "NA";
+        this.lnsizeUnkDes = StringUtils.isNotEmpty(lnsizeUnkDes) ? lnsizeUnkDes : "NA";
+        this.lnslnlargSize = StringUtils.isNotEmpty(lnslnlargSize) ? lnslnlargSize : "NA";
+        this.lnihcDesc = StringUtils.isNotEmpty(lnihcDesc) ? lnihcDesc : "NA";
+        this.s100Stain = StringUtils.isNotEmpty(s100Stain) ? s100Stain : "NA";
+        this.lnimmhmb45Des = StringUtils.isNotEmpty(lnimmhmb45Des) ? lnimmhmb45Des : "NA";
+        this.lnimmMelaDes = StringUtils.isNotEmpty(lnimmMelaDes) ? lnimmMelaDes : "NA";
+        this.reportYear = StringUtils.isNotEmpty(reportYear) ? reportYear : "NA";
+        this.procedureYear = StringUtils.isNotEmpty(procedureYear) ? procedureYear : "NA";
+        this.tumorType = StringUtils.isNotEmpty(tumorType) ? tumorType : "NA";
+        this.primarySite = StringUtils.isNotEmpty(primarySite) ? primarySite : "NA";
+        this.metastaticSite = StringUtils.isNotEmpty(metastaticSite) ? metastaticSite : "NA";
+        this.initialMetDisease = StringUtils.isNotEmpty(initialMetDisease) ? initialMetDisease : "NA";
+        this.otherSitesOfMets = StringUtils.isNotEmpty(otherSitesOfMets) ? otherSitesOfMets : "NA";
+        this.yearMetDiseaseIdentified = StringUtils.isNotEmpty(yearMetDiseaseIdentified) ? yearMetDiseaseIdentified : "NA";
+    }
+    
+    public String getPATIENT_ID() {
+        return patientId;
+    }
+    
+    public void setPATIENT_ID(String patientId) {
+        this.patientId = patientId;
+    }
+    
+    public String getSAMPLE_ID() {
+        return sampleId;
+    }
+    
+    public void setSAMPLE_ID(String sampleId) {
+        this.sampleId = sampleId;
+    }
+    
+    public String getSTAGE_YEAR() {
+        return this.stageYear;
+    }
+
+    public void setSTAGE_YEAR(String stageYear) {
+        this.stageYear = stageYear;
+    }
+
+    public String getSTG_GRP_NAME() {
+        return this.stgGrpName;
+    }
+
+    public void setSTG_GRP_NAME(String stgGrpName) {
+        this.stgGrpName = stgGrpName;
+    }
+
+    public String getVITAL_STATUS() {
+        return this.vitalStatus;
+    }
+
+    public void setVITAL_STATUS(String vitalStatus) {
+        this.vitalStatus = vitalStatus;
+    }
+
+    public String getSTS_SRCE_DESC() {
+        return this.stsSrcDesc;
+    }
+
+    public void setSTS_SRCE_DESC(String stsSrcDesc) {
+        this.stsSrcDesc = stsSrcDesc;
+    }
+
+    public String getLAST_STATUS() {
+        return this.lastStatus;
+    }
+
+    public void setLAST_STATUS(String lastStatus) {
+        this.lastStatus = lastStatus;
+    }
+
+    public String getDERMAGRPHX_DES() {
+        return this.dermagrphxDes;
+    }
+
+    public void setDERMAGRPHX_DES(String dermagrphxDes) {
+        this.dermagrphxDes = dermagrphxDes;
+    }
+
+    public String getPRES_STG_YEAR() {
+        return this.presStgYear;
+    }
+
+    public void setPRES_STG_YEAR(String presStgYear) {
+        this.presStgYear = presStgYear;
+    }
+
+    public String getFAMILY_HISTORY() {
+        return this.familyHistory;
+    }
+
+    public void setFAMILY_HISTORY(String familyHistory) {
+        this.familyHistory = familyHistory;
+    }
+
+    public String getTIME_TO_FIRST_RECURRENCE() {
+        return this.timeToFirstRecurrence;
+    }
+
+    public void setTIME_TO_FIRST_RECURRENCE(String timeToFirstRecurrence) {
+        this.timeToFirstRecurrence = timeToFirstRecurrence;
+    }
+
+    public String getLOCAL_DESC() {
+        return this.localDesc;
+    }
+
+    public void setLOCAL_DESC(String localDesc) {
+        this.localDesc = localDesc;
+    }
+
+    public String getNODAL_DESC() {
+        return this.nodalDesc;
+    }
+
+    public void setNODAL_DESC(String nodalDesc) {
+        this.nodalDesc = nodalDesc;
+    }
+
+    public String getINTRANSIT_DESC() {
+        return this.intransitDesc;
+    }
+
+    public void setINTRANSIT_DESC(String intransitDesc) {
+        this.intransitDesc = intransitDesc;
+    }
+
+    public String getSYS_DESC() {
+        return this.sysDesc;
+    }
+
+    public void setSYS_DESC(String sysDesc) {
+        this.sysDesc = sysDesc;
+    }
+
+    public String getRECUR_NDSZ_DES() {
+        return this.recurNdszDes;
+    }
+
+    public void setRECUR_NDSZ_DES(String recurNdszDes) {
+        this.recurNdszDes = recurNdszDes;
+    }
+
+    public String getRECUR_NODAL_NO() {
+        return this.recurNodalNo;
+    }
+
+    public void setRECUR_NODAL_NO(String recurNodalNo) {
+        this.recurNodalNo = recurNodalNo;
+    }
+
+    public String getLDH_LEVEL() {
+        return this.ldh;
+    }
+
+    public void setLDH_LEVEL(String ldh) {
+        this.ldh = ldh;
+    }
+
+    public String getLDH_YEAR() {
+        return this.ldhYear;
+    }
+
+    public void setLDH_YEAR(String ldhYear) {
+        this.ldhYear = ldhYear;
+    }
+
+    public String getMETASTASIS() {
+        return this.metastasis;
+    }
+
+    public void setMETASTASIS(String metastasis) {
+        this.metastasis = metastasis;
+    }
+
+    public String getADJUVANT_TX() {
+        return this.adjvntTx;
+    }
+
+    public void setADJUVANT_TX(String adjvntTx) {
+        this.adjvntTx = adjvntTx;
+    }
+
+    public String getSYSTEMIC_TREATMENT() {
+        return this.systemicTreatment;
+    }
+
+    public void setSYSTEMIC_TREATMENT(String systemicTreatment) {
+        this.systemicTreatment = systemicTreatment;
+    }
+
+    public String getTREATMENT_RADIATION() {
+        return this.treatmentRadiation;
+    }
+
+    public void setTREATMENT_RADIATION(String treatmentRadiation) {
+        this.treatmentRadiation = treatmentRadiation;
+    }
+
+    public String getSURGERY() {
+        return this.surgery;
+    }
+
+    public void setSURGERY(String surgery) {
+        this.surgery = surgery;
+    }
+
+    public String getTISSUE_BANK_AVAIL() {
+        return this.tissueBankAvail;
+    }
+
+    public void setTISSUE_BANK_AVAIL(String tissueBankAvail) {
+        this.tissueBankAvail = tissueBankAvail;
+    }
+
+    public String getPRIM_SEQ() {
+        return this.primSeq;
+    }
+
+    public void setPRIM_SEQ(String primSeq) {
+        this.primSeq = primSeq;
+    }
+
+    public String getYEAR_OF_DIAGNOSIS() {
+        return this.yearOfDiagnosis;
+    }
+
+    public void setYEAR_OF_DIAGNOSIS(String yearOfDiagnosis) {
+        this.yearOfDiagnosis = yearOfDiagnosis;
+    }
+
+    public String getMSK_REVIEW_DES() {
+        return this.mskReviewDes;
+    }
+
+    public void setMSK_REVIEW_DES(String mskReviewDes) {
+        this.mskReviewDes = mskReviewDes;
+    }
+
+    public String getTUMOR_THICKNESS_MEASUREMENT() {
+        return this.tumorThicknessMeasurement;
+    }
+
+    public void setTUMOR_THICKNESS_MEASUREMENT(String tumorThicknessMeasurement) {
+        this.tumorThicknessMeasurement = tumorThicknessMeasurement;
+    }
+
+    public String getCLARK_LEVEL_AT_DIAGNOSIS() {
+        return this.clarkLevelAtDiagnosis;
+    }
+
+    public void setCLARK_LEVEL_AT_DIAGNOSIS(String clarkLevelAtDiagnosis) {
+        this.clarkLevelAtDiagnosis = clarkLevelAtDiagnosis;
+    }
+
+    public String getPRIMARY_MELANOMA_TUMOR_ULCERATION() {
+        return this.primaryMelanomaTumorUlceration;
+    }
+
+    public void setPRIMARY_MELANOMA_TUMOR_ULCERATION(String primaryMelanomaTumorUlceration) {
+        this.primaryMelanomaTumorUlceration = primaryMelanomaTumorUlceration;
+    }
+
+    public String getTUMOR_TISSUE_SITE() {
+        return this.tumorTissueSite;
+    }
+
+    public void setTUMOR_TISSUE_SITE(String tumorTissueSite) {
+        this.tumorTissueSite = tumorTissueSite;
+    }
+
+    public String getDETAILED_PRIMARY_SITE() {
+        return this.detailedPrimarySite;
+    }
+
+    public void setDETAILED_PRIMARY_SITE(String detailedPrimarySite) {
+        this.detailedPrimarySite = detailedPrimarySite;
+    }
+
+    public String getLYMPHOCYTE_INFILTRATION() {
+        return this.lymphocyteInfiltration;
+    }
+
+    public void setLYMPHOCYTE_INFILTRATION(String lymphocyteInfiltration) {
+        this.lymphocyteInfiltration = lymphocyteInfiltration;
+    }
+
+    public String getREGRESSION_DES() {
+        return this.regressionDes;
+    }
+
+    public void setREGRESSION_DES(String regressionDes) {
+        this.regressionDes = regressionDes;
+    }
+
+    public String getMARGIN_STATUS() {
+        return this.marginStatus;
+    }
+
+    public void setMARGIN_STATUS(String marginStatus) {
+        this.marginStatus = marginStatus;
+    }
+
+    public String getMITOTIC_INDEX() {
+        return this.mitoticIndex;
+    }
+
+    public void setMITOTIC_INDEX(String mitoticIndex) {
+        this.mitoticIndex = mitoticIndex;
+    }
+
+    public String getHISTOLOGICAL_TYPE() {
+        return this.histologicalType;
+    }
+
+    public void setHISTOLOGICAL_TYPE(String histologicalType) {
+        this.histologicalType = histologicalType;
+    }
+
+    public String getSATELLITES_DES() {
+        return this.satellitesDes;
+    }
+
+    public void setSATELLITES_DES(String satellitesDes) {
+        this.satellitesDes = satellitesDes;
+    }
+
+    public String getEXT_SLIDES_DES() {
+        return this.extSlidesDes;
+    }
+
+    public void setEXT_SLIDES_DES(String extSlidesDes) {
+        this.extSlidesDes = extSlidesDes;
+    }
+
+    public String getPRIMARY_LYMPH_NODE_PRESENTATION_ASSESSMENT() {
+        return this.primaryLymphNodePresentationAssessment;
+    }
+
+    public void setPRIMARY_LYMPH_NODE_PRESENTATION_ASSESSMENT(String primaryLymphNodePresentationAssessment) {
+        this.primaryLymphNodePresentationAssessment = primaryLymphNodePresentationAssessment;
+    }
+
+    public String getLNCLIN_STS_DES() {
+        return this.lnclinStsDes;
+    }
+
+    public void setLNCLIN_STS_DES(String lnclinStsDes) {
+        this.lnclinStsDes = lnclinStsDes;
+    }
+
+    public String getLNSENTINBX_DES() {
+        return this.lnsentinbxDes;
+    }
+
+    public void setLNSENTINBX_DES(String lnsentinbxDes) {
+        this.lnsentinbxDes = lnsentinbxDes;
+    }
+
+    public String getLNSENTINBX_YEA() {
+        return this.lnsentinbxYea;
+    }
+
+    public void setLNSENTINBX_YEA(String lnsentinbxYea) {
+        this.lnsentinbxYea = lnsentinbxYea;
+    }
+
+    public String getLNPROLYSCT_DES() {
+        return this.lnprolysctDes;
+    }
+
+    public void setLNPROLYSCT_DES(String lnprolysctDes) {
+        this.lnprolysctDes = lnprolysctDes;
+    }
+
+    public String getLNPROSUCC_DESC() {
+        return this.lnprosuccDesc;
+    }
+
+    public void setLNPROSUCC_DESC(String lnprosuccDesc) {
+        this.lnprosuccDesc = lnprosuccDesc;
+    }
+
+    public String getLNDSCT_CMP_DES() {
+        return this.lndsctCmpDes;
+    }
+
+    public void setLNDSCT_CMP_DES(String lndsctCmpDes) {
+        this.lndsctCmpDes = lndsctCmpDes;
+    }
+
+    public String getLNDSCT_YEAR() {
+        return this.lndsctYear;
+    }
+
+    public void setLNDSCT_YEAR(String lndsctYear) {
+        this.lndsctYear = lndsctYear;
+    }
+
+    public String getLNMATTED_DESC() {
+        return this.lnmattedDesc;
+    }
+
+    public void setLNMATTED_DESC(String lnmattedDesc) {
+        this.lnmattedDesc = lnmattedDesc;
+    }
+
+    public String getLNEXTNODST_DES() {
+        return this.lnextnodstDes;
+    }
+
+    public void setLNEXTNODST_DES(String lnextnodstDes) {
+        this.lnextnodstDes = lnextnodstDes;
+    }
+
+    public String getLNINTRMETS_DES() {
+        return this.lnintrmetsDes;
+    }
+
+    public void setLNINTRMETS_DES(String lnintrmetsDes) {
+        this.lnintrmetsDes = lnintrmetsDes;
+    }
+
+    public String getLNSIZE() {
+        return this.lnsize;
+    }
+
+    public void setLNSIZE(String lnsize) {
+        this.lnsize = lnsize;
+    }
+
+    public String getLNSIZE_UNK_DES() {
+        return this.lnsizeUnkDes;
+    }
+
+    public void setLNSIZE_UNK_DES(String lnsizeUnkDes) {
+        this.lnsizeUnkDes = lnsizeUnkDes;
+    }
+
+    public String getLNSLNLARG_SIZE() {
+        return this.lnslnlargSize;
+    }
+
+    public void setLNSLNLARG_SIZE(String lnslnlargSize) {
+        this.lnslnlargSize = lnslnlargSize;
+    }
+
+    public String getLNIHC_DESC() {
+        return this.lnihcDesc;
+    }
+
+    public void setLNIHC_DESC(String lnihcDesc) {
+        this.lnihcDesc = lnihcDesc;
+    }
+
+    public String getS_100_STAIN() {
+        return this.s100Stain;
+    }
+
+    public void setS_100_STAIN(String s100Stain) {
+        this.s100Stain = s100Stain;
+    }
+
+    public String getLNIMMHMB45_DES() {
+        return this.lnimmhmb45Des;
+    }
+
+    public void setLNIMMHMB45_DES(String lnimmhmb45Des) {
+        this.lnimmhmb45Des = lnimmhmb45Des;
+    }
+
+    public String getLNIMM_MELA_DES() {
+        return this.lnimmMelaDes;
+    }
+
+    public void setLNIMM_MELA_DES(String lnimmMelaDes) {
+        this.lnimmMelaDes = lnimmMelaDes;
+    }
+
+    public String getREPORT_YEAR() {
+        return this.reportYear;
+    }
+
+    public void setREPORT_YEAR(String reportYear) {
+        this.reportYear = reportYear;
+    }
+
+    public String getPROCEDURE_YEAR() {
+        return this.procedureYear;
+    }
+
+    public void setPROCEDURE_YEAR(String procedureYear) {
+        this.procedureYear = procedureYear;
+    }
+
+    public String getTUMOR_TYPE() {
+        return this.tumorType;
+    }
+
+    public void setTUMOR_TYPE(String tumorType) {
+        this.tumorType = tumorType;
+    }
+
+    public String getPRIMARY_SITE() {
+        return this.primarySite;
+    }
+
+    public void setPRIMARY_SITE(String primarySite) {
+        this.primarySite = primarySite;
+    }
+
+    public String getMETASTATIC_SITE() {
+        return this.metastaticSite;
+    }
+
+    public void setMETASTATIC_SITE(String metastaticSite) {
+        this.metastaticSite = metastaticSite;
+    }
+
+    public String getINITIAL_MET_DISEASE() {
+        return this.initialMetDisease;
+    }
+
+    public void setINITIAL_MET_DISEASE(String initialMetDisease) {
+        this.initialMetDisease = initialMetDisease;
+    }
+
+    public String getOTHER_SITES_OF_METS() {
+        return this.otherSitesOfMets;
+    }
+
+    public void setOTHER_SITES_OF_METS(String otherSitesOfMets) {
+        this.otherSitesOfMets = otherSitesOfMets;
+    }
+
+    public String getYEAR_MET_DISEASE_IDENTIFIED() {
+        return this.yearMetDiseaseIdentified;
+    }
+
+    public void setYEAR_MET_DISEASE_IDENTIFIED(String yearMetDiseaseIdentified) {
+        this.yearMetDiseaseIdentified = yearMetDiseaseIdentified;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    public List<String> getFieldNames() {
+        List<String> fieldNames = new ArrayList<>();
+        fieldNames.add("PATIENT_ID");
+        fieldNames.add("SAMPLE_ID");
+        fieldNames.add("STAGE_YEAR");
+        fieldNames.add("STG_GRP_NAME");
+        fieldNames.add("VITAL_STATUS");
+        fieldNames.add("STS_SRCE_DESC");
+        fieldNames.add("LAST_STATUS");
+        fieldNames.add("DERMAGRPHX_DES");
+        fieldNames.add("PRES_STG_YEAR");
+        fieldNames.add("FAMILY_HISTORY");
+        fieldNames.add("TIME_TO_FIRST_RECURRENCE");
+        fieldNames.add("LOCAL_DESC");
+        fieldNames.add("NODAL_DESC");
+        fieldNames.add("INTRANSIT_DESC");
+        fieldNames.add("SYS_DESC");
+        fieldNames.add("RECUR_NDSZ_DES");
+        fieldNames.add("RECUR_NODAL_NO");
+        fieldNames.add("LDH_LEVEL");
+        fieldNames.add("LDH_YEAR");
+        fieldNames.add("METASTASIS");
+        fieldNames.add("ADJUVANT_TX");
+        fieldNames.add("SYSTEMIC_TREATMENT");
+        fieldNames.add("TREATMENT_RADIATION");
+        fieldNames.add("SURGERY");
+        fieldNames.add("TISSUE_BANK_AVAIL");
+        fieldNames.add("PRIM_SEQ");
+        fieldNames.add("YEAR_OF_DIAGNOSIS");
+        fieldNames.add("MSK_REVIEW_DES");
+        fieldNames.add("TUMOR_THICKNESS_MEASUREMENT");
+        fieldNames.add("CLARK_LEVEL_AT_DIAGNOSIS");
+        fieldNames.add("PRIMARY_MELANOMA_TUMOR_ULCERATION");
+        fieldNames.add("TUMOR_TISSUE_SITE");
+        fieldNames.add("DETAILED_PRIMARY_SITE");
+        fieldNames.add("LYMPHOCYTE_INFILTRATION");
+        fieldNames.add("REGRESSION_DES");
+        fieldNames.add("MARGIN_STATUS");
+        fieldNames.add("MITOTIC_INDEX");
+        fieldNames.add("HISTOLOGICAL_TYPE");
+        fieldNames.add("SATELLITES_DES");
+        fieldNames.add("EXT_SLIDES_DES");
+        fieldNames.add("PRIMARY_LYMPH_NODE_PRESENTATION_ASSESSMENT");
+        fieldNames.add("LNCLIN_STS_DES");
+        fieldNames.add("LNSENTINBX_DES");
+        fieldNames.add("LNSENTINBX_YEA");
+        fieldNames.add("LNPROLYSCT_DES");
+        fieldNames.add("LNPROSUCC_DESC");
+        fieldNames.add("LNDSCT_CMP_DES");
+        fieldNames.add("LNDSCT_YEAR");
+        fieldNames.add("LNMATTED_DESC");
+        fieldNames.add("LNEXTNODST_DES");
+        fieldNames.add("LNINTRMETS_DES");
+        fieldNames.add("LNSIZE");
+        fieldNames.add("LNSIZE_UNK_DES");
+        fieldNames.add("LNSLNLARG_SIZE");
+        fieldNames.add("LNIHC_DESC");
+        fieldNames.add("S_100_STAIN");
+        fieldNames.add("LNIMMHMB45_DES");
+        fieldNames.add("LNIMM_MELA_DES");
+        fieldNames.add("REPORT_YEAR");
+        fieldNames.add("PROCEDURE_YEAR");
+        fieldNames.add("TUMOR_TYPE");
+        fieldNames.add("PRIMARY_SITE");
+        fieldNames.add("METASTATIC_SITE");
+        fieldNames.add("INITIAL_MET_DISEASE");
+        fieldNames.add("OTHER_SITES_OF_METS");
+        fieldNames.add("YEAR_MET_DISEASE_IDENTIFIED");
+        return fieldNames;
+    }
+    
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }    
+    
+}

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalPatientProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalPatientProcessor.java
@@ -54,7 +54,7 @@ public class Skcm_mskcc_2015_chantClinicalPatientProcessor implements ItemProces
 
     @Override
     public Skcm_mskcc_2015_chantClinicalCompositeRecord process(final Skcm_mskcc_2015_chantClinicalCompositeRecord melanomaClinicalCompositeRecord) throws Exception {
-        Skcm_mskcc_2015_chantClinicalRecord melanomaClinicalRecord = melanomaClinicalCompositeRecord.getRecord();
+        Skcm_mskcc_2015_chantNormalizedClinicalRecord melanomaClinicalRecord = melanomaClinicalCompositeRecord.getRecord();
         List<String> header =  melanomaClinicalRecord.getFieldNames();
         List<String> record = new ArrayList<>();
 
@@ -68,8 +68,7 @@ public class Skcm_mskcc_2015_chantClinicalPatientProcessor implements ItemProces
             // get value by external column header (same as melanoma clinical record field name)
             // field data might contain '|'-delimited values - if only one unique
             // value then use that, otherwise just use the data that's there
-            String extColumn = patientHeader.get("external_header").get(i+1);  // need to shift by one b/c writer removes PATIENT_ID metadata for header
-            String value = melanomaClinicalRecord.getClass().getMethod("get" + extColumn).invoke(melanomaClinicalRecord).toString();
+            String value = melanomaClinicalRecord.getClass().getMethod("get" + normColumn).invoke(melanomaClinicalRecord).toString();
             Set<String> uniqueValues = new HashSet(Arrays.asList(darwinUtils.convertWhitespace(value).split("\\|")));
             List<String> values = Arrays.asList(value.split("\\|"));
             if (uniqueValues.size() == 1) {

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalSampleProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalSampleProcessor.java
@@ -44,7 +44,7 @@ import org.springframework.beans.factory.annotation.Value;
  *
  * @author heinsz
  */
-public class Skcm_mskcc_2015_chantClinicalSampleProcessor implements ItemProcessor<Skcm_mskcc_2015_chantClinicalRecord, Skcm_mskcc_2015_chantClinicalCompositeRecord> {
+public class Skcm_mskcc_2015_chantClinicalSampleProcessor implements ItemProcessor<Skcm_mskcc_2015_chantNormalizedClinicalRecord, Skcm_mskcc_2015_chantClinicalCompositeRecord> {
 
     @Autowired
     private DarwinUtils darwinUtils;
@@ -53,7 +53,7 @@ public class Skcm_mskcc_2015_chantClinicalSampleProcessor implements ItemProcess
     private Map<String, List<String>> sampleHeader;
 
     @Override
-    public Skcm_mskcc_2015_chantClinicalCompositeRecord process(final Skcm_mskcc_2015_chantClinicalRecord melanomaClinicalRecord) throws Exception {
+    public Skcm_mskcc_2015_chantClinicalCompositeRecord process(final Skcm_mskcc_2015_chantNormalizedClinicalRecord melanomaClinicalRecord) throws Exception {
         List<String> record = new ArrayList<>();
         // first add sample and patient id to record then iterate through rest of sample header
         record.add(darwinUtils.convertWhitespace(melanomaClinicalRecord.getSAMPLE_ID()).split("\\|")[0]);
@@ -66,8 +66,7 @@ public class Skcm_mskcc_2015_chantClinicalSampleProcessor implements ItemProcess
             // get value by external column header (same as melanoma clinical record field name)
             // field data might contain '|'-delimited values - if only one unique
             // value then use that, otherwise just use the data that's there
-            String extColumn = sampleHeader.get("external_header").get(i+1); // need to shift by one b/c writer removes SAMPLE_ID metadata for header
-            String value = melanomaClinicalRecord.getClass().getMethod("get" + extColumn).invoke(melanomaClinicalRecord).toString();
+            String value = melanomaClinicalRecord.getClass().getMethod("get" + normColumn).invoke(melanomaClinicalRecord).toString();
             Set<String> uniqueValues = new HashSet(Arrays.asList(darwinUtils.convertWhitespace(value).split("\\|")));
             List<String> values = Arrays.asList(value.split("\\|"));
             if (uniqueValues.size() == 1) {

--- a/darwin/src/main/resources/application.properties.EXAMPLE
+++ b/darwin/src/main/resources/application.properties.EXAMPLE
@@ -62,10 +62,6 @@ redcap_login_hidden_input_name=
 
 # RedCap mapping token for ID_MAPPING - any tables that we want to access need to be in this project
 mapping_token=
-# The name of the RedCap project that contains the metadata about the clinical attributes in RedCap
-metadata_project=
-# The name of the RedCap project that contains the namespace mapping of external column headers to normalized
-namespace_project=
 
 # email properties
 email.server=localhost

--- a/import-scripts/create_case_lists_by_cancer_type.py
+++ b/import-scripts/create_case_lists_by_cancer_type.py
@@ -21,7 +21,7 @@
 # belong to PATIENT_ID
 # 
 # As a special case, if the attribute is
-# 12_245_PART_C_CONSENTED then only the value "YES" is
+# PART_C_CONSENTED_12_245 then only the value "YES" is
 # written to a case list, with a name containing "germline"
 # ---------------------------------------------------------------
 
@@ -139,10 +139,10 @@ def create_case_lists(clinical_file_name, output_directory, study_id, attribute)
         case_lists_map = create_case_lists_map(clinical_file_name, attribute)
         # We do not want to filter off the value of the attribute in the case of case lists by cancer type - we want them all, so pass None as the filter
         write_case_list_files(case_lists_map, output_directory, study_id, 'Tumor Type: ', 'All tumors with cancer type ', None)
-    elif attribute == '12_245_PARTC_CONSENTED':
+    elif attribute == 'PARTC_CONSENTED_12_245':
         case_lists_map = create_case_lists_map(clinical_file_name, attribute, 'YES')
-        # If we want germline case list, the value of the column '12_245_PART_C_CONSENTED' will be YES or NO. Samples with YES for that value are the ones to add to the list
-        write_case_list_files(case_lists_map, output_directory, study_id, 'Tumors with germline data 12_245_PARTC_CONSENTED ', 'Tumors with germline data available 12_245_PARTC_CONSENTED ', 'YES', 'germline')
+        # If we want germline case list, the value of the column 'PART_C_CONSENTED_12_245' will be YES or NO. Samples with YES for that value are the ones to add to the list
+        write_case_list_files(case_lists_map, output_directory, study_id, 'Tumors with germline data PARTC_CONSENTED_12_245 ', 'Tumors with germline data available PARTC_CONSENTED_12_245 ', 'YES', 'germline')
     else:
         print >> ERROR_FILE, "Error : case lists cannot be generated for attribute " + attribute
         sys.exit(2)

--- a/import-scripts/import-dmp-impact-data.sh
+++ b/import-scripts/import-dmp-impact-data.sh
@@ -26,7 +26,7 @@ function addCancerTypeCaseLists {
     $PYTHON_BINARY $PORTAL_HOME/scripts/oncotree_code_converter.py --oncotree-url "http://oncotree.mskcc.org/oncotree/" --oncotree-version $ONCOTREE_VERSION_TO_USE --clinical-file $FILEPATH_1 --force
     $PYTHON_BINARY $PORTAL_HOME/scripts/create_case_lists_by_cancer_type.py --clinical-file-list="$CLINICAL_FILE_LIST" --output-directory="$STUDY_DATA_DIRECTORY/case_lists" --study-id="$STUDY_ID" --attribute="CANCER_TYPE"
     if [ "$STUDY_ID" == "mskimpact" ] || [ "$STUDY_ID" == "mixedpact" ] ; then
-       $PYTHON_BINARY $PORTAL_HOME/scripts/create_case_lists_by_cancer_type.py --clinical-file-list="$CLINICAL_FILE_LIST" --output-directory="$STUDY_DATA_DIRECTORY/case_lists" --study-id="$STUDY_ID" --attribute="12_245_PARTC_CONSENTED"
+       $PYTHON_BINARY $PORTAL_HOME/scripts/create_case_lists_by_cancer_type.py --clinical-file-list="$CLINICAL_FILE_LIST" --output-directory="$STUDY_DATA_DIRECTORY/case_lists" --study-id="$STUDY_ID" --attribute="PARTC_CONSENTED_12_245"
     fi
 }
 

--- a/import-scripts/set_custom_overrides.py
+++ b/import-scripts/set_custom_overrides.py
@@ -43,7 +43,7 @@ def createDefaultMskimpactMetadataMap():
         },
         "ATTRIBUTE_TYPE" : {},
         "PRIORITY" : {
-            "12_245_PARTC_CONSENTED" : "1",
+            "PARTC_CONSENTED_12_245" : "1",
             "AGE_CURRENT" : "1",
             "CANCER_TYPE" : "1",
             "CANCER_TYPE_DETAILED" : "1",

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/RedcapPipeline.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/RedcapPipeline.java
@@ -85,6 +85,7 @@ public class RedcapPipeline {
     private static void checkIfProjectOrStableIdExistsAndExit(String[] args, CommandLine commandLine)
     {
         SpringApplication app = new SpringApplication(RedcapPipeline.class);
+        app.setWebEnvironment(false);
         ConfigurableApplicationContext ctx = app.run(args);
         String projectTitle = commandLine.getOptionValue("redcap-project-title");
         String stableId = commandLine.getOptionValue("stable-id");
@@ -112,6 +113,7 @@ public class RedcapPipeline {
     private static void launchJob(String[] args, char executionMode, CommandLine commandLine) throws Exception
     {
         SpringApplication app = new SpringApplication(RedcapPipeline.class);
+        app.setWebEnvironment(false);
         ConfigurableApplicationContext ctx = app.run(args);
         JobLauncher jobLauncher = ctx.getBean(JobLauncher.class);
         JobParametersBuilder builder = new JobParametersBuilder();

--- a/redcap/redcap_pipeline/src/main/resources/application.properties.EXAMPLE
+++ b/redcap/redcap_pipeline/src/main/resources/application.properties.EXAMPLE
@@ -16,7 +16,14 @@ redcap_login_hidden_input_name=
 
 # RedCap mapping token for ID_MAPPING - any tables that we want to access need to be in this project
 mapping_token=
-# The name of the RedCap project that contains the metadata about the clinical attributes in RedCap
-metadata_project=
-# The name of the RedCap project that contains the namespace mapping of external column headers to normalized
-namespace_project=
+
+# google docs credentials
+google.id=
+google.pw=
+
+# google docs portal importer configuration worksheet
+importer.google.service.private.key.file=
+importer.google.service.email=
+importer.spreadsheet_service_appname=
+importer.spreadsheet=
+importer.clinical_attributes_worksheet=

--- a/redcap/redcap_pipeline/src/test/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReaderTest.java
+++ b/redcap/redcap_pipeline/src/test/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017-2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -53,7 +53,7 @@ public class ClinicalDataReaderTest {
     @Autowired
     private ClinicalDataReader clinicalDataReader;
 
-    /** This test reads two mocked redcap projects, one of which has no SAMPLE_ID attribute.
+    /** This test reads a set of mocked redcap projects.
      * Proper output is expected. In particular, no records should be missing the SAMPLE_ID field.
      */
     @Test
@@ -63,6 +63,7 @@ public class ClinicalDataReaderTest {
         StringBuilder errorMessage = new StringBuilder("\nFailures:\n");
         int failCount = 0;
         Map<String, Map<String, String>> expectedSampleToRecordMap = makeExpectedSampleToRecordMap();
+        // reads data from makeMockGbmSampleData() and makeMockGbmPatientData() in ClinicalDataReaderTestConfiguration
         Map<String, Map<String, String>> returnedSampleToRecordMap = new HashMap<>();
         // compare returned values to expected
         while (true) {

--- a/redcap/redcap_pipeline/src/test/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReaderTestConfiguration.java
+++ b/redcap/redcap_pipeline/src/test/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReaderTestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017-2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -44,6 +44,7 @@ import org.mskcc.cmo.ks.redcap.pipeline.ClinicalDataReader;
 import org.mskcc.cmo.ks.redcap.pipeline.util.RedcapUtils;
 import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
 import org.mskcc.cmo.ks.redcap.source.internal.ClinicalDataSourceRedcapImpl;
+import org.mskcc.cmo.ks.redcap.source.internal.GoogleSessionManager;
 import org.mskcc.cmo.ks.redcap.source.internal.MetadataCache;
 import org.mskcc.cmo.ks.redcap.source.internal.MetadataManagerRedcapImpl;
 import org.mskcc.cmo.ks.redcap.source.internal.RedcapRepository;
@@ -86,6 +87,15 @@ public class ClinicalDataReaderTestConfiguration {
     }
 
     @Bean
+    public GoogleSessionManager googleSessionManager() {
+        GoogleSessionManager googleSessionManager = Mockito.mock(GoogleSessionManager.class);
+        //configure meta data requests
+        RedcapAttributeMetadata[] mockReturnForGetMetadata = makeMockMetadata();
+        Mockito.when(googleSessionManager.getRedcapMetadata()).thenReturn(mockReturnForGetMetadata);
+        return googleSessionManager;
+    }
+
+    @Bean
     public MetadataCache metadataCache() {
         return new MetadataCache();
     }
@@ -116,13 +126,8 @@ public class ClinicalDataReaderTestConfiguration {
         //configure token requests
         Mockito.when(mockRedcapSessionManager.getTokenByProjectTitle(ArgumentMatchers.eq(MSKIMPACT_GBM_SAMPLE_CLINICAL_PROJECT_TITLE))).thenReturn(MSKIMPACT_GBM_SAMPLE_CLINICAL_PROJECT_TOKEN);
         Mockito.when(mockRedcapSessionManager.getTokenByProjectTitle(ArgumentMatchers.eq(MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TITLE))).thenReturn(MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TOKEN);
-        Mockito.when(mockRedcapSessionManager.getMetadataToken()).thenReturn(METADATA_TOKEN);
-        Mockito.when(mockRedcapSessionManager.getNamespaceToken()).thenReturn(NAMESPACE_TOKEN);
         Mockito.when(mockRedcapSessionManager.getTimelineTokenMapByStableId(ArgumentMatchers.eq(REDCAP_STABLE_ID))).thenReturn(makeMockTimelineTokenMap());
         Mockito.when(mockRedcapSessionManager.getClinicalTokenMapByStableId(ArgumentMatchers.eq(REDCAP_STABLE_ID))).thenReturn(makeMockClinicalTokenMap());
-        //configure meta data requests
-        Mockito.when(mockRedcapSessionManager.getRedcapMetadataByToken(ArgumentMatchers.eq(METADATA_TOKEN))).thenReturn(makeMockMetadata());
-        Mockito.when(mockRedcapSessionManager.getRedcapNamespace()).thenReturn(makeMockNamespace());
         //configure redcap data requests
         Mockito.when(mockRedcapSessionManager.getRedcapAttributeByToken(ArgumentMatchers.eq(MSKIMPACT_GBM_SAMPLE_CLINICAL_PROJECT_TOKEN))).thenReturn(makeMockGbmSampleAttributesData());
         Mockito.when(mockRedcapSessionManager.getRedcapAttributeByToken(ArgumentMatchers.eq(MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TOKEN))).thenReturn(makeMockGbmPatientAttributesData());
@@ -149,30 +154,21 @@ public class ClinicalDataReaderTestConfiguration {
     private RedcapAttributeMetadata[] makeMockMetadata() {
         RedcapAttributeMetadata[] metadata = new RedcapAttributeMetadata[4];
         metadata[0] = new RedcapAttributeMetadata();
-        metadata[0].setRecordId(1L);
         metadata[0].setNormalizedColumnHeader("PATIENT_ID");
-        metadata[0].setExternalColumnHeader("PATIENT_ID");
-        metadata[0].setRedcapId("patient_id");
         metadata[0].setAttributeType("PATIENT");
         metadata[0].setPriority("1");
         metadata[0].setDisplayName("Patient Id");
         metadata[0].setDatatype("STRING");
         metadata[0].setDescriptions("This identifies a patient");
         metadata[1] = new RedcapAttributeMetadata();
-        metadata[1].setRecordId(2L);
         metadata[1].setNormalizedColumnHeader("CANCER_TYPE");
-        metadata[1].setExternalColumnHeader("CANCER_TYPE");
-        metadata[1].setRedcapId("cancer_type");
         metadata[1].setAttributeType("SAMPLE");
         metadata[1].setPriority("1");
         metadata[1].setDisplayName("cancer type");
         metadata[1].setDatatype("STRING");
         metadata[1].setDescriptions("cancer type");
         metadata[2] = new RedcapAttributeMetadata();
-        metadata[2].setRecordId(3L);
         metadata[2].setNormalizedColumnHeader("AGE");
-        metadata[2].setExternalColumnHeader("AGE");
-        metadata[2].setRedcapId("age");
         metadata[2].setAttributeType("PATIENT");
         metadata[2].setPriority("1");
         metadata[2].setDisplayName("AGE");
@@ -180,10 +176,7 @@ public class ClinicalDataReaderTestConfiguration {
         metadata[2].setDescriptions("Patient age in years");
         //Added the following for getSampleHeader() / getPatientHeader() tests
         metadata[3] = new RedcapAttributeMetadata();
-        metadata[3].setRecordId(4L);
         metadata[3].setNormalizedColumnHeader("SAMPLE_ID");
-        metadata[3].setExternalColumnHeader("SAMPLE_ID");
-        metadata[3].setRedcapId("sample_id");
         metadata[3].setAttributeType("SAMPLE");
         metadata[3].setPriority("1");
         metadata[3].setDisplayName("Sample Id");

--- a/redcap/redcap_source/pom.xml
+++ b/redcap/redcap_source/pom.xml
@@ -11,11 +11,51 @@
     <version>0.1.0</version>
   </parent>
 
+
+  <!-- repositories -->
+  <repositories>
+    <repository>
+      <id>gdata-maven-github</id>
+      <name>Google Gdata Maven Repository</name>
+      <url>https://raw.github.com/eburtsev/gdata-maven/master/</url>
+    </repository>
+  </repositories>
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <spring.social.version>1.1.0.RELEASE</spring.social.version>
+    <org.springframework.social.google-version>1.0.0.RELEASE</org.springframework.social.google-version>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <guava.version>19.0-rc2</guava.version>
   </properties>
   <dependencies>
+    <!-- spring -->
+    <dependency>
+      <groupId>org.springframework.social</groupId>
+      <artifactId>spring-social-config</artifactId>
+      <version>${spring.social.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.social</groupId>
+      <artifactId>spring-social-core</artifactId>
+      <version>${spring.social.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.social</groupId>
+      <artifactId>spring-social-security</artifactId>
+      <version>${spring.social.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.social</groupId>
+      <artifactId>spring-social-web</artifactId>
+      <version>${spring.social.version}</version>
+    </dependency>
+    <!-- Spring Social Google-->
+    <dependency>
+      <groupId>org.springframework.social</groupId>
+      <artifactId>spring-social-google</artifactId>
+      <version>${org.springframework.social.google-version}</version>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
@@ -34,6 +74,29 @@
       <artifactId>commons-text</artifactId>
       <version>1.1</version>
     </dependency>
+    <!-- google -->
+    <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>com.google.gdata</groupId>
+        <artifactId>core</artifactId>
+        <version>1.47.1</version>
+    </dependency>
+    <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client</artifactId>
+        <version>1.19.0</version>
+        <type>jar</type>
+     </dependency>
+     <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-jackson</artifactId>
+        <version>1.19.0</version>
+        <type>jar</type>
+     </dependency>
   </dependencies>
 
   <build>

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/models/RedcapAttributeMetadata.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/models/RedcapAttributeMetadata.java
@@ -45,24 +45,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({
-    "record_id",
-    "external_column_header",
     "normalized_column_header",
     "display_name",
     "descriptions",
     "datatype",
     "attribute_type",
     "priority",
-    "note",
-    "redcap_id",
-    "clinical_metadata_complete"
 })
 public class RedcapAttributeMetadata {
 
-    @JsonProperty("record_id")
-    private Long recordId;
-    @JsonProperty("external_column_header")
-    private String externalColumnHeader;
     @JsonProperty("normalized_column_header")
     private String normalizedColumnHeader;
     @JsonProperty("display_name")
@@ -75,12 +66,6 @@ public class RedcapAttributeMetadata {
     private String attributeType;
     @JsonProperty("priority")
     private String priority;
-    @JsonProperty("note")
-    private String note;
-    @JsonProperty("redcap_id")
-    private String redcapId;
-    @JsonProperty("clinical_metadata_complete")
-    private String clinicalMetadataComplete;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
@@ -92,70 +77,20 @@ public class RedcapAttributeMetadata {
 
     /**
     *
-    * @param recordId
     * @param normalizedColumnHeader
-    * @param clinicalMetadataComplete
-    * @param externalColumnHeader
     * @param priority
     * @param attributeType
     * @param datatype
     * @param displayName
-    * @param note
-    * @param redcapId
     * @param descriptions
     */
-    public RedcapAttributeMetadata(Long recordId, String externalColumnHeader, String normalizedColumnHeader, String displayName, String descriptions, String datatype, String attributeType, String priority, String note, String redcapId, String clinicalMetadataComplete) {
-        this.recordId = recordId;
-        this.externalColumnHeader = externalColumnHeader;
+    public RedcapAttributeMetadata(String normalizedColumnHeader, String displayName, String descriptions, String datatype, String attributeType, String priority) {
         this.normalizedColumnHeader = normalizedColumnHeader;
         this.displayName = displayName;
         this.descriptions = descriptions;
         this.datatype = datatype;
         this.attributeType = attributeType;
         this.priority = priority;
-        this.note = note;
-        this.redcapId = redcapId;
-        this.clinicalMetadataComplete = clinicalMetadataComplete;
-    }
-
-    /**
-    *
-    * @return
-    * The recordId
-    */
-    @JsonProperty("record_id")
-    public Long getRecordId() {
-        return recordId;
-    }
-
-    /**
-    *
-    * @param recordId
-    * The record_id
-    */
-    @JsonProperty("record_id")
-    public void setRecordId(Long recordId) {
-        this.recordId = recordId;
-    }
-
-    /**
-    *
-    * @return
-    * The externalColumnHeader
-    */
-    @JsonProperty("external_column_header")
-    public String getExternalColumnHeader() {
-        return externalColumnHeader;
-    }
-
-    /**
-    *
-    * @param externalColumnHeader
-    * The external_column_header
-    */
-    @JsonProperty("external_column_header")
-    public void setExternalColumnHeader(String externalColumnHeader) {
-        this.externalColumnHeader = externalColumnHeader;
     }
 
     /**
@@ -276,66 +211,6 @@ public class RedcapAttributeMetadata {
     @JsonProperty("priority")
     public void setPriority(String priority) {
         this.priority = priority;
-    }
-
-    /**
-    *
-    * @return
-    * The note
-    */
-    @JsonProperty("note")
-    public String getNote() {
-        return note;
-    }
-
-    /**
-    *
-    * @param note
-    * The note
-    */
-    @JsonProperty("note")
-    public void setNote(String note) {
-        this.note = note;
-    }
-
-    /**
-    *
-    * @return
-    * The note
-    */
-    @JsonProperty("redcap_id")
-    public String getRedcapId() {
-        return redcapId;
-    }
-
-    /**
-    *
-    * @param note
-    * The note
-    */
-    @JsonProperty("redcap_id")
-    public void setRedcapId(String redcapId) {
-        this.redcapId = redcapId;
-    }
-
-    /**
-    *
-    * @return
-    * The clinicalMetadataComplete
-    */
-    @JsonProperty("clinical_metadata_complete")
-    public String getClinicalMetadataComplete() {
-        return clinicalMetadataComplete;
-    }
-
-    /**
-    *
-    * @param clinicalMetadataComplete
-    * The clinical_metadata_complete
-    */
-    @JsonProperty("clinical_metadata_complete")
-    public void setClinicalMetadataComplete(String clinicalMetadataComplete) {
-        this.clinicalMetadataComplete = clinicalMetadataComplete;
     }
 
     @JsonAnyGetter

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceRedcapImpl.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceRedcapImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 - 2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -303,20 +303,14 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
         combinedHeader = makeHeader(combinedAttributeMap);
     }
 
+    //change so that redcap ids are just lower cased "externalFieldNames"
     public String[] externalFieldNamesToRedcapFieldIds(String[] externalFieldNames) {
         if (externalFieldNames == null) {
             return new String[0];
         }
         String[] redcapFieldIds = new String[externalFieldNames.length];
         for (int i = 0; i < externalFieldNames.length; i++) {
-            RedcapAttributeMetadata metadataForField = metadataCache.getMetadataByExternalColumnHeader(externalFieldNames[i]);
-            if (metadataForField == null) {
-                String errorString = "Error : attempt to persist file to RedCap failed due to external field name " +
-                        externalFieldNames[i] + " not having metadata defined in the RedCap Metadata Project";
-                log.warn(errorString);
-                throw new RuntimeException(errorString);
-            }
-            redcapFieldIds[i] = metadataForField.getRedcapId();
+            redcapFieldIds[i] =  metadataCache.getMetadataByNormalizedColumnHeader(externalFieldNames[i]).getNormalizedColumnHeader().toLowerCase();
         }
         return redcapFieldIds;
     }
@@ -361,7 +355,6 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
         List<String> descriptions = new ArrayList<>();
         List<String> datatypes = new ArrayList<>();
         List<String> priorities = new ArrayList<>();
-        List<String> externalHeader = new ArrayList<>();
         List<String> header = new ArrayList<>();
 
         for (int i=0; i<fullHeader.get("header").size(); i++) {
@@ -370,7 +363,6 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
                 descriptions.add(fullHeader.get("descriptions").get(i));
                 datatypes.add(fullHeader.get("datatypes").get(i));
                 priorities.add(fullHeader.get("priorities").get(i));
-                externalHeader.add(fullHeader.get("external_header").get(i));
                 header.add(fullHeader.get("header").get(i));
             }
         }
@@ -378,7 +370,6 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
         fullPatientHeader.put("descriptions", descriptions);
         fullPatientHeader.put("datatypes", datatypes);
         fullPatientHeader.put("priorities", priorities);
-        fullPatientHeader.put("external_header", externalHeader);
         fullPatientHeader.put("header", header);
         return fullPatientHeader;
     }
@@ -394,7 +385,6 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
         List<String> descriptions = new ArrayList<>();
         List<String> datatypes = new ArrayList<>();
         List<String> priorities = new ArrayList<>();
-        List<String> externalHeader = new ArrayList<>();
         List<String> header = new ArrayList<>();
 
         for (int i=0; i<fullHeader.get("header").size(); i++) {
@@ -403,7 +393,6 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
                 descriptions.add(fullHeader.get("descriptions").get(i));
                 datatypes.add(fullHeader.get("datatypes").get(i));
                 priorities.add(fullHeader.get("priorities").get(i));
-                externalHeader.add(fullHeader.get("external_header").get(i));
                 header.add(fullHeader.get("header").get(i));
             }
         }
@@ -411,7 +400,6 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
         fullSampleHeader.put("descriptions", descriptions);
         fullSampleHeader.put("datatypes", datatypes);
         fullSampleHeader.put("priorities", priorities);
-        fullSampleHeader.put("external_header", externalHeader);
         fullSampleHeader.put("header", header);
         return fullSampleHeader;
     }

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/GoogleSessionManager.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/GoogleSessionManager.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.redcap.source.internal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.gdata.client.spreadsheet.*;
+import com.google.gdata.data.spreadsheet.*;
+import com.google.gdata.util.common.base.Preconditions;
+import java.io.*;
+import java.net.*;
+import java.security.GeneralSecurityException;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.logging.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.logging.*;
+import org.mskcc.cmo.ks.redcap.models.ProjectInfoResponse;
+import org.mskcc.cmo.ks.redcap.models.RedcapAttributeMetadata;
+import org.mskcc.cmo.ks.redcap.models.RedcapProjectAttribute;
+import org.mskcc.cmo.ks.redcap.models.RedcapToken;
+import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.http.*;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Repository
+public class GoogleSessionManager {
+
+    @Value("${google.id}")
+    private String googleId;
+    @Value("${google.pw}")
+    private String googlePw;
+    @Value("${importer.spreadsheet_service_appname}")
+    private String appName;
+    @Value("${importer.spreadsheet}")
+    private String gdataSpreadsheet;
+    @Value("${importer.google.service.email}")
+    private String googleServiceEmail;
+    @Value("${importer.google.service.private.key.file}")
+    private String googleServicePrivateKeyFile;
+    @Value ("${importer.clinical_attributes_worksheet}")
+    private String clinicalAttributesWorksheet;
+
+    private SpreadsheetService spreadsheetService;
+    private ArrayList<ArrayList<String>> clinicalAttributesMatrix;
+
+    private static Log LOG = LogFactory.getLog(GoogleSessionManager.class);
+
+    public SpreadsheetService getService() {
+	if (spreadsheetService == null) {
+	    initService();
+	}
+	return spreadsheetService;
+    }
+
+    private void initService() {
+        try {
+	    HttpTransport httpTransport = new NetHttpTransport();
+	    JacksonFactory jsonFactory = new JacksonFactory();
+	    String [] SCOPESArray= {"https://spreadsheets.google.com/feeds", "https://docs.google.com/feeds"};
+	    final List SCOPES = Arrays.asList(SCOPESArray);
+	    GoogleCredential credential = new GoogleCredential.Builder()
+		.setTransport(httpTransport)
+	        .setJsonFactory(jsonFactory)
+		.setServiceAccountId(googleServiceEmail)
+		.setServiceAccountScopes(SCOPES)
+		.setServiceAccountPrivateKeyFromP12File(new File(googleServicePrivateKeyFile)).build();
+	    spreadsheetService = new SpreadsheetService("data");
+	    spreadsheetService.setOAuth2Credentials(credential);
+	}
+	catch (IOException | GeneralSecurityException e) {
+	    e.printStackTrace();
+	}
+    }
+
+    /**
+     * Gets an array of RedcapAttributeMetadata.
+     * @return RedcapAttributeMetadata[] array 
+     */
+    public RedcapAttributeMetadata[] getRedcapMetadata() {
+        // generate matrix representing each record in metadata worksheet
+        if (clinicalAttributesMatrix == null) {
+            clinicalAttributesMatrix = getWorksheetData(gdataSpreadsheet, clinicalAttributesWorksheet);
+        }
+        // initialize array to store all metadata bojects
+        RedcapAttributeMetadata[] redcapAttributeMetadataList = getRedcapAttributeMetadataFromMatrix(clinicalAttributesMatrix);
+        return redcapAttributeMetadataList; // if user wants all, we're done
+    }
+
+    /**
+     * Constructs a collection of objects of the given classname from the given matrix.
+     *
+     * @param metadataMatrix ArrayList<ArrayList<String>>
+     * @return RedcapAttributeMetadata[] array
+     */
+    private RedcapAttributeMetadata[] getRedcapAttributeMetadataFromMatrix(ArrayList<ArrayList<String>> metadataMatrix) {
+        RedcapAttributeMetadata[] redcapAttributeMetadataList = new RedcapAttributeMetadata[metadataMatrix.size() - 1];
+        // we start at one and subtract 1 from metadataMatrix size because row 0 is the column headers
+        for (int row = 1; row < metadataMatrix.size(); row++) {
+            ArrayList<String> record = metadataMatrix.get(row);
+            RedcapAttributeMetadata redcapAttributeMetadata = new RedcapAttributeMetadata(record.get(0),
+                record.get(1),
+                record.get(2),
+                record.get(3),
+                record.get(4),
+                record.get(5));
+            redcapAttributeMetadataList[row - 1] = redcapAttributeMetadata;
+        }
+        return redcapAttributeMetadataList;
+    }
+
+    /**
+     * Gets the spreadsheet.
+     *
+     * @param spreadsheetName String
+     * @returns SpreadsheetEntry
+     * @throws Exception
+     */
+    private SpreadsheetEntry getSpreadsheet(String spreadsheetName) throws Exception {
+        FeedURLFactory factory = FeedURLFactory.getDefault();
+        SpreadsheetFeed feed = null;
+        // error happens here
+        feed = spreadsheetService.getFeed(factory.getSpreadsheetsFeedUrl(), SpreadsheetFeed.class);
+        for (SpreadsheetEntry entry : feed.getEntries()) {
+            System.out.println(entry.getTitle().getPlainText());
+            if (entry.getTitle().getPlainText().equals(spreadsheetName)) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets the worksheet feed.
+     *
+     * @param spreadsheetName String
+     * @param worksheetName String
+     * @returns WorksheetFeed
+     * @throws Exception
+     */
+    private WorksheetEntry getWorksheet(String spreadsheetName, String worksheetName) throws Exception {
+        // first get the spreadsheet
+        SpreadsheetEntry spreadsheet = getSpreadsheet(spreadsheetName);
+        if (spreadsheet != null) {
+            WorksheetFeed worksheetFeed = spreadsheetService.getFeed(spreadsheet.getWorksheetFeedUrl(), WorksheetFeed.class);
+            for (WorksheetEntry worksheet : worksheetFeed.getEntries()) {
+                if (worksheet.getTitle().getPlainText().equals(worksheetName)) {
+                    return worksheet;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     *
+     * @param worksheetName
+     * @param columnName
+     * @return A List of String values from a specified column in a specified worksheet
+     *
+     */
+    private List<String> getWorksheetDataByColumnName(String worksheetName, String columnName) {
+        com.google.common.base.Preconditions.checkState(!Strings.isNullOrEmpty(this.gdataSpreadsheet),
+                "The Google spreadsheet has not been defined.");
+        com.google.common.base.Preconditions.checkArgument(!Strings.isNullOrEmpty(worksheetName),
+                "A worksheet name is required");
+        com.google.common.base.Preconditions.checkArgument(!Strings.isNullOrEmpty(columnName),
+                "A worksheet column name is required");
+        return null;
+    }
+
+    /**
+     * Helper function to retrieve the given google worksheet data matrix. as a
+     * list of string lists.
+     *
+     * @param spreadsheetName String
+     * @param worksheetName String
+     * @return ArrayList<ArrayList<String>>
+     */
+    private ArrayList<ArrayList<String>> getWorksheetData(String spreadsheetName, String worksheetName) {
+        this.spreadsheetService = getService();
+        ArrayList<ArrayList<String>> toReturn = new ArrayList<ArrayList<String>>();
+        if (LOG.isInfoEnabled()) {
+            LOG.info("getWorksheetData(): " + spreadsheetName + ", " + worksheetName);
+        }
+        try {
+            //login();
+            WorksheetEntry worksheet = getWorksheet(spreadsheetName, worksheetName);
+            if (worksheet != null) {
+                ListFeed feed = spreadsheetService.getFeed(worksheet.getListFeedUrl(), ListFeed.class);
+                if (feed != null && feed.getEntries().size() > 0) {
+                    boolean needHeaders = true;
+                    for (ListEntry entry : feed.getEntries()) {
+                        if (needHeaders) {
+                            ArrayList<String> headers = new ArrayList<String>(entry.getCustomElements().getTags());
+                            toReturn.add(headers);
+                            needHeaders = false;
+                        }
+                        ArrayList<String> customElements = new ArrayList<String>();
+                        for (String tag : toReturn.get(0)) {
+                            String value = entry.getCustomElements().getValue(tag);
+                            if (value == null) {
+                                value = "";
+                            }
+                            customElements.add(value);
+                        }
+                        toReturn.add(customElements);
+                    }
+                } else {
+                    if (LOG.isInfoEnabled()) {
+                        LOG.info("Worksheet contains no entries!");
+                    }
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Problem connecting to " + spreadsheetName + ":" + worksheetName);
+            throw new RuntimeException(e);
+        }
+        return toReturn;
+    }
+}

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepository.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017 - 2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -74,13 +74,15 @@ public class RedcapRepository {
             while (redcapNodeIterator.hasNext()) {
                 Map.Entry<String, JsonNode> entry = (Map.Entry<String, JsonNode>)redcapNodeIterator.next();
                 String redcapId = entry.getKey();
-                RedcapAttributeMetadata metadata = metadataCache.getMetadataByRedcapId(redcapId);
-                if (metadata == null) {
-                    if (redcapId.equals(redcapInstrumentCompleteFieldName)) {
-                        continue;
-                    }
-                    String errorString = "Error : attempt to export data from RedCap failed due to redcap_id " +
-                            redcapId + " not having metadata defined in the RedCap Metadata Project";
+                RedcapAttributeMetadata metadata = null;
+                if (redcapId.equals(redcapInstrumentCompleteFieldName)) {
+                    continue;
+                }
+                try {
+                    metadata = metadataCache.getMetadataByRedcapId(redcapId);
+                } catch (RuntimeException e) {
+                    String errorString = "Error: attempt to export data from redcap failed due to redcap_id " +
+                            redcapId + " not having metadata defined in the Google clinical attributes worksheet";
                     log.warn(errorString);
                     throw new RuntimeException(errorString);
                 }

--- a/redcap/redcap_source/src/test/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepositoryTest.java
+++ b/redcap/redcap_source/src/test/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017-2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -49,9 +49,8 @@ public class RedcapRepositoryTest {
     @Autowired
     private RedcapRepository redcapRepository;
 
-    /* This test mocks the RedcapSessionManager to add a project with fields {"PATIENT_ID", "CRDB_CONSENT_DATE_DAYS", "12_245_PARTA_CONSENTED"}.
-     * getRedcapDataForProject() is called to test whether the mocked data is returned for all fields, including fields which begin with a digit
-     * The proper resolution of redcap_id to EXTERNAL_COLUMN_HEADER should happen within this method.
+    /* This test mocks the RedcapSessionManager to add a project with fields {"PATIENT_ID", "CRDB_CONSENT_DATE_DAYS", "PARTA_CONSENTED_12_245"}.
+     * getRedcapDataForProject() is called to test whether the mocked data is returned for all fields.
      */
     @Test
     public void testGetDataForRedcapProjectID() {
@@ -81,16 +80,16 @@ public class RedcapRepositoryTest {
             Map<String, String> dataReturnedItem = dataReturned.get(pos);
             Map<String, String> expectedReturnValueItem = expectedReturnValue.get(pos);
             if (dataReturnedItem.size() != expectedReturnValueItem.size()) {
-                result.append("Different number of attribute for items at index " + Integer.toString(pos) + " returnedItem has (" + Integer.toString(dataReturnedItem.size()) + ") versus expectedItem has  (" + Integer.toString(expectedReturnValueItem.size()) + ")");
+                result.append("\n\tDifferent number of attribute for items at index " + Integer.toString(pos) + " returnedItem has (" + Integer.toString(dataReturnedItem.size()) + ") versus expectedItem has  (" + Integer.toString(expectedReturnValueItem.size()) + ")");
             }
             for (String key : dataReturnedItem.keySet()) {
                 if (!expectedReturnValueItem.containsKey(key)) {
-                    result.append("attribute name '" + key + "' returned but expected value does not contain any key with that name (in record number " + Integer.toString(pos) + ")");
+                    result.append("\n\tattribute name '" + key + "' returned but expected value does not contain any key with that name (in record number " + Integer.toString(pos) + ")");
                 } else {
                     String dataReturnedValue = dataReturnedItem.get(key);
                     String expectedValue = expectedReturnValueItem.get(key);
                     if (!dataReturnedValue.equals(expectedValue)) {
-                        result.append("attribute name '" + key + "' has value '" + dataReturnedValue + "' in returned value in record number " + Integer.toString(pos) + ", but expected value was '" + expectedValue);
+                        result.append("\n\tattribute name '" + key + "' has value '" + dataReturnedValue + "' in returned value in record number " + Integer.toString(pos) + ", but expected value was '" + expectedValue);
                     }
                }
             }
@@ -105,15 +104,15 @@ public class RedcapRepositoryTest {
         Map<String, String> returnValue3 = new HashMap<String, String>();
         returnValue1.put("PATIENT_ID", "P-0000004");
         returnValue1.put("CRDB_CONSENT_DATE_DAYS", "14484");
-        returnValue1.put("12_245_PARTA_CONSENTED", "YES");
+        returnValue1.put("PARTA_CONSENTED_12_245", "YES");
         returnValue.add(returnValue1);
         returnValue2.put("PATIENT_ID", "P-0000012");
         returnValue2.put("CRDB_CONSENT_DATE_DAYS", "21192");
-        returnValue2.put("12_245_PARTA_CONSENTED", "YES");
+        returnValue2.put("PARTA_CONSENTED_12_245", "YES");
         returnValue.add(returnValue2);
         returnValue3.put("PATIENT_ID", "P-9999999");
         returnValue3.put("CRDB_CONSENT_DATE_DAYS", "99999");
-        returnValue3.put("12_245_PARTA_CONSENTED", "");
+        returnValue3.put("PARTA_CONSENTED_12_245", "");
         returnValue.add(returnValue3);
         return returnValue;
     }

--- a/redcap/redcap_source/src/test/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapSourceTestConfiguration.java
+++ b/redcap/redcap_source/src/test/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapSourceTestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017-2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -42,6 +42,7 @@ import org.mskcc.cmo.ks.redcap.models.RedcapAttributeMetadata;
 import org.mskcc.cmo.ks.redcap.models.RedcapProjectAttribute;
 import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
 import org.mskcc.cmo.ks.redcap.source.internal.ClinicalDataSourceRedcapImpl;
+import org.mskcc.cmo.ks.redcap.source.internal.GoogleSessionManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -66,6 +67,15 @@ public class RedcapSourceTestConfiguration {
     }
 
     @Bean
+    public GoogleSessionManager googleSessionManager() {
+        GoogleSessionManager googleSessionManager = Mockito.mock(GoogleSessionManager.class);
+        //configure meta data requests
+        RedcapAttributeMetadata[] mockReturnForGetMetadata = makeMockRedcapIdToMetadataList();
+        Mockito.when(googleSessionManager.getRedcapMetadata()).thenReturn(mockReturnForGetMetadata);
+        return googleSessionManager;
+    }
+
+    @Bean
     public MetadataCache metadataCache() {
         return new MetadataCache();
     }
@@ -82,14 +92,12 @@ public class RedcapSourceTestConfiguration {
         Mockito.when(redcapSessionManager.getClinicalTokenMapByStableId(SIMPLE_MIXED_TYPE_CLINICAL_STABLE_ID)).thenReturn(mockReturnClinicalTokenMap);
         //configure meta data requests
         RedcapAttributeMetadata[] mockReturnForGetMetadata = makeMockRedcapIdToMetadataList();
-        Mockito.when(redcapSessionManager.getRedcapMetadataByToken(Matchers.eq(METADATA_TOKEN))).thenReturn(mockReturnForGetMetadata);
         JsonNode[] mockReturnForGetData = makeMockReturnForGetData();
         //configure data requests
         Mockito.when(redcapSessionManager.getRedcapDataForProjectByToken(Matchers.eq(ONE_DIGIT_PROJECT_TOKEN))).thenReturn(mockReturnForGetData);
         RedcapProjectAttribute[] mockReturnForGetAttributesData = makeMockReturnForGetAttributesData();
         //Mockito.when(redcapSessionManager.getRedcapAttributeByToken(SIMPLE_MIXED_TYPE_CLINICAL_PROJECT_TOKEN)).thenReturn(mockReturnForGetAttributesData);
         Mockito.when(redcapSessionManager.getRedcapAttributeByToken(Matchers.any(String.class))).thenReturn(mockReturnForGetAttributesData);
-        Mockito.when(redcapSessionManager.getMetadataToken()).thenReturn(METADATA_TOKEN);
         Mockito.when(redcapSessionManager.getRedcapInstrumentNameByToken(SIMPLE_MIXED_TYPE_CLINICAL_PROJECT_TOKEN)).thenReturn(SIMPLE_MIXED_TYPE_CLINICAL_PROJECT_INSTRUMENT_NAME);
         return redcapSessionManager;
     }
@@ -102,61 +110,43 @@ public class RedcapSourceTestConfiguration {
     private RedcapAttributeMetadata[] makeMockRedcapIdToMetadataList() {
         RedcapAttributeMetadata[] metadata = new RedcapAttributeMetadata[6];
         metadata[0] = new RedcapAttributeMetadata();
-        metadata[0].setRecordId(1L);
         metadata[0].setNormalizedColumnHeader("PATIENT_ID");
-        metadata[0].setExternalColumnHeader("PATIENT_ID");
-        metadata[0].setRedcapId("patient_id");
         metadata[0].setAttributeType("PATIENT");
         metadata[0].setPriority("1");
         metadata[0].setDisplayName("Patient Id");
         metadata[0].setDatatype("STRING");
         metadata[0].setDescriptions("This identifies a patient");
         metadata[1] = new RedcapAttributeMetadata();
-        metadata[1].setRecordId(2L);
         metadata[1].setNormalizedColumnHeader("CRDB_CONSENT_DATE_DAYS");
-        metadata[1].setExternalColumnHeader("CRDB_CONSENT_DATE_DAYS");
-        metadata[1].setRedcapId("crdb_consent_date_days");
         metadata[1].setAttributeType("PATIENT");
         metadata[1].setPriority("1");
         metadata[1].setDisplayName("crdb consent date days");
         metadata[1].setDatatype("STRING");
         metadata[1].setDescriptions("days since consent");
         metadata[2] = new RedcapAttributeMetadata();
-        metadata[2].setRecordId(3L);
-        metadata[2].setNormalizedColumnHeader("12_245_PARTA_CONSENTED");
-        metadata[2].setExternalColumnHeader("12_245_PARTA_CONSENTED");
-        metadata[2].setRedcapId("parta_consented_12_245");
+        metadata[2].setNormalizedColumnHeader("PARTA_CONSENTED_12_245");
         metadata[2].setAttributeType("PATIENT");
         metadata[2].setPriority("1");
-        metadata[2].setDisplayName("12 245 PARTA CONSENTED");
+        metadata[2].setDisplayName("12-245 Part A Consented");
         metadata[2].setDatatype("STRING");
-        metadata[2].setDescriptions("Flag showing if patient has consented to 12 245 part a");
+        metadata[2].setDescriptions("12-245 Part A Consented Status");
         //Added the following for getSampleHeader() / getPatientHeader() tests
         metadata[3] = new RedcapAttributeMetadata();
-        metadata[3].setRecordId(4L);
         metadata[3].setNormalizedColumnHeader("SAMPLE_ID");
-        metadata[3].setExternalColumnHeader("SAMPLE_ID");
-        metadata[3].setRedcapId("sample_id");
         metadata[3].setAttributeType("SAMPLE");
         metadata[3].setPriority("1");
         metadata[3].setDisplayName("Sample Id");
         metadata[3].setDatatype("STRING");
         metadata[3].setDescriptions("This identifies a sample");
         metadata[4] = new RedcapAttributeMetadata();
-        metadata[4].setRecordId(5L);
         metadata[4].setNormalizedColumnHeader("NECROSIS");
-        metadata[4].setExternalColumnHeader("NECROSIS");
-        metadata[4].setRedcapId("necrosis");
         metadata[4].setAttributeType("SAMPLE");
         metadata[4].setPriority("1");
         metadata[4].setDisplayName("Necrosis");
         metadata[4].setDatatype("STRING");
         metadata[4].setDescriptions("State of tissue");
         metadata[5] = new RedcapAttributeMetadata();
-        metadata[5].setRecordId(6L);
         metadata[5].setNormalizedColumnHeader("ETHNICITY");
-        metadata[5].setExternalColumnHeader("ETHNICITY");
-        metadata[5].setRedcapId("ethnicity");
         metadata[5].setAttributeType("PATIENT");
         metadata[5].setPriority("1");
         metadata[5].setDisplayName("Ethnicity");


### PR DESCRIPTION
metadata cache changed to store only one mapping (normalized column headers to redcap attribute metadata)
references to metadata (i.e looking up metadata by redcap id) changed to use normalized column headers
lookups changed to use simple conversion (i.e lower-casing or upper-casing)
metadata cache initialized through google sheets (clinical attributes worksheet)
dependencies added to pom
RedcapAttributeMetadata model stripped of extraneous attributes (no longer provided in google spreadsheet)
Added additional entires into application properties to be injected 
Added new class to Darwin pipeline to provide mapping for skim_chant project (originally done through the namespace project) 