### PR TITLE
remove darwin generated OS_STATUS, OS_MONTHS, SEX, PED_IND, AGE_CURRENT

### DIFF
--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientDemographics.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientDemographics.java
@@ -350,13 +350,9 @@ public class MskimpactPatientDemographics {
     public static List<String> getPatientDemographicsFieldNames() {
         List<String> fieldNames = new ArrayList<>();
         fieldNames.add("DMP_ID_DEMO");
-        fieldNames.add("DARWIN_PATIENT_AGE");
         fieldNames.add("RACE");
         fieldNames.add("RELIGION");
-        fieldNames.add("GENDER");
         fieldNames.add("ETHNICITY");
-        fieldNames.add("OS_STATUS");
-        fieldNames.add("OS_MONTHS");
         fieldNames.add("PED_IND");
         return fieldNames;
     }
@@ -364,13 +360,9 @@ public class MskimpactPatientDemographics {
     public static List<String> getPatientDemographicsHeaders() {
         List<String> fieldNames = new ArrayList<>();
         fieldNames.add("PATIENT_ID");
-        fieldNames.add("AGE_CURRENT"); // DARWIN_PATIENT_AGE has been renamed
         fieldNames.add("RACE");
         fieldNames.add("RELIGION");
-        fieldNames.add("SEX");
         fieldNames.add("ETHNICITY");
-        fieldNames.add("OS_STATUS");
-        fieldNames.add("OS_MONTHS");
         fieldNames.add("PED_IND");
         return fieldNames;
     }


### PR DESCRIPTION
will no longer be written out darwin_demographics
attributes will be generated by DDP-pipeline