### PR TITLE
cleanup, including unchecked type conversions in redcap_pipeline

### DIFF
--- a/cvr/src/main/resources/log4j.properties
+++ b/cvr/src/main/resources/log4j.properties
@@ -1,6 +1,0 @@
-log4j.rootLogger=DEBUG, a
-
-log4j.appender.a = org.apache.log4j.FileAppender
-log4j.appender.a.File =
-log4j.appender.a.layout = org.apache.log4j.SimpleLayout
-log4j.appender.a.append = true

--- a/darwin/src/main/resources/application.properties.EXAMPLE
+++ b/darwin/src/main/resources/application.properties.EXAMPLE
@@ -50,18 +50,12 @@ darwin.medicaltherapy.skip_negative_dosage_records=true
 # Absoulte URL to the redcap web application
 redcap_base_url=
 redcap_api_url_path=
-# Relative URL path to the erase_project_data php module, and project setup page
-redcap_erase_project_data_url_path=
-redcap_project_setup_url_path=
-# If http method is POST (redcap_v7), a token is first obtained from project setup page, when GET (redcap_v6) the request goes only to the erase data module
-redcap_erase_project_data_http_method=
-# Superuser login is needed to get a session id to set cookie headers for the request to erase project data to succeed
-redcap_username=
-redcap_password=
-redcap_login_hidden_input_name=
 
 # RedCap mapping token for ID_MAPPING - any tables that we want to access need to be in this project
 mapping_token=
+
+# cdd metadata api
+cdd_base_url=
 
 # email properties
 email.server=localhost

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <properties>
-    <java.version>1.7</java.version>
+    <spring.version>4.3.14.RELEASE</spring.version>
   </properties>
 
   <dependencies>

--- a/redcap/redcap_pipeline/pom.xml
+++ b/redcap/redcap_pipeline/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <spring.version>4.3.14.RELEASE</spring.version>
   </properties>
   <dependencies>
     <dependency>
@@ -63,7 +62,7 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
-          <compilerArgument>-Xlint:deprecation</compilerArgument>
+          <compilerArgument>-Xlint:deprecation,unchecked</compilerArgument>
         </configuration>
       </plugin>
     </plugins>

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/BatchConfiguration.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/BatchConfiguration.java
@@ -173,9 +173,11 @@ public class BatchConfiguration {
 
     @Bean
     @StepScope
-    public ItemProcessor clinicalDataProcessor() {
-        CompositeItemProcessor processor = new CompositeItemProcessor();
-        List<ItemProcessor> delegates = new ArrayList<>();
+    @SuppressWarnings("unchecked")
+    public CompositeItemProcessor<Map<String, String>, ClinicalDataComposite> clinicalDataProcessor() {
+        CompositeItemProcessor<Map<String, String>, ClinicalDataComposite> processor = new CompositeItemProcessor<>();
+        //TODO combine clinical data processors into a single class in order to avoid the need for a mixed type list
+        List delegates = new ArrayList();
         delegates.add(sampleProcessor());
         delegates.add(patientProcessor());
         processor.setDelegates(delegates);
@@ -190,9 +192,11 @@ public class BatchConfiguration {
 
     @Bean
     @StepScope
+    @SuppressWarnings("unchecked")
     public CompositeItemWriter<ClinicalDataComposite> clinicalDataWriter() {
-        CompositeItemWriter writer = new CompositeItemWriter();
-        List<ItemWriter> delegates = new ArrayList<>();
+        CompositeItemWriter<ClinicalDataComposite> writer = new CompositeItemWriter<>();
+        //TODO combine clinical data writers into a single class in order to avoid the need for a mixed type list
+        List delegates = new ArrayList();
         delegates.add(sampleWriter());
         delegates.add(patientWriter());
         writer.setDelegates(delegates);

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReader.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReader.java
@@ -70,7 +70,7 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
 
     private Map<String, List<String>> fullSampleHeader = new HashMap<>();
     private Map<String, List<String>> fullPatientHeader = new HashMap<>();
-    private List<Map<String, String>> clinicalRecords = new ArrayList();
+    private List<Map<String, String>> clinicalRecords = new ArrayList<>();
     private Map<String, Map<String, String>> compiledClinicalSampleRecords = new LinkedHashMap<>();
     private Map<String, Map<String, String>> compiledClinicalPatientRecords = new LinkedHashMap<>();
 
@@ -132,7 +132,7 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
      * @return
      */
     private List<Map<String,String>> mergePatientSampleClinicalRecords() {
-        List<Map<String,String>> mergedClinicalRecords = new ArrayList();
+        List<Map<String,String>> mergedClinicalRecords = new ArrayList<>();
         for (Map<String, String> record : compiledClinicalSampleRecords.values()) {
             Map<String, String> patientData = compiledClinicalPatientRecords.getOrDefault(record.get("PATIENT_ID"), new HashMap<>());
             record.putAll(patientData);

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalPatientDataWriter.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalPatientDataWriter.java
@@ -58,7 +58,7 @@ public class ClinicalPatientDataWriter implements ItemStreamWriter<ClinicalDataC
 
     @Value("#{stepExecutionContext['patientHeader']}")
     private Map<String, List<String>> header;
-    private Set<String> writtenPatientSet = new HashSet();
+    private Set<String> writtenPatientSet = new HashSet<>();
     private static final String OUTPUT_FILENAME = "data_clinical_patient.txt";
     private File stagingFile;
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<String>();
@@ -69,7 +69,7 @@ public class ClinicalPatientDataWriter implements ItemStreamWriter<ClinicalDataC
     public void open(ExecutionContext ec) throws ItemStreamException {
         this.stagingFile = new File(directory, OUTPUT_FILENAME);
         if (writeClinicalPatient) {
-            PassThroughLineAggregator aggr = new PassThroughLineAggregator();
+            PassThroughLineAggregator<String> aggr = new PassThroughLineAggregator<>();
             flatFileItemWriter.setLineAggregator(aggr);
             flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalSampleDataProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalSampleDataProcessor.java
@@ -48,7 +48,7 @@ public class ClinicalSampleDataProcessor implements ItemProcessor<Map<String, St
     @Override
     public ClinicalDataComposite process(Map<String, String> i) throws Exception {
         ClinicalDataComposite composite = new ClinicalDataComposite(i);
-        List<String> record = new ArrayList();
+        List<String> record = new ArrayList<>();
         List<String> header = total_header.get("header");
 
         // get the sample and patient ids first before processing the other columns

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalSampleDataWriter.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalSampleDataWriter.java
@@ -71,7 +71,7 @@ public class ClinicalSampleDataWriter implements ItemStreamWriter<ClinicalDataCo
     public void open(ExecutionContext ec) throws ItemStreamException {
         this.stagingFile  = new File(directory, OUTPUT_FILENAME);
         if (writeClinicalSample) {
-            PassThroughLineAggregator aggr = new PassThroughLineAggregator();
+            PassThroughLineAggregator<String> aggr = new PassThroughLineAggregator<>();
             flatFileItemWriter.setLineAggregator(aggr);
             flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataProcessor.java
@@ -44,7 +44,7 @@ public class RawClinicalDataProcessor implements ItemProcessor<Map<String, Strin
 
     @Override
     public String process(Map<String, String> i) throws Exception {
-        List<String> record = new ArrayList();
+        List<String> record = new ArrayList<>();
 
         // get the sample and patient ids first before processing the other columns
         if (fullHeader.contains("SAMPLE_ID")) {

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataWriter.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataWriter.java
@@ -70,7 +70,7 @@ public class RawClinicalDataWriter implements ItemStreamWriter<String> {
     public void open(ExecutionContext ec) throws ItemStreamException {
         if (writeRawClinicalData) {
             File stagingFile = new File(directory, OUTPUT_FILENAME_PREFIX + projectTitle + ".txt");
-            PassThroughLineAggregator aggr = new PassThroughLineAggregator();
+            PassThroughLineAggregator<String> aggr = new PassThroughLineAggregator<>();
             flatFileItemWriter.setLineAggregator(aggr);
             flatFileItemWriter.setResource( new FileSystemResource(stagingFile));
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineProcessor.java
@@ -53,7 +53,7 @@ public class TimelineProcessor implements ItemProcessor<Map<String, String>, Str
 
     @Override
     public String process(Map<String, String> i) throws Exception {
-        List<String> record = new ArrayList();
+        List<String> record = new ArrayList<>();
 
         for (String column : standardTimelineDataFields) {
             if (timelineHeader.contains(column)) {

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineReader.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineReader.java
@@ -62,7 +62,7 @@ public class TimelineReader implements ItemStreamReader<Map<String, String>> {
     private final Logger log = Logger.getLogger(ClinicalDataReader.class);
 
     public List<Map<String, String>> timelineRecords = new ArrayList<>();
-    private List<String> timelineHeader = new ArrayList();
+    private List<String> timelineHeader = new ArrayList<>();
 
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineWriter.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineWriter.java
@@ -84,7 +84,7 @@ public class TimelineWriter  implements ItemStreamWriter<String> {
             this.stagingFile = new File(directory, OUTPUT_FILENAME_PREFIX + ".txt");
         }
         if (writeTimelineData) {
-            PassThroughLineAggregator aggr = new PassThroughLineAggregator();
+            PassThroughLineAggregator<String> aggr = new PassThroughLineAggregator<>();
             flatFileItemWriter.setLineAggregator(aggr);
             flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
@@ -117,7 +117,7 @@ public class TimelineWriter  implements ItemStreamWriter<String> {
     }
 
     private String getHeaderLine(List<String> metaData) {
-        List<String> header = new ArrayList();
+        List<String> header = new ArrayList<>();
         for (String column : standardTimelineDataFields) {
             if (metaData.contains(column)) {
                 header.add(column);

--- a/redcap/redcap_source/pom.xml
+++ b/redcap/redcap_source/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <spring.version>4.3.14.RELEASE</spring.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <guava.version>19.0-rc2</guava.version>
   </properties>
@@ -49,8 +48,7 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
-          <compilerArgument>-Xlint:unchecked</compilerArgument>
-          <compilerArgument>-Xlint:deprecation</compilerArgument>
+          <compilerArgument>-Xlint:unchecked,deprecation</compilerArgument>
         </configuration>
       </plugin>
     </plugins>

--- a/redcap/redcap_source/src/test/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepositoryTest.java
+++ b/redcap/redcap_source/src/test/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepositoryTest.java
@@ -48,8 +48,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class RedcapRepositoryTest {
 
     @Autowired
-    private RedcapSessionManager redcapSessionManager;
-    @Autowired
     private RedcapRepository redcapRepository;
     @Autowired
     private RedcapSourceTestConfiguration redcapSourceTestConfiguration;


### PR DESCRIPTION
- move spring.version property definition to root pom
- add reporting of details of unchecked type conversions
- fix type specifiers in redcap_pipeine where possible
- inhibit unchecked warnings for composite processor/writer delegate lists
- better logging of delete record api usage : warn when number deleted does not match request
- remove incorrect acceptance of redirection status for http request
- remove unneeded System.out.println() call
- remove uneeded redcapSessionManager reference in RedcapRepositoryTest
- remove improperly checked in production log4j.properties from cvr pipeine
- adjust darwin application.properties.EXAMPLE to remove google stuff and add CDD stuff