### PR TITLE
Update merge and subset scripts for patient id-based subsets (support PED cohort).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /redcap/redcap_pipeline/target/
 /gene/target/
 /common/target/
+import-scripts/clinicalfile_utils.pyc

--- a/import-scripts/automation-environment.sh
+++ b/import-scripts/automation-environment.sh
@@ -22,6 +22,7 @@ export MSKIMPACT_REDCAP_BACKUP=$REDCAP_BACKUP_DATA_HOME/mskimpact
 export HEMEPACT_REDCAP_BACKUP=$REDCAP_BACKUP_DATA_HOME/hemepact
 export RAINDANCE_REDCAP_BACKUP=$REDCAP_BACKUP_DATA_HOME/raindance
 export ARCHER_REDCAP_BACKUP=$REDCAP_BACKUP_DATA_HOME/archer
+export MSKIMPACT_PED_DATA_HOME=$PORTAL_DATA_HOME/msk-impact/mskimpact_ped
 # CMO_DATA_HOME looks unused
 #export CMO_DATA_HOME=/data/cbio-portal-data/bic-mskcc
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk.x86_64

--- a/import-scripts/import-dmp-impact-data.sh
+++ b/import-scripts/import-dmp-impact-data.sh
@@ -306,6 +306,7 @@ miamicancerinstitute_notification_file=$(mktemp $JAVA_TMPDIR/miamicancerinstitut
 hartfordhealthcare_notification_file=$(mktemp $JAVA_TMPDIR/hartfordhealthcare-portal-update-notification.$now.XXXXXX)
 lymphoma_super_cohort_notification_file=$(mktemp $JAVA_TMPDIR/lymphoma-super-cohort-portal-update-notification.$now.XXXXXX)
 sclc_mskimpact_notification_file=$(mktemp $JAVA_TMPDIR/sclc-mskimpact-portal-update-notification.$now.XXXXXX)
+mskimpact_ped_notification_file=$(mktemp $JAVA_TMPDIR/mskimpact-ped-update-notification.$now.XXXXXX)
 
 # fetch clinical data mercurial
 echo "fetching updates from msk-impact repository..."
@@ -346,16 +347,11 @@ MSK_QUEENS_SUBSET_FAIL=0
 MSK_LEHIGH_SUBSET_FAIL=0
 MSK_MCI_SUBSET_FAIL=0
 MSK_HARTFORD_SUBSET_FAIL=0
+MSKIMPACT_PED_SUBSET_FAIL=0
 SCLC_MSKIMPACT_SUBSET_FAIL=0
 LYMPHOMA_SUPER_COHORT_SUBSET_FAIL=0
 
 MIXEDPACT_ADD_HEADER_FAIL=0
-MSK_KINGS_ADD_HEADER_FAIL=0
-MSK_QUEENS_ADD_HEADER_FAIL=0
-MSK_LEHIGH_ADD_HEADER_FAIL=0
-MSK_MCI_ADD_HEADER_FAIL=0
-MSK_HARTFORD_ADD_HEADER_FAIL=0
-SCLC_MSKIMPACT_ADD_HEADER_FAIL=0
 LYMPHOMA_SUPER_COHORT_ADD_HEADER_FAIL=0
 
 IMPORT_FAIL_MIXEDPACT=0
@@ -364,6 +360,7 @@ IMPORT_FAIL_LEHIGH=0
 IMPORT_FAIL_QUEENS=0
 IMPORT_FAIL_MCI=0
 IMPORT_FAIL_HARTFORD=0
+IMPORT_FAIL_MSKIMPACT_PED=0
 IMPORT_FAIL_SCLC_MSKIMPACT=0
 IMPORT_FAIL_LYMPHOMA=0
 GENERATE_MASTERLIST_FAIL=0
@@ -1053,7 +1050,7 @@ fi
 ## Subset MIXEDPACT on INSTITUTE for institute specific impact studies
 
 # subset the mixedpact study for Queens Cancer Center, Lehigh Valley, Kings County Cancer Center, Miami Cancer Institute, and Hartford Health Care
-bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_kingscounty -o=$MSK_KINGS_DATA_HOME -m=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Kings County Cancer Center" -s=$JAVA_TMPDIR/kings_subset.txt -c=data_clinical_sample.txt
+bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_kingscounty -o=$MSK_KINGS_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Kings County Cancer Center" -s=$JAVA_TMPDIR/kings_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
 if [ $? -gt 0 ] ; then
     echo "MSK Kings County subset failed! Study will not be updated in the portal."
     sendFailureMessageMskPipelineLogsSlack "KINGSCOUNTY subset"
@@ -1061,15 +1058,9 @@ if [ $? -gt 0 ] ; then
 else
     echo "MSK Kings County subset successful!"
     addCancerTypeCaseLists $MSK_KINGS_DATA_HOME "msk_kingscounty" "data_clinical_sample.txt" "data_clinical_patient.txt"
-    # add metadata headers before importing
-    $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -f $MSK_KINGS_DATA_HOME/data_clinical*
-    if [ $? -gt 0 ] ; then
-        MSK_KINGS_ADD_HEADER_FAIL=1
-        echo "Something went wrong while adding metadata headers for KINGSCOUNTY."
-    fi
 fi
 
-bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_lehighvalley -o=$MSK_LEHIGH_DATA_HOME -m=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Lehigh Valley Health Network" -s=$JAVA_TMPDIR/lehigh_subset.txt -c=data_clinical_sample.txt
+bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_lehighvalley -o=$MSK_LEHIGH_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Lehigh Valley Health Network" -s=$JAVA_TMPDIR/lehigh_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
 if [ $? -gt 0 ] ; then
     echo "MSK Lehigh Valley subset failed! Study will not be updated in the portal."
     sendFailureMessageMskPipelineLogsSlack "LEHIGHVALLEY subset"
@@ -1077,15 +1068,9 @@ if [ $? -gt 0 ] ; then
 else
     echo "MSK Lehigh Valley subset successful!"
     addCancerTypeCaseLists $MSK_LEHIGH_DATA_HOME "msk_lehighvalley" "data_clinical_sample.txt" "data_clinical_patient.txt"
-    # add metadata headers before importing
-    $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -f $MSK_LEHIGH_DATA_HOME/data_clinical*
-    if [ $? -gt 0 ] ; then
-        MSK_LEHIGH_ADD_HEADER_FAIL=1
-        echo "Something went wrong while adding metadata headers for LEHIGHVALLEY."
-    fi
 fi
 
-bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_queenscancercenter -o=$MSK_QUEENS_DATA_HOME -m=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Queens Cancer Center,Queens Hospital Cancer Center" -s=$JAVA_TMPDIR/queens_subset.txt -c=data_clinical_sample.txt
+bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_queenscancercenter -o=$MSK_QUEENS_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Queens Cancer Center,Queens Hospital Cancer Center" -s=$JAVA_TMPDIR/queens_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
 if [ $? -gt 0 ] ; then
     echo "MSK Queens Cancer Center subset failed! Study will not be updated in the portal."
     sendFailureMessageMskPipelineLogsSlack "QUEENSCANCERCENTER subset"
@@ -1093,15 +1078,9 @@ if [ $? -gt 0 ] ; then
 else
     echo "MSK Queens Cancer Center subset successful!"
     addCancerTypeCaseLists $MSK_QUEENS_DATA_HOME "msk_queenscancercenter" "data_clinical_sample.txt" "data_clinical_patient.txt"
-    # add metadata headers before importing
-    $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -f $MSK_QUEENS_DATA_HOME/data_clinical*
-    if [ $? -gt 0 ] ; then
-        MSK_QUEENS_ADD_HEADER_FAIL=1
-        echo "Something went wrong while adding metadata headers for QUEENSCANCERCENTER."
-    fi
 fi
 
-bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_miamicancerinstitute -o=$MSK_MCI_DATA_HOME -m=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Miami Cancer Institute" -s=$JAVA_TMPDIR/mci_subset.txt -c=data_clinical_sample.txt
+bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_miamicancerinstitute -o=$MSK_MCI_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Miami Cancer Institute" -s=$JAVA_TMPDIR/mci_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
 if [ $? -gt 0 ] ; then
     echo "MSK Miami Cancer Institute subset failed! Study will not be updated in the portal."
     sendFailureMessageMskPipelineLogsSlack "MIAMICANCERINSTITUTE subset"
@@ -1109,15 +1088,9 @@ if [ $? -gt 0 ] ; then
 else
     echo "MSK Miami Cancer Institute subset successful!"
     addCancerTypeCaseLists $MSK_MCI_DATA_HOME "msk_miamicancerinstitute" "data_clinical_sample.txt" "data_clinical_patient.txt"
-    # add metadata headers before importing
-    $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -f $MSK_MCI_DATA_HOME/data_clinical*
-    if [ $? -gt 0 ] ; then
-        MSK_MCI_ADD_HEADER_FAIL=1
-        echo "Something went wrong while adding metadata headers for MIAMICANCERINSTITUTE."
-    fi
 fi
 
-bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_hartfordhealthcare -o=$MSK_HARTFORD_DATA_HOME -m=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Hartford Healthcare" -s=$JAVA_TMPDIR/hartford_subset.txt -c=data_clinical_sample.txt
+bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_hartfordhealthcare -o=$MSK_HARTFORD_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Hartford Healthcare" -s=$JAVA_TMPDIR/hartford_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
 if [ $? -gt 0 ] ; then
     echo "MSK Hartford Healthcare subset failed! Study will not be updated in the portal."
     sendFailureMessageMskPipelineLogsSlack "HARTFORDHEALTHCARE subset"
@@ -1125,18 +1098,12 @@ if [ $? -gt 0 ] ; then
 else
     echo "MSK Hartford Healthcare subset successful!"
     addCancerTypeCaseLists $MSK_HARTFORD_DATA_HOME "msk_hartfordhealthcare" "data_clinical_sample.txt" "data_clinical_patient.txt"
-    # add metadata headers before importing
-    $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -f $MSK_HARTFORD_DATA_HOME/data_clinical*
-    if [ $? -gt 0 ] ; then
-        MSK_HARTFORD_ADD_HEADER_FAIL=1
-        echo "Something went wrong while adding metadata headers for HARTFORDHEALTHCARE."
-    fi
 fi
 
-# set 'RESTART_AFTER_MSK_AFFILIATE_IMPORT' flag to 1 if Kings County, Lehigh Valley, Queens Cancer Center, Miami Cancer Institute, or Lymphoma super cohort succesfully update
+# set 'RESTART_AFTER_MSK_AFFILIATE_IMPORT' flag to 1 if Kings County, Lehigh Valley, Queens Cancer Center, Miami Cancer Institute, MSKIMPACT Ped, or Lymphoma super cohort succesfully update
 RESTART_AFTER_MSK_AFFILIATE_IMPORT=0
-# update msk_kingscounty in portal only if subset was successful and metadata headers were added
-if [ $MSK_KINGS_SUBSET_FAIL -eq 0 ] && [ $MSK_KINGS_ADD_HEADER_FAIL -eq 0 ] ; then
+# update msk_kingscounty in portal only if subset was successful
+if [ $MSK_KINGS_SUBSET_FAIL -eq 0 ] ; then
     echo "Importing msk_kingscounty study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_kingscounty" --temp-study-id="temporary_msk_kingscounty" --backup-study-id="yesterday_msk_kingscounty" --portal-name="msk-kingscounty-portal" --study-path="$MSK_KINGS_DATA_HOME" --notification-file="$kingscounty_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1160,8 +1127,8 @@ else
     cd $MSK_KINGS_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest KINGSCOUNTY dataset"
 fi
 
-# update msk_lehighvalley in portal only if subset was successful and metadata headers were added
-if [ $MSK_LEHIGH_SUBSET_FAIL -eq 0 ] && [ $MSK_LEHIGH_ADD_HEADER_FAIL -eq 0 ] ; then
+# update msk_lehighvalley in portal only if subset was successful
+if [ $MSK_LEHIGH_SUBSET_FAIL -eq 0 ] ; then
     echo "Importing msk_lehighvalley study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_lehighvalley" --temp-study-id="temporary_msk_lehighvalley" --backup-study-id="yesterday_msk_lehighvalley" --portal-name="msk-lehighvalley-portal" --study-path="$MSK_LEHIGH_DATA_HOME" --notification-file="$lehighvalley_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1185,8 +1152,8 @@ else
     cd $MSK_LEHIGH_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest LEHIGHVALLEY dataset"
 fi
 
-# update msk_queenscancercenter in portal only if subset was successful and metadata headers were added
-if [ $MSK_QUEENS_SUBSET_FAIL -eq 0 ] && [ $MSK_QUEENS_ADD_HEADER_FAIL -eq 0 ] ; then
+# update msk_queenscancercenter in portal only if subset was successful
+if [ $MSK_QUEENS_SUBSET_FAIL -eq 0 ] ; then
     echo "Importing msk_queenscancercenter study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_queenscancercenter" --temp-study-id="temporary_msk_queenscancercenter" --backup-study-id="yesterday_msk_queenscancercenter" --portal-name="msk-queenscancercenter-portal" --study-path="$MSK_QUEENS_DATA_HOME" --notification-file="$queenscancercenter_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1210,8 +1177,8 @@ else
     cd $MSK_QUEENS_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest QUEENSCANCERCENTER dataset"
 fi
 
-# update msk_miamicancerinstitute in portal only if subset was successful and metadata headers were added
-if [ $MSK_MCI_SUBSET_FAIL -eq 0 ] && [ $MSK_MCI_ADD_HEADER_FAIL -eq 0 ] ; then
+# update msk_miamicancerinstitute in portal only if subset was successful
+if [ $MSK_MCI_SUBSET_FAIL -eq 0 ] ; then
     echo "Importing msk_miamicancerinstitute study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_miamicancerinstitute" --temp-study-id="temporary_msk_miamicancerinstitute" --backup-study-id="yesterday_msk_miamicancerinstitute" --portal-name="msk-mci-portal" --study-path="$MSK_MCI_DATA_HOME" --notification-file="$miamicancerinstitute_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1235,8 +1202,8 @@ else
     cd $MSK_MCI_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest MIAMICANCERINSTITUTE dataset"
 fi
 
-# update msk_hartfordhealthcare in portal only if subset was successful and metadata headers were added
-if [ $MSK_HARTFORD_SUBSET_FAIL -eq 0 ] && [ $MSK_HARTFORD_ADD_HEADER_FAIL -eq 0 ] ; then
+# update msk_hartfordhealthcare in portal only if subset was successful
+if [ $MSK_HARTFORD_SUBSET_FAIL -eq 0 ] ; then
     echo "Importing msk_hartfordhealthcare study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_hartfordhealthcare" --temp-study-id="temporary_msk_hartfordhealthcare" --backup-study-id="yesterday_msk_hartfordhealthcare" --portal-name="msk-hartford-portal" --study-path="$MSK_HARTFORD_DATA_HOME" --notification-file="$hartfordhealthcare_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1259,13 +1226,50 @@ else
     echo "Committing HARTFORDHEALTHCARE data"
     cd $MSK_HARTFORD_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest HARTFORDHEALTHCARE dataset"
 fi
-
 ## END Subset MIXEDPACT on INSTITUTE
+#-------------------------------------------------------------------------------------------------------------------------------------
+# Subset MSKIMPACT on PED_IND for MSKIMPACT_PED cohort
+
+bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=mskimpact_ped -o=$MSKIMPACT_PED_DATA_HOME -d=$MSK_IMPACT_DATA_HOME -f="PED_IND=Yes" -s=$tmp/mskimpact_ped_subset.txt -c=$MSK_IMPACT_DATA_HOME/data_clinical_patient.txt
+if [ $? -gt 0 ]; then
+    echo "MSKIMPACT_PED subset failed! Study will not be updated in the portal."
+    sendFailureMessageMskPipelineLogsSlack "MSKIMPACT_PED subset"
+    MSKIMPACT_PED_SUBSET_FAIL=1
+else
+    echo "MSKIMPACT_PED subset successful!"
+    addCancerTypeCaseLists $MSKIMPACT_PED_DATA_HOME "mskimpact_ped" "data_clinical_sample.txt" "data_clinical_patient.txt"
+fi
+
+# update mskimpact_ped in portal only if subset was successful
+if [ $MSKIMPACT_PED_SUBSET_FAIL -eq 0 ]; then
+    echo "Importing mskimpact_ped study..."
+    echo $(date)
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskimpact_ped" --temp-study-id="temporary_mskimpact_ped" --backup-study-id="yesterday_mskimpact_ped" --portal-name="msk-ped-portal" --study-path="$MSKIMPACT_PED_DATA_HOME" --notification-file="$mskimpact_ped_notification_file" --tmp-directory="$tmp" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    if [ $? -gt 0 ]; then
+        IMPORT_FAIL_MSKIMPACT_PED=1
+        sendFailureMessageMskPipelineLogsSlack "MSKIMPACT_PED import"
+    else
+        RESTART_AFTER_MSK_AFFILIATE_IMPORT=1
+        sendSuccessMessageMskPipelineLogsSlack "MSKIMPACT_PED"
+    fi
+else
+    echo "Something went wrong with subsetting clinical studies for MSKIMPACT_PED."
+    IMPORT_FAIL_MSKIMPACT_PED=1
+fi
+# commit or revert changes for MSKIMPACT_PED
+if [ $IMPORT_FAIL_MSKIMPACT_PED -gt 0 ] ; then
+    echo "MSKIMPACT_PED subset and/or updates failed! Reverting data to last commit."
+    cd $MSKIMPACT_PED_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
+else
+    echo "Committing MSKIMPACT_PED data"
+    cd $MSKIMPACT_PED_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest MSKIMPACT_PED dataset"
+fi
+## END Subset MSKIMPACT on PED_IND for MSKIMPACT_PED cohort
 #-------------------------------------------------------------------------------------------------------------------------------------
 # Subset MSKIMPACT on ONCOTREE_CODE for SCLC cohort
 
 RESTART_AFTER_SCLC_IMPORT=0
-bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=sclc_mskimpact_2017 -o=$MSK_SCLC_DATA_HOME -m=$MSK_IMPACT_DATA_HOME -f="ONCOTREE_CODE=SCLC" -s=$JAVA_TMPDIR/sclc_subset.txt -c=data_clinical_sample.txt
+bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=sclc_mskimpact_2017 -o=$MSK_SCLC_DATA_HOME -d=$MSK_IMPACT_DATA_HOME -f="ONCOTREE_CODE=SCLC" -s=$JAVA_TMPDIR/sclc_subset.txt -c=$MSK_IMPACT_DATA_HOME/data_clinical_sample.txt
 if [ $? -gt 0 ] ; then
     echo "MSKIMPACT SCLC subset failed! Study will not be updated in the portal."
     sendFailureMessageMskPipelineLogsSlack "SCLCMSKIMPACT subset"
@@ -1273,16 +1277,10 @@ if [ $? -gt 0 ] ; then
 else
     echo "MSKIMPACT SCLC subset successful!"
     addCancerTypeCaseLists $MSK_SCLC_DATA_HOME "sclc_mskimpact_2017" "data_clinical_sample.txt" "data_clinical_patient.txt"
-    # add metadata headers before importing
-    $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s sclc_mskimpact_2017 -f $MSK_SCLC_DATA_HOME/data_clinical*
-    if [ $? -gt 0 ] ; then
-        SCLC_MSKIMPACT_ADD_HEADER_FAIL=1
-        echo "Something went wrong while adding metadata headers for MSKIMPACT SCLC."
-    fi
 fi
 
 # update sclc_mskimpact_2017 in portal only if subset was successful and metadata headers were added
-if [ $SCLC_MSKIMPACT_SUBSET_FAIL -eq 0 ] && [ $SCLC_MSKIMPACT_ADD_HEADER_FAIL -eq 0 ] ; then
+if [ $SCLC_MSKIMPACT_SUBSET_FAIL -eq 0 ] ; then
     echo "Importing sclc_mskimpact_2017 study..."
     echo $(date)
     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="sclc_mskimpact_2017" --temp-study-id="temporary_sclc_mskimpact_2017" --backup-study-id="yesterday_sclc_mskimpact_2017" --portal-name="msk-sclc-portal" --study-path="$MSK_SCLC_DATA_HOME" --notification-file="$sclc_mskimpact_notification_file" --tmp-directory="$JAVA_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
@@ -1516,10 +1514,22 @@ if [ $MSK_HARTFORD_SUBSET_FAIL -gt 0 ] ; then
     echo -e "$EMAIL_BODY" |  mail -s "HARTFORDHEALTHCARE Subset Failure: Study will not be updated." $email_list
 fi
 
+EMAIL_BODY="Failed to subset MSKIMPACT_PED data. Subset study will not be updated."
+if [ $MSKIMPACT_PED_SUBSET_FAIL -gt 0 ]; then
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT_PED Subset Failure: Study will not be updated." $email_list
+fi
+
 EMAIL_BODY="Failed to subset MSKIMPACT SCLC data. Subset study will not be updated."
 if [ $SCLC_MSKIMPACT_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
     echo -e "$EMAIL_BODY" | mail -s "SCLCMSKIMPACT Subset Failure: Study will not be updated." $email_list
+fi
+
+EMAIL_BODY="Failed to subset LYMPHOMASUPERCOHORT data. Subset study will not be updated."
+if [ $LYMPHOMA_SUPER_COHORT_SUBSET_FAIL -gt 0 ] ; then
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" | mail -s "LYMPHOMASUPERCOHORT Subset Failure: Study will not be updated." $email_list
 fi
 
 echo "Fetching and importing of clinical datasets complete!"

--- a/import-scripts/subset-impact-data.sh
+++ b/import-scripts/subset-impact-data.sh
@@ -2,7 +2,7 @@
 
 # (1): study id
 # (2): output directory
-# (3): mskimpact data directory
+# (3): input data directory
 # (4): data filter criteria to subset IMPACT data with (either SEQ_DATE or <ATTRIBUTE_NAME>=[ATTRIBUTE_VAL1,ATTRIBUTE_VAL2,...])
 # (5): output subset filename
 # (6): data_clinical filename containing attribute being filtered in (4)
@@ -17,8 +17,8 @@ case $i in
     OUTPUT_DIRECTORY="${i#*=}"
     shift # past argument=value
     ;;
-    -m=*|--mskimpact-directory=*)
-    MSK_IMPACT_DATA_DIRECTORY="${i#*=}"
+    -d=*|--input-directory=*)
+    INPUT_DIRECTORY="${i#*=}"
     shift # past argument=value
     ;;
     -f=*|--filter-criteria=*)
@@ -46,7 +46,7 @@ done
 echo "Input arguments: "
 echo -e "\tSTUDY_ID="$STUDY_ID
 echo -e "\tOUTPUT_DIRECTORY="$OUTPUT_DIRECTORY
-echo -e "\tMSK_IMPACT_DATA_DIRECTORY="$MSK_IMPACT_DATA_DIRECTORY
+echo -e "\tINPUT_DIRECTORY="$INPUT_DIRECTORY
 echo -e "\tFILTER_CRITERIA="$FILTER_CRITERIA
 echo -e "\tSUBSET_FILENAME="$SUBSET_FILENAME
 echo -e "\tCLINICAL_FILENAME="$CLINICAL_FILENAME
@@ -55,48 +55,96 @@ if [ -z $PORTAL_SCRIPTS_DIRECTORY ]; then
 fi
 echo -e "\tPORTAL_SCRIPTS_DIRECTORY="$PORTAL_SCRIPTS_DIRECTORY
 
+# status flags
+GEN_SUBSET_LIST_FAILURE=0
+MERGE_SCRIPT_FAILURE=0
+ADD_METADATA_HEADERS_FAILURE=0
+
 if [ $STUDY_ID == "genie" ]; then
-    CLINICAL_SUPP_FILE="$MSK_IMPACT_DATA_DIRECTORY/cvr/seq_date.txt"
+    CLINICAL_SUPP_FILE="$INPUT_DIRECTORY/cvr/seq_date.txt"
 
     # in the case of genie data, the input data directory must be the msk-impact data home, where we expect to see darwin_naaccr.txt
     # copy the darwin genie files to the output directory with different filenames
-    cp $MSK_IMPACT_DATA_DIRECTORY/darwin/darwin_naaccr.txt $OUTPUT_DIRECTORY/data_clinical_supp_patient.txt
-    cut -f1,2 $MSK_IMPACT_DATA_DIRECTORY/$CLINICAL_FILENAME > $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt
-    
+    cp $INPUT_DIRECTORY/darwin/darwin_naaccr.txt $OUTPUT_DIRECTORY/data_clinical_supp_patient.txt
+    cut -f1,2 $CLINICAL_FILENAME > $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt
+
     # run the generate clinical subset script to generate list of sample ids to subset from impact data - subset of sample ids will be written to given $SUBSET_FILENAME
+    echo "Generating subset list from $INPUT_DIRECTORY/$CLINICAL_FILENAME using filter criteria $FILTER_CRITERIA..."
     $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/generate-clinical-subset.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-supp-file="$CLINICAL_SUPP_FILE" --filter-criteria="$FILTER_CRITERIA" --subset-filename="$SUBSET_FILENAME" --anonymize-date='true' --clinical-patient-file="$OUTPUT_DIRECTORY/data_clinical_supp_patient.txt"
+    if [ $? -gt 0 ] ; then
+        GEN_SUBSET_LIST_FAILURE=1
+    else
+        # expand data_clinical_supp_sample.txt with ONCOTREE_CODE, SAMPLE_TYPE, GENE_PANEL from data_clinical.txt
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-supp-file="$CLINICAL_FILENAME" --fields="ONCOTREE_CODE,SAMPLE_TYPE,GENE_PANEL" --identifier-column-name="SAMPLE_ID"
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/add-age-at-seq-report.py --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --seq-date-file="$INPUT_DIRECTORY/cvr/seq_date.txt" --age-file="$INPUT_DIRECTORY/darwin/darwin_age.txt" --convert-to-days="true"
+        # expand data_clinical_supp_patient.txt with AGE_AT_DEATH, AGE_AT_LAST_FOLLOWUP, OS_STATUS
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_patient.txt" --clinical-supp-file="$INPUT_DIRECTORY/data_clinical_supp_darwin_demographics.txt" --fields="OS_STATUS" --identifier-column-name="PATIENT_ID"
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_patient.txt" --clinical-supp-file="$INPUT_DIRECTORY/darwin/darwin_vital_status.txt" --fields="AGE_AT_DEATH,AGE_AT_LAST_FOLLOWUP" --identifier-column-name="PATIENT_ID"
 
-    # expand data_clinical_supp_sample.txt with ONCOTREE_CODE, SAMPLE_TYPE, GENE_PANEL from data_clinical.txt
-    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-supp-file="$MSK_IMPACT_DATA_DIRECTORY/$CLINICAL_FILENAME" --fields="ONCOTREE_CODE,SAMPLE_TYPE,GENE_PANEL" --identifier-column-name="SAMPLE_ID"
-    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/add-age-at-seq-report.py --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --seq-date-file="$MSK_IMPACT_DATA_DIRECTORY/cvr/seq_date.txt" --age-file="$MSK_IMPACT_DATA_DIRECTORY/darwin/darwin_age.txt" --convert-to-days="true"
-    # expand data_clinical_supp_patient.txt with AGE_AT_DEATH, AGE_AT_LAST_FOLLOWUP, OS_STATUS
-    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_patient.txt" --clinical-supp-file="$MSK_IMPACT_DATA_DIRECTORY/data_clinical_supp_darwin_demographics.txt" --fields="OS_STATUS" --identifier-column-name="PATIENT_ID"
-    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_patient.txt" --clinical-supp-file="$MSK_IMPACT_DATA_DIRECTORY/darwin/darwin_vital_status.txt" --fields="AGE_AT_DEATH,AGE_AT_LAST_FOLLOWUP" --identifier-column-name="PATIENT_ID"
+        # rename GENE_PANEL to SEQ_ASSAY_ID in data_clinical_supp_sample.txt
+        sed -i -e 's/GENE_PANEL/SEQ_ASSAY_ID/' $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt
 
-    # rename GENE_PANEL to SEQ_ASSAY_ID in data_clinical_supp_sample.txt
-    sed -i -e 's/GENE_PANEL/SEQ_ASSAY_ID/' $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt
+        # rename OS_STATUS to VITAL_STATUS in data_clinical_supp_patient.txt
+        sed -i -e 's/OS_STATUS/VITAL_STATUS/' $OUTPUT_DIRECTORY/data_clinical_supp_patient.txt
 
-    # rename OS_STATUS to VITAL_STATUS in data_clinical_supp_patient.txt
-    sed -i -e 's/OS_STATUS/VITAL_STATUS/' $OUTPUT_DIRECTORY/data_clinical_supp_patient.txt
-    
-    # touch meta clinical if not already exists
-    if [ ! -f $MSK_IMPACT_DATA_DIRECTORY/meta_clinical.txt ]; then
-        touch $MSK_IMPACT_DATA_DIRECTORY/meta_clinical.txt
-    fi
-
-    # generate subset of impact data using the subset file generated above
-    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/merge.py  -d $OUTPUT_DIRECTORY -i "genie" -s "$SUBSET_FILENAME" -x "true" $MSK_IMPACT_DATA_DIRECTORY
-    
-    # remove germline mutations from maf
-    grep -v 'GERMLINE' $OUTPUT_DIRECTORY/data_mutations_extended.txt > $OUTPUT_DIRECTORY/data_mutations_extended.txt.tmp
-    mv $OUTPUT_DIRECTORY/data_mutations_extended.txt.tmp $OUTPUT_DIRECTORY/data_mutations_extended.txt
-
-    # remove if file empty
-    if [ $(wc -l < $MSK_IMPACT_DATA_HOME/meta_clinical.txt) -eq 0 ]; then
-        rm $MSK_IMPACT_DATA_HOME/meta_clinical.txt
+        # generate subset of impact data using the subset file generated above
+        echo "Subsetting data from $INPUT_DIRECTORY..."
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/merge.py  -d $OUTPUT_DIRECTORY -i "genie" -s "$SUBSET_FILENAME" -x "true" $INPUT_DIRECTORY
+        if [ $? -gt 0 ] ; then
+            MERGE_SCRIPT_FAILURE=1
+        else
+            # remove germline mutations from maf
+            grep -v 'GERMLINE' $OUTPUT_DIRECTORY/data_mutations_extended.txt > $OUTPUT_DIRECTORY/data_mutations_extended.txt.tmp
+            mv $OUTPUT_DIRECTORY/data_mutations_extended.txt.tmp $OUTPUT_DIRECTORY/data_mutations_extended.txt
+        fi
     fi
 else
+    # touch meta clinical if not already exists only if input dir has data_clinical.txt
+    if [[ -f $INPUT_DIRECTORY/data_clinical.txt && ! -f $INPUT_DIRECTORY/meta_clinical.txt ]] ; then
+        touch $INPUT_DIRECTORY/meta_clinical.txt
+    fi
+
     # generate subset list of sample ids based on filter criteria and subset MSK-IMPACT using generated list in $SUBSET_FILENAME
-    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/generate-clinical-subset.py --study-id="$STUDY_ID" --clinical-file="$MSK_IMPACT_DATA_DIRECTORY/$CLINICAL_FILENAME" --filter-criteria="$FILTER_CRITERIA" --subset-filename="$SUBSET_FILENAME"
-    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/merge.py -d $OUTPUT_DIRECTORY -i "$STUDY_ID" -s "$SUBSET_FILENAME" -x "true" -m "true" $MSK_IMPACT_DATA_DIRECTORY
+    echo "Generating subset list from $CLINICAL_FILENAME using filter criteria $FILTER_CRITERIA..."
+    $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/generate-clinical-subset.py --study-id="$STUDY_ID" --clinical-file="$CLINICAL_FILENAME" --filter-criteria="$FILTER_CRITERIA" --subset-filename="$SUBSET_FILENAME"
+    if [ $? -gt 0 ]; then
+        GEN_SUBSET_LIST_FAILURE=1
+    else
+        echo "Subsetting data from $INPUT_DIRECTORY..."
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/merge.py -d $OUTPUT_DIRECTORY -i "$STUDY_ID" -s "$SUBSET_FILENAME" -x "true" -m "true" $INPUT_DIRECTORY
+        if [ $? -gt 0 ]; then
+            MERGE_SCRIPT_FAILURE=1
+        else
+            # add clinical meta data headers if clinical sample file exists
+            if [ -f $OUTPUT_DIRECTORY/data_clinical_sample.txt ]; then
+                echo "Adding clinical attribute meta data headers..."
+                $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/add_clinical_attribute_metadata_headers.py -f $OUTPUT_DIRECTORY/data_clinical*
+                if [ $? -gt 0 ]; then
+                    ADD_METADATA_HEADERS_FAILURE=1
+                fi
+            fi
+        fi
+    fi
+
+    # remove temp meta_clinical.txt if created
+    if [[ -f $INPUT_DIRECTORY/meta_clinical.txt && $(wc -l < $INPUT_DIRECTORY/meta_clinical.txt) -eq 0 ]] ; then
+        rm $INPUT_DIRECTORY/meta_clinical.txt
+    fi
+fi
+# report errors
+if [ $GEN_SUBSET_LIST_FAILURE -ne 0 ] ; then
+    echo "Error while attempting to generate subset of sample ids by filter criteria $FILTER_CRITERIA"
+fi
+if [ $MERGE_SCRIPT_FAILURE -ne 0 ] ; then
+    echo "Error while trying to subset data from $INPUT_DIRECTORY using subset list from $SUBSET_FILENAME"
+fi
+if [ $ADD_METADATA_HEADERS_FAILURE -ne 0 ] ; then
+    echo "Error while attempting to add clinical attribute meta data headers to $OUTPUT_DIRECTORY/data_clinical*"
+fi
+# exit accordingly
+if [[ $GEN_SUBSET_LIST_FAILURE -eq 0 && $MERGE_SCRIPT_FAILURE -eq 0 && $ADD_METADATA_HEADERS_FAILURE -eq 0 ]] ; then
+    echo "Successfully subset data from $INPUT_DIRECTORY by filter criteria $FILTER_CRITERIA"
+    exit 0
+else
+    exit 1
 fi


### PR DESCRIPTION
`automation-environment.sh` updates:
- **added MSKIMPACT_PED_DATA_HOME**

`import-dmp-impact-data.sh` updates:
- **added status flags, notification filename, subset, import, and emails for updating the `MSKIMPACT_PED` cohort**
- removed calls to add meta data headers (and corresponding status flags) for cohorts generated using `subset-impact-data.sh` script since this step is now included as part of the script
- updated input arg `-m` to `-d` to reflect change in arg name for `subset-impact-data.sh`
- added missing subset failure email for lymphoma super cohort

`generate-clinical-subset.py` updates:
-  now handles subsetting by patient attributes

`subset-impact-data.sh` updates:
- changed input arg name `mskimpact-directory` to more generic `input-directory`
- added a step to insert clinical meta data headers when running `subset-impact-data.sh` for a study other than genie (sage handles this for genie, we don't need to do it ourselves)
- added status flags for (1) generating subset list, (2) running the merge script, and (3) adding meta data clinical headers if `data_clinical_sample.txt` exists

`merge.py` updates:
- determines which case id column (`PATIENT_ID` or `SAMPLE_ID`) to use when checking whether current record is in the reference set (basically if a match is found by the current patient id in the reference set then use `PATIENT_ID` as case id column to determine whether the patient-to-sample map should be updated)
- if case id column `PATIENT_ID` is used then also add associated sample IDs to the reference set if reference set is not empty. this is to ensure that the data gets subsetted correctly since genomic data files are exclusively sample-based, meaning if only patient ids were in the reference set then the merge script would not be able to find any matches (unless patient ids and sample ids happen to be the same)




Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>