### PR TITLE
Bugfix for CVRUtilities bean

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
@@ -90,6 +90,11 @@ public class BatchConfiguration {
     }
 
     @Bean
+    public CVRUtilities cvrUtilities() {
+        return new CVRUtilities();
+    }
+
+    @Bean
     public Job gmlJob() {
         return jobBuilderFactory.get(GML_JOB)
                 .start(cvrMasterListStep())

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -49,7 +49,6 @@ import org.springframework.context.annotation.*;
  * @author heinsz
  */
 
-@Configuration
 public class CVRUtilities {
 
     public static final String CVR_FILE = "cvr_data.json";
@@ -95,11 +94,6 @@ public class CVRUtilities {
         list.add("TNP");
         list.add("ONP");
         this.variationList = list;
-    }
-
-    @Bean
-    public CVRUtilities CVRUtilities() {
-        return new CVRUtilities();
     }
 
     public CVRUtilities() {


### PR DESCRIPTION
- moved CVRUtilities bean creation to Batch Configuration
- removed some annotations in CVRUtilities class

Previously encountering error: 
Invalid bean definition with name 'CVRUtilities' defined in class path resource [org/cbioportal/cmo/pipelines/cvr/CVRUtilities.class]: factory-bean reference points back to the same bean definition