### PR TITLE
Refresh CDD/ONCOTREE cache before importing.

### DIFF
--- a/import-scripts/import-cmo-data-triage.sh
+++ b/import-scripts/import-cmo-data-triage.sh
@@ -14,6 +14,16 @@ JAVA_PROXY_ARGS="-Dhttp.proxyHost=jxi2.mskcc.org -Dhttp.proxyPort=8080"
 triage_notification_file=$(mktemp $tmp/triage-portal-update-notification.$now.XXXXXX)
 ONCOTREE_VERSION_TO_USE=oncotree_candidate_release
 
+# refresh cdd and oncotree cache
+CDD_ONCOTREE_RECACHE_FAIL=0
+bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
+if [ $? -gt 0 ]; then
+    CDD_ONCOTREE_RECACHE_FAIL=1
+    message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
+    echo $message
+    echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $pipeline_email_list
+fi
+
 # fetch updates in CMO repository
 echo "fetching updates from bic-mskcc..."
 CMO_FETCH_FAIL=0
@@ -138,8 +148,7 @@ then
 fi
 
 # if the database version is correct and ALL fetches succeed, then import
-if [[ $DB_VERSION_FAIL -eq 0 && $CMO_FETCH_FAIL -eq 0 && $PRIVATE_FETCH_FAIL -eq 0 && $GENIE_FETCH_FAIL -eq 0 && $CMO_IMPACT_FETCH_FAIL -eq 0 && $IMPACT_MERGED_FETCH_FAIL -eq 0 && $CBIO_PORTAL_DATA_FETCH_FAIL -eq 0 && $IMMUNOTHERAPY_FETCH_FAIL -eq 0 && $DATAHUB_FETCH_FAIL -eq 0 && $PANCAN_FETCH_FAIL -eq 0 ]]
-then
+if [[ $DB_VERSION_FAIL -eq 0 && $CMO_FETCH_FAIL -eq 0 && $PRIVATE_FETCH_FAIL -eq 0 && $GENIE_FETCH_FAIL -eq 0 && $CMO_IMPACT_FETCH_FAIL -eq 0 && $IMPACT_MERGED_FETCH_FAIL -eq 0 && $CBIO_PORTAL_DATA_FETCH_FAIL -eq 0 && $IMMUNOTHERAPY_FETCH_FAIL -eq 0 && $DATAHUB_FETCH_FAIL -eq 0 && $PANCAN_FETCH_FAIL -eq 0 && $CDD_ONCOTREE_RECACHE_FAIL -eq 0 ]] ; then
     echo "importing study data into triage portal database..."
     IMPORT_FAIL=0
     $JAVA_HOME/bin/java $JAVA_PROXY_ARGS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27183 -Xmx32G -ea -Dspring.profiles.active=dbcp -Djava.io.tmpdir="$tmp" -cp $PORTAL_HOME/lib/triage-cmo-importer.jar org.mskcc.cbio.importer.Admin --update-study-data --portal triage-portal --use-never-import --update-worksheet --notification-file "$triage_notification_file" --oncotree-version ${ONCOTREE_VERSION_TO_USE} --transcript-overrides-source mskcc

--- a/import-scripts/refresh-cdd-oncotree-cache.sh
+++ b/import-scripts/refresh-cdd-oncotree-cache.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
+MAX_ATTEMPTS=5
+
+function usage {
+    echo "refresh-cdd-oncotree-cache.sh"
+    echo -e "\t-h | --help                          prints usage statement and exits"
+    echo -e "\t-c | --cdd-only                      refresh CDD cache only [cannot be used with --oncotree-only]"
+    echo -e "\t-o | --oncotree-only                 refresh Oncotree cache only [cannot be used with --cdd-only]"
+    exit 2
+}
+
+# set default value(s)
+REFRESH_SERVICE="ALL"
+CDD_ONLY=0
+ONCOTREE_ONLY=0
+
+for i in "$@"; do
+case $i in
+    -c|--cdd-only)
+    CDD_ONLY=1
+    REFRESH_SERVICE="CDD"
+    shift
+    ;;
+    -o|--oncotree-only)
+    ONCOTREE_ONLY=1
+    REFRESH_SERVICE="ONCOTREE"
+    shift
+    ;;
+    -h|--help)
+        usage
+    shift
+    ;;
+    *)
+    ;;
+esac
+done
+
+# validate input arguments
+if [[ $CDD_ONLY -eq 1 && $ONCOTREE_ONLY -eq 1 ]]; then
+    echo -e "ERROR: either no arguments or only one argument ('--cdd-only' or '--oncotree-only') can be passed!"
+    usage
+fi
+
+## FUNCTIONS
+
+# Function for alerting pipelines team via slack and email
+function sendFailureMessageSlackEmail {
+    MESSAGE_BODY=$1
+    SUBJECT_MESSAGE=$2
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"[TEST]MSK cBio pipelines recache process status: $MESSAGE_BODY\", \"icon_emoji\": \":fire:\"}" https://hooks.slack.com/services/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
+    echo -e "$MESSAGE_BODY" | mail -s "$SUBJECT_MESSAGE" $EMAIL_LIST
+}
+
+# Function for alerting pipelines team via slack and email
+function sendSuccessMessageSlackEmail {
+    MESSAGE_BODY=$1
+    SUBJECT_MESSAGE=$2
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"[TEST]MSK cBio pipelines recache process status: $MESSAGE_BODY\", \"icon_emoji\": \":arrows_counterclockwise:\"}" https://hooks.slack.com/services/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
+    echo -e "$MESSAGE_BODY" | mail -s "$SUBJECT_MESSAGE" $EMAIL_LIST
+}
+
+function checkServerEndpointResponse {
+    # CHECK SERVER ENDPOINT RESPONSE
+    # (1): SERVICE_NAME:  name of service [CDD, ONCOTREE]
+    # (2): ENDPOINT:      endpoint to use
+    # (3): SERVER_LIST:   list of server names as array
+    SERVICE_NAME=$1
+    ENDPOINT=$2
+    server_args=("$@") # extract server list from server args
+	SERVER_LIST="${server_args[@]:2}"
+
+	CURL_RESPONSES=""
+    return_value=0
+    for server in ${SERVER_LIST[@]} ; do
+    	URL="$server/$ENDPOINT"
+    	echo "Checking $SERVICE_NAME endpoint $ENDPOINT ($URL)..."    	
+	    curl -X GET --header 'Accept: */*' $URL
+	    if [ $? -gt 0 ] ; then
+	        return_value=1
+	    fi
+    done
+    return $return_value
+}
+
+function refreshCache {
+    # REFRESH CACHE FOR A GIVEN SERVICE
+    # (1): SERVICE_NAME:  name of service [CDD, ONCOTREE]
+    # (2): REATTEMPT:     number of reattempts to refresh cache if failure occurs
+    # (3): ENDPOINT:      endpoint to use
+    # (4): SERVER_LIST:   list of server names as array
+    SERVICE_NAME=$1
+    REATTEMPT=$2
+    ENDPOINT=$3
+    server_args=("$@") # extract server list from server args
+	SERVER_LIST="${server_args[@]:3}"
+
+    checkServerEndpointResponse $SERVICE_NAME $ENDPOINT ${SERVER_LIST[@]}; return_value=$?
+
+    if [ $return_value -eq 1 ]; then       
+        if [ $REATTEMPT -gt 0 ] ; then
+            # decrement number of reattempts left and wait 5 seconds before next attempt
+            REATTEMPTS_LEFT=$(($REATTEMPT - 1))
+            CURRENT_ATTEMPT=$(($MAX_ATTEMPTS - $REATTEMPTS_LEFT))
+
+            echo "Reattempting to refresh $SERVICE_NAME cache (reattempt # $CURRENT_ATTEMPT of $MAX_ATTEMPTS)..."
+            sleep 5; refreshCache "$SERVICE_NAME" $REATTEMPTS_LEFT $ENDPOINT ${SERVER_LIST[@]}; return_value=$?
+        else
+		    FAILURE_MESSAGE="Failed to refresh $SERVICE_NAME cache:\n\tendpoint=$ENDPOINT\n\tservers=${SERVER_LIST[@]}"
+		    SUBJECT_MESSAGE="Failed to refresh $SERVICE_NAME cache"
+            sendFailureMessageSlackEmail "$FAILURE_MESSAGE" "$SUBJECT_MESSAGE"
+        fi
+    else
+        echo "$SERVICE_NAME cache refresh successful!"
+    fi
+    return $return_value
+}
+
+function checkForValidStaleCache {
+	# CHECK SERVERS FOR VALID STALE CACHE
+    # REFRESH CACHE FOR A GIVEN SERVICE
+    # (1): SERVICE_NAME:  name of service [CDD, ONCOTREE]
+    # (2): ENDPOINT:      endpoint to use
+    # (3): SERVER_LIST:   list of server names as array	
+    SERVICE_NAME=$1
+    ENDPOINT=$2
+    server_args=("$@") # extract server list from server args
+	SERVER_LIST="${server_args[@]:2}"
+
+	checkServerEndpointResponse $SERVICE_NAME $ENDPOINT ${SERVER_LIST[@]}; return_value=$?
+
+	if [ $return_value -eq 1 ] ; then
+		FAILURE_MESSAGE="Failed to fall back on stale cache for $SERVICE_NAME:\n\tendpoint=$ENDPOINT\n\tservers=${SERVER_LIST[@]}"	
+		FAILURE_MESSAGE="$FAILURE_MESSAGE\n$SERVICE_NAME needs to be refreshed manually!"
+		SUBJECT_MESSAGE="[URGENT] $SERVICE_NAME cache must be reset manually"
+		echo -e $FAILURE_MESSAGE
+		sendFailureMessageSlackEmail "$FAILURE_MESSAGE" "$SUBJECT_MESSAGE"
+	else
+		SUCCESS_MESSAGE="Fallback on stale $SERVICE_NAME cache succeeded! $SERVICE_NAME may need manual refreshing eventually"
+		SUBJECT_MESSAGE="$SERVICE_NAME cache fallback succeeded!"
+		echo -e "$SUCCESS_MESSAGE"
+		sendSuccessMessageSlackEmail "$SUCCESS_MESSAGE" "$SUBJECT_MESSAGE"
+	fi
+	return $return_value
+}
+
+function refreshCddCache {
+    # attempt to recache CDD
+    ENDPOINT="refreshCache"
+    CDD_SERVER1="http://dashi.cbio.mskcc.org:8280/cdd/api"
+    CDD_SERVER2="http://dashi2.cbio.mskcc.org:8280/cdd/api"
+    CDD_SERVER_LIST=($CDD_SERVER1 $CDD_SERVER2)
+    refreshCache "CDD" $MAX_ATTEMPTS $ENDPOINT ${CDD_SERVER_LIST[@]}; return_value=$?
+    if [ $return_value -gt 0 ] ; then
+        # query cdd for known clinical attribute and check response - if still failed then alert pipelines team
+        # that subsequent imports will fail if they require new attributes not stored in cache
+        echo "Recache of CDD attempt failed!"
+        echo "Checking for valid stale cache to fallback on for CDD"
+        KNOWN_WORKING_ENDPOINT="SAMPLE_ID"
+        checkForValidStaleCache "CDD" $KNOWN_WORKING_ENDPOINT ${CDD_SERVER_LIST[@]}; return_value=$?
+    fi
+    return $return_value
+}
+
+function refreshOncotreeCache {
+    # attempt to recache ONCOTREE
+    ENDPOINT="refreshCache"
+    ONCOTREE_SERVER1="http://dashi.cbio.mskcc.org:8280/oncotree/api"
+    ONCOTREE_SERVER2="http://dashi2.cbio.mskcc.org:8280/oncotree/api"
+    ONCOTREE_SERVER_LIST=($ONCOTREE_SERVER1 $ONCOTREE_SERVER2)
+    refreshCache "ONCOTREE" $MAX_ATTEMPTS $ENDPOINT ${ONCOTREE_SERVER_LIST[@]}; return_value=$?
+    if [ $return_value -gt 0 ] ; then
+        # query oncotree for known oncotree code and check response - if still failed then alert pipelines team
+        # that subsequent imports might fail if importer also fails to query oncotree service when
+        # generating oncotree code cache
+        echo "Recache of ONCOTREE attempt failed!"
+        echo "Checking for valid stale cache to fallback on for ONCOTREE"
+        KNOWN_WORKING_ENDPOINT="tumorTypes/search/code/TISSUE?exactMatch=true&levels=0,1"
+        checkForValidStaleCache "ONCOTREE" $KNOWN_WORKING_ENDPOINT ${ONCOTREE_SERVER_LIST[@]}; return_value=$?
+    fi
+    return $return_value
+}
+
+## REFRESH CACHE FOR DESIRED SERVICE(S)
+
+# NOTE: We only really care about stopping the imports when the return value for
+#        'refreshOncotreeCache' is non-zero.
+#
+#         If the CDD service fails to recache then we are okay letting the
+#        imports continue and we will see the error in the importer logs, email, and slack.
+#
+#        However, if the ONCOTREE service fails to recache AND the service failed
+#        to fall back on a 'stale' cache then we want to prevent imports from running
+#        so that the issue can be addressed immediately, perhaps by manually
+#        restarting the oncotree tomcat. Therefore the 'return_value' will only be
+#        overwritten by the 'refreshOncotreeCache' call, and not the 'refreshCddCache'
+#        unless the --cdd-only option was passed.
+
+return_value=0
+case $REFRESH_SERVICE in
+    ALL)
+        refreshCddCache
+        refreshOncotreeCache; return_value=$?
+    ;;
+    CDD)
+        refreshCddCache; return_value=$?
+    ;;
+    ONCOTREE)
+        refreshOncotreeCache; return_value=$?
+    ;;
+    *)
+        # sanity checking that REFRESH_SERVICE gets resolved correctly
+        echo -e "REFRESH_SERVICE is not set to valid value: $REFRESH_SERVICE not in [ALL | CDD | ONCOTREE]"
+        usage
+    ;;
+esac
+exit $return_value


### PR DESCRIPTION
Fallback on stale cache now checks endpoint on all servers for a given service. 

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>