### PR TITLE
Skip fusion rec's where both genes are null/empty

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataReader.java
@@ -32,6 +32,7 @@
 
 package org.cbioportal.cmo.pipelines.cvr.fusion;
 
+import com.google.common.base.Strings;
 import org.cbioportal.cmo.pipelines.cvr.*;
 import org.cbioportal.cmo.pipelines.cvr.model.*;
 
@@ -118,7 +119,12 @@ public class CVRFusionDataReader implements ItemStreamReader<CVRFusionRecord> {
             String sampleId = result.getMetaData().getDmpSampleId();
             List<CVRSvVariant> variants = result.getSvVariants();
             for (CVRSvVariant variant : variants) {
-
+                // skip records where both gene 1 and gene 2 are null or empty
+                if (Strings.isNullOrEmpty(variant.getSite1_Gene()) && Strings.isNullOrEmpty(variant.getSite2_Gene())) {
+                    log.warn("Skipping fusion record where genes are missing for sample '" + sampleId + "'" + 
+                            (Strings.isNullOrEmpty(variant.getAnnotation()) ? "" :  " - record annotation: " + variant.getAnnotation()));
+                    continue;
+                }
                 CVRFusionRecord record = null;
                 try {
                     record = new CVRFusionRecord(variant, sampleId, false);


### PR DESCRIPTION
Fusion/structural variants are being added to `data_fusions.txt` even when both gene sites are empty/null values. 

Example of missing gene info in `sv-variants` results for a given sample:
```
    "sv-variants" : [ {
      "annotation" : "DIAGNOSTIC INTERPRETATION:\n\nNEGATIVE FOR GENE FUSIONS IN THE CLINICALLY VALIDATED PANEL\n\nNEGATIVE FOR GENE FUSIONS IN THE INVESTIGATIONAL PANEL",
      "comments" : "some made up comments",
      "site1_gene" : "",
      "site2_gene" : "",
      "gene1" : "",
      "gene2" : "",
      "exon1" : "",
      "exon2" : "",
      "sample_comment" : "some made up sample comment",
      "ct" : "24.95",
      "sample_notes" : "some made up sample notes"
    } ]
```

Log warning when fusion record missing gene info is found. Print value in `annotation` if not empty along with sample id.


Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>