### PR TITLE
Cleanup quotation marks from Homo_sapiens.info

### DIFF
--- a/import-scripts/update-gene-data.sh
+++ b/import-scripts/update-gene-data.sh
@@ -19,7 +19,7 @@ gunzip $tmp/Homo_sapiens.gene_info.gz
 gunzip $tmp/ref_GRCh38.p7_top_level.gff3.gz
 echo "Finished!"
 
-sed -i 's/^#//' $tmp/Homo_sapiens.gene_info
+sed -i 's/^#//; s/\"//' $tmp/Homo_sapiens.gene_info
 if [[ !  -f $tmp/Homo_sapiens.gene_info || $(wc -l < $tmp/Homo_sapiens.gene_info) -eq 0 ]]; then
     echo "Error downloading Homo_sapiens.gene_info from NCBI. Exiting..."
     exit 1


### PR DESCRIPTION
A double quotes in a single data row in `Homo_sapiens.info` caused the gene update tool to break when attempting to parse `Homo_sapiens.info`. 

Modified sed statement in `update-gene-data.sh` to cleanup quotes.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>