### PR TITLE
new feature: masking specified projects from export

### DIFF
--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalReader.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalReader.java
@@ -86,8 +86,8 @@ public class Skcm_mskcc_2015_chantClinicalReader implements ItemStreamReader<Skc
     public void open(ExecutionContext executionContext) throws ItemStreamException {
         // add the patient and sample headers to the execution context
         Map<String, List<String>> fullHeader = metadataManager.getFullHeader(new Skcm_mskcc_2015_chantNormalizedClinicalRecord().getFieldNames());
-        executionContext.put("sampleHeader", clinicalDataSource.getFullSampleHeader(fullHeader));
-        executionContext.put("patientHeader", clinicalDataSource.getFullPatientHeader(fullHeader));
+        executionContext.put("sampleHeader", metadataManager.getFullSampleHeader(fullHeader));
+        executionContext.put("patientHeader", metadataManager.getFullPatientHeader(fullHeader));
 
         // getting records from db view and merge data by sample id
         this.melanomaClinicalRecords = getMelanomaClinicalRecords();

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/RedcapPipeline.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/RedcapPipeline.java
@@ -33,6 +33,7 @@
 package org.mskcc.cmo.ks.redcap;
 
 import java.io.PrintWriter;
+import java.util.*;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -57,6 +58,12 @@ import org.springframework.context.ConfigurableApplicationContext;
 @SpringBootApplication
 public class RedcapPipeline {
 
+    private static ClinicalDataSource clinicalDataSource;
+    private static MetadataManager metadataManager;
+
+    private static Set<String> maskProjectArgument = new HashSet<String>();
+    private static Set<String> projectSetForStableId = new HashSet<String>();
+
     private static final char EXPORT_MODE = 'e';
     private static final char IMPORT_MODE = 'i';
     private static final char CHECK_MODE = 'c';
@@ -68,6 +75,7 @@ public class RedcapPipeline {
     private static final String OPTION_FILENAME = "filename";
     private static final String OPTION_RAW_DATA = "raw-data";
     private static final String OPTION_KEEP_EXISTING_PROJECT_DATA = "keep-existing-project-data";
+    private static final String OPTION_MASK_REDCAP_PROJECTS = "mask-redcap-projects";
     private static final String OPTION_IMPORT_MODE = "import-mode";
     private static final String OPTION_EXPORT_MODE = "export-mode";
     private static final String OPTION_CHECK_MODE = "check-mode";
@@ -83,9 +91,10 @@ public class RedcapPipeline {
             .addOption("f", OPTION_FILENAME, true, "Input filename (required for input-mode)")
             .addOption("r", OPTION_RAW_DATA, false, "Export data without manipulation (no merging of data sources or splitting of attribute types)")
             .addOption("k", OPTION_KEEP_EXISTING_PROJECT_DATA, false, "During import, disable the deletion of existing project records which are not present in the imported file (can not be used when the project record name field is an autonumbered record_id)")
+            .addOption("m", OPTION_MASK_REDCAP_PROJECTS, true, "Export (or check) of data will not include the data for these redcap project titles. (can not be used with --" + OPTION_REDCAP_PROJECT_TITLE + ")")
             .addOption("i", OPTION_IMPORT_MODE, false, "Import from file to redcap-project (use one of { -i, -e, -c })")
-            .addOption("e", OPTION_EXPORT_MODE, false, "Export either " + OPTION_REDCAP_PROJECT_TITLE + " or " + OPTION_STABLE_ID + " to directory (use one of -i, -e, -c)")
-            .addOption("c", OPTION_CHECK_MODE, false, "Check if either " + OPTION_REDCAP_PROJECT_TITLE + " or " + OPTION_STABLE_ID + " is present in RedCap (use one of { -i, -e, -c })");
+            .addOption("e", OPTION_EXPORT_MODE, false, "Export either --" + OPTION_REDCAP_PROJECT_TITLE + " or --" + OPTION_STABLE_ID + " to directory (use one of -i, -e, -c)")
+            .addOption("c", OPTION_CHECK_MODE, false, "Check if either --" + OPTION_REDCAP_PROJECT_TITLE + " or --" + OPTION_STABLE_ID + " is present in RedCap (use one of { -i, -e, -c })");
         return options;
     }
 
@@ -95,25 +104,45 @@ public class RedcapPipeline {
         System.exit(exitStatus);
     }
 
-    private static void checkIfProjectOrStableIdExistsAndExit(String[] args, CommandLine commandLine) {
-        SpringApplication app = new SpringApplication(RedcapPipeline.class);
-        app.setWebEnvironment(false);
-        ConfigurableApplicationContext ctx = app.run(args);
+    private static List<Boolean> checkIfProjectsExist(List<String> projectNames) {
+        ArrayList<Boolean> projectExists = new ArrayList<>();
+        for (String projectName : projectNames) {
+            if (projectName == null) {
+                projectExists.add(false);
+            } else {
+                projectExists.add(clinicalDataSource.projectExists(projectName));
+            }
+        }
+        return projectExists;
+    }
+
+    private static Boolean checkIfProjectsExistForStableId() {
+        Set<String> unmaskedProjects = new HashSet<String>();
+        for (String projectName : projectSetForStableId) {
+            if (!maskProjectArgument.contains(projectName)) {
+                unmaskedProjects.add(projectName);
+            }
+        }
+        return unmaskedProjects.size() > 0;
+    }
+
+    private static void checkIfProjectOrStableIdExistsAndExit(CommandLine commandLine) {
         String projectTitle = commandLine.getOptionValue(OPTION_REDCAP_PROJECT_TITLE);
         String stableId = commandLine.getOptionValue(OPTION_STABLE_ID);
-        ClinicalDataSource clinicalDataSource = ctx.getBean(ClinicalDataSource.class);
         String message = "project " + projectTitle + " does not exists in RedCap";
         int exitStatusCode = 1;
         if (projectTitle != null) {
             // checking if projectTitle exists in RedCap
-            if (clinicalDataSource.projectExists(projectTitle)) {
+            List<Boolean> projectExists = checkIfProjectsExist(Collections.singletonList(projectTitle));
+            if (projectExists.get(0)) {
                 message = "project " + projectTitle + " exists in RedCap";
                 exitStatusCode = 0;
             }
         } else {
             // checking if any project for stableId exists in RedCap
             message = "no project for stable-id " + stableId + " exists in RedCap";
-            if (clinicalDataSource.projectsExistForStableId(stableId)) {
+            // Both the passed in argument for masked project names and the actual redcap project list have been stored in static data members
+            if (checkIfProjectsExistForStableId()) {
                 message = "projects for stable-id " + stableId + " exist in RedCap";
                 exitStatusCode = 0;
             }
@@ -122,18 +151,26 @@ public class RedcapPipeline {
         System.exit(exitStatusCode);
     }
 
-    private static void launchJob(String[] args, char executionMode, CommandLine commandLine) throws Exception {
-        SpringApplication app = new SpringApplication(RedcapPipeline.class);
-        app.setWebEnvironment(false);
-        ConfigurableApplicationContext ctx = app.run(args);
+    private static Set<String> getProjectTitlesForStableId(String stableId) {
+        Set<String> projectTitleSet = new HashSet<>();
+        ListIterator<String> clinicalProjectIterator = clinicalDataSource.getClinicalProjectTitleIterator(stableId);
+        while (clinicalProjectIterator.hasNext()) {
+            projectTitleSet.add(clinicalProjectIterator.next());
+        }
+        ListIterator<String> timelineProjectIterator = clinicalDataSource.getTimelineProjectTitleIterator(stableId);
+        while (timelineProjectIterator.hasNext()) {
+            projectTitleSet.add(timelineProjectIterator.next());
+        }
+        return projectTitleSet;
+    }
+
+    private static void launchJob(ConfigurableApplicationContext ctx, char executionMode, CommandLine commandLine) throws Exception {
         JobLauncher jobLauncher = ctx.getBean(JobLauncher.class);
         JobParametersBuilder builder = new JobParametersBuilder();
         Job redcapJob = null;
         if (executionMode == EXPORT_MODE) {
             String stableId = commandLine.getOptionValue(OPTION_STABLE_ID);
             String redcapProjectTitle = commandLine.getOptionValue(OPTION_REDCAP_PROJECT_TITLE);
-            ClinicalDataSource clinicalDataSource = ctx.getBean(ClinicalDataSource.class);
-            MetadataManager metadataManager = ctx.getBean(MetadataManager.class);
             if (commandLine.hasOption(OPTION_STABLE_ID)) {
                 if (!clinicalDataSource.projectsExistForStableId(stableId)) {
                     log.error("no project for stable-id " + stableId + " exists in RedCap");
@@ -156,6 +193,7 @@ public class RedcapPipeline {
             }
             builder.addString(OPTION_DIRECTORY, commandLine.getOptionValue(OPTION_DIRECTORY));
             builder.addString("rawData", String.valueOf(commandLine.hasOption(OPTION_RAW_DATA)));
+            builder.addString("maskRedcapProjects", String.join(",", maskProjectArgument));
             if (commandLine.hasOption(OPTION_RAW_DATA)) {
                 redcapJob = ctx.getBean(BatchConfiguration.REDCAP_RAW_EXPORT_JOB, Job.class);
             } else {
@@ -173,7 +211,7 @@ public class RedcapPipeline {
                 log.error("RedcapPipeline job failed with exit status: " + jobExecution.getExitStatus());
                 System.exit(1);
             }
-        }        
+        }
     }
 
     private static char parseModeFromOptions(CommandLine commandLine) {
@@ -227,8 +265,16 @@ public class RedcapPipeline {
             errOut.println("error: only one of -p (--" + OPTION_REDCAP_PROJECT_TITLE + ") or -s (--" + OPTION_STABLE_ID + ") can be provided");
             detectedIllegalUse = true;
         }
+        if (commandLine.hasOption(OPTION_MASK_REDCAP_PROJECTS) && commandLine.hasOption(OPTION_REDCAP_PROJECT_TITLE)) {
+            errOut.println("error: the --" + OPTION_MASK_REDCAP_PROJECTS + " option can not be used with the --" + OPTION_REDCAP_PROJECT_TITLE + " option");
+            detectedIllegalUse = true;
+        }
         if (commandLine.hasOption(OPTION_STABLE_ID) && mode != EXPORT_MODE && mode != CHECK_MODE) {
             errOut.println("error: the --" + OPTION_STABLE_ID + " option can only be used with export-mode or check-mode");
+            detectedIllegalUse = true;
+        }
+        if (commandLine.hasOption(OPTION_MASK_REDCAP_PROJECTS) && mode != EXPORT_MODE && mode != CHECK_MODE) {
+            errOut.println("error: the --" + OPTION_MASK_REDCAP_PROJECTS + " option can only be used with export-mode or check-mode");
             detectedIllegalUse = true;
         }
         if (commandLine.hasOption(OPTION_DIRECTORY) && mode != EXPORT_MODE) {
@@ -287,6 +333,34 @@ public class RedcapPipeline {
         return detectedIllegalUse;
     }
 
+    private static void exitIfMaskProjectsAreNotFound(CommandLine commandLine) {
+        StringBuilder errorMessageBuilder = new StringBuilder();
+        String maskProjectListString = commandLine.getOptionValue(OPTION_MASK_REDCAP_PROJECTS, "");
+        String[] projectNameArgument = maskProjectListString.split(",");
+        for (String projectName : projectNameArgument) {
+            String trimmedProjectName = projectName.trim();
+            if (maskProjectArgument.contains(trimmedProjectName)) {
+                errorMessageBuilder.append("Duplicated project name given in argument to --" + OPTION_MASK_REDCAP_PROJECTS + " : '" + trimmedProjectName + "'\n");
+                continue;
+            }
+            if (trimmedProjectName.length() > 0) {
+                maskProjectArgument.add(trimmedProjectName);
+            }
+        }
+        String stableId = commandLine.getOptionValue(OPTION_STABLE_ID);
+        projectSetForStableId = getProjectTitlesForStableId(stableId);
+        for (String projectName : maskProjectArgument) {
+            if (!projectSetForStableId.contains(projectName)) {
+                errorMessageBuilder.append("Non-existent project name '" + projectName + "' was given for option --" + OPTION_MASK_REDCAP_PROJECTS + "\n");
+                continue;
+            }
+        }
+        if (errorMessageBuilder.length() > 0) {
+            log.error(errorMessageBuilder.toString());
+            System.exit(1);
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         Options options = RedcapPipeline.getOptions(args);
         CommandLineParser parser = new DefaultParser();
@@ -298,9 +372,16 @@ public class RedcapPipeline {
         if (executionMode == UNDETERMINED_MODE) {
             help(options, 1);
         }
+        SpringApplication app = new SpringApplication(RedcapPipeline.class);
+        app.setWebEnvironment(false);
+        ConfigurableApplicationContext ctx = app.run(args);
+        // get necessary beans from context
+        clinicalDataSource = ctx.getBean(ClinicalDataSource.class);
+        metadataManager = ctx.getBean(MetadataManager.class);
+        exitIfMaskProjectsAreNotFound(commandLine);
         if (executionMode == CHECK_MODE) {
-            checkIfProjectOrStableIdExistsAndExit(args, commandLine);
+            checkIfProjectOrStableIdExistsAndExit(commandLine);
         }
-        launchJob(args, executionMode, commandLine);
+        launchJob(ctx, executionMode, commandLine);
     }
 }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReader.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReader.java
@@ -68,17 +68,35 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
     @Value("#{jobParameters[stableId]}")
     private String stableId;
 
+    @Value("#{jobParameters[maskRedcapProjects]}")
+    private String maskRedcapProjects;
+
     private Map<String, List<String>> fullSampleHeader = new HashMap<>();
     private Map<String, List<String>> fullPatientHeader = new HashMap<>();
     private List<Map<String, String>> clinicalRecords = new ArrayList<>();
     private Map<String, Map<String, String>> compiledClinicalSampleRecords = new LinkedHashMap<>();
     private Map<String, Map<String, String>> compiledClinicalPatientRecords = new LinkedHashMap<>();
+    private Set<String> maskRedcapProjectSet = new HashSet<>();
 
     private final Logger log = Logger.getLogger(ClinicalDataReader.class);
 
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
-        String projectTitle = (redcapProjectTitle == null) ? clinicalDataSource.getNextClinicalProjectTitle(stableId) : redcapProjectTitle;
+        parseMaskRedcapProjectSet();
+        String projectTitle = redcapProjectTitle;
+        while (projectTitle == null && clinicalDataSource.hasMoreClinicalData(stableId)) {
+            String nextProjectTitle = clinicalDataSource.getNextClinicalProjectTitle(stableId);
+            if (maskRedcapProjectSet.contains(projectTitle)) {
+                clinicalDataSource.getClinicalData(stableId); // currently, we must get the data in order to move past this project
+                continue;
+            } else {
+                projectTitle = nextProjectTitle;
+            }
+        }
+        if (projectTitle == null) {
+            ec.put("writeRawClinicalData", false);
+            return; // short circuit when all remaining clinical projects have been masked
+        }
         if (rawData && clinicalDataSource.redcapDataTypeIsTimeline(projectTitle)) {
             ec.put("writeRawClinicalData", false);
             return; // short circuit when only exporting a timeline file in rawData mode
@@ -92,18 +110,11 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
             // get clinical data for current clinical data source
             clinicalRecords = clinicalDataSource.exportRawDataForProjectTitle(projectTitle);
         } else {
-            log.info("Getting sample header for project: " + projectTitle);
-            this.fullSampleHeader = metadataManager.getFullHeader(clinicalDataSource.getSampleHeader(stableId));
-            log.info("Getting patient header for project: " + projectTitle);
-            this.fullPatientHeader = metadataManager.getFullHeader(clinicalDataSource.getPatientHeader(stableId));
-            // get clinical and sample data for current clinical data source
-            for (Map<String, String> record : clinicalDataSource.getClinicalData(stableId)) {
-                updateClinicalData(record);
-            }
-            // merge remaining clinical data sources if in merge mode and more clinical data exists
-            if (clinicalDataSource.hasMoreClinicalData(stableId)) {
-                mergeClinicalDataSources();
-            }
+            resetFullHeaders(fullSampleHeader);
+            resetFullHeaders(fullPatientHeader);
+            compiledClinicalSampleRecords.clear();
+            compiledClinicalPatientRecords.clear();
+            mergeClinicalDataSources();
             // associate patient data with their samples so that patient data for each sample is the same
             this.clinicalRecords = mergePatientSampleClinicalRecords();
             // if sample header size is <= 2 then skip writing the sample clinical data file
@@ -127,6 +138,25 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
         ec.put("projectTitle", projectTitle);
     }
 
+    private void parseMaskRedcapProjectSet() {
+        maskRedcapProjectSet.clear();
+        String[] projectNameArgument = maskRedcapProjects.split(",");
+        for (String projectName : projectNameArgument) {
+            String trimmedProjectName = projectName.trim();
+            if (trimmedProjectName.length() > 0) {
+                maskRedcapProjectSet.add(trimmedProjectName);
+            }
+        }
+    }
+
+    private void resetFullHeaders(Map<String, List<String>> fullHeaders) {
+        fullHeaders.clear();
+        String[] headerLineKeys = { "display_names", "descriptions", "datatypes", "priorities", "header" };
+        for (String key : headerLineKeys) {
+            fullHeaders.put(key, new ArrayList<String>());
+        }
+    }
+
     /**
      * Associates patient data with each sample it's associated with.
      * @return
@@ -144,6 +174,10 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
     private void mergeClinicalDataSources() {
         while (clinicalDataSource.hasMoreClinicalData(stableId)) {
             String projectTitle = clinicalDataSource.getNextClinicalProjectTitle(stableId);
+            if (maskRedcapProjectSet.contains(projectTitle)) {
+                clinicalDataSource.getClinicalData(stableId); // currently, we must get the data in order to move past this project
+                continue; // skip masked projects
+            }
 
             // get sample header for project and merge into global sample header list
             log.info("Merging sample header for project: " + projectTitle);

--- a/redcap/redcap_pipeline/src/test/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReaderTestConfiguration.java
+++ b/redcap/redcap_pipeline/src/test/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReaderTestConfiguration.java
@@ -79,6 +79,7 @@ public class ClinicalDataReaderTestConfiguration {
         Properties properties = new Properties();
         properties.setProperty("rawData", "false");
         properties.setProperty("stableId", REDCAP_STABLE_ID);
+        properties.setProperty("maskRedcapProjects", "");
         return properties;
      }
 

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/ClinicalDataSource.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/ClinicalDataSource.java
@@ -29,6 +29,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.redcap.source;
 
 import java.util.*;
@@ -39,6 +40,7 @@ import java.util.*;
  */
 
 public interface ClinicalDataSource {
+
     boolean projectExists(String projectTitle);
     boolean redcapDataTypeIsTimeline(String projectTitle);
     void importClinicalDataFile(String projectTitle, String filename, boolean keepExistingProjectData) throws Exception;
@@ -55,6 +57,6 @@ public interface ClinicalDataSource {
     String getNextTimelineProjectTitle(String stableId);
     boolean hasMoreTimelineData(String stableId);
     boolean hasMoreClinicalData(String stableId);
-    Map<String, List<String>> getFullPatientHeader(Map<String, List<String>> fullHeader);
-    Map<String, List<String>> getFullSampleHeader(Map<String, List<String>> fullHeader);
+    ListIterator<String> getClinicalProjectTitleIterator(String stableId);
+    ListIterator<String> getTimelineProjectTitleIterator(String stableId);
 }

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/MetadataManager.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/MetadataManager.java
@@ -41,6 +41,8 @@ import java.util.Map;
 
 public interface MetadataManager {
     Map<String, List<String>> getFullHeader(List<String> header);
+    Map<String, List<String>> getFullPatientHeader(Map<String, List<String>> fullHeader);
+    Map<String, List<String>> getFullSampleHeader(Map<String, List<String>> fullHeader);
     boolean checkOverridesExist(String studyId);
     boolean allHeadersAreValidClinicalAttributes(List<String> headers);
     void setOverrideStudyId(String studyId);

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceRedcapImpl.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/ClinicalDataSourceRedcapImpl.java
@@ -181,6 +181,16 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
     }
 
     @Override
+    public ListIterator<String> getClinicalProjectTitleIterator(String stableId) {
+        return redcapRepository.getClinicalProjectTitleIterator(stableId);
+    }
+
+    @Override
+    public ListIterator<String> getTimelineProjectTitleIterator(String stableId) {
+        return redcapRepository.getTimelineProjectTitleIterator(stableId);
+    }
+
+    @Override
     public void importClinicalDataFile(String projectTitle, String filename, boolean keepExistingProjectData) throws Exception {
         String projectToken = redcapRepository.getTokenByProjectTitle(projectTitle);
         if (projectToken == null) {
@@ -279,66 +289,6 @@ public class ClinicalDataSourceRedcapImpl implements ClinicalDataSource {
             clinicalTimelineTokens = redcapRepository.getTimelineTokenMapByStableId(stableId);
             clinicalDataTokens = redcapRepository.getClinicalTokenMapByStableId(stableId);
         }
-    }
-
-    /**
-     * Generates list of patient attributes from full header from redcap.
-     * @param fullHeader
-     * @return
-     */
-    @Override
-    public Map<String, List<String>> getFullPatientHeader(Map<String, List<String>> fullHeader) {
-        List<String> displayNames = new ArrayList<>();
-        List<String> descriptions = new ArrayList<>();
-        List<String> datatypes = new ArrayList<>();
-        List<String> priorities = new ArrayList<>();
-        List<String> header = new ArrayList<>();
-
-        for (int i=0; i<fullHeader.get("header").size(); i++) {
-            if (fullHeader.get("attribute_types").get(i).equals("PATIENT")) {
-                displayNames.add(fullHeader.get("display_names").get(i));
-                descriptions.add(fullHeader.get("descriptions").get(i));
-                datatypes.add(fullHeader.get("datatypes").get(i));
-                priorities.add(fullHeader.get("priorities").get(i));
-                header.add(fullHeader.get("header").get(i));
-            }
-        }
-        fullPatientHeader.put("display_names", displayNames);
-        fullPatientHeader.put("descriptions", descriptions);
-        fullPatientHeader.put("datatypes", datatypes);
-        fullPatientHeader.put("priorities", priorities);
-        fullPatientHeader.put("header", header);
-        return fullPatientHeader;
-    }
-
-    /**
-     * Generates list of sample attributes from full header from redcap.
-     * @param fullHeader
-     * @return
-     */
-    @Override
-    public Map<String, List<String>> getFullSampleHeader(Map<String, List<String>> fullHeader) {
-        List<String> displayNames = new ArrayList<>();
-        List<String> descriptions = new ArrayList<>();
-        List<String> datatypes = new ArrayList<>();
-        List<String> priorities = new ArrayList<>();
-        List<String> header = new ArrayList<>();
-
-        for (int i=0; i<fullHeader.get("header").size(); i++) {
-            if (fullHeader.get("attribute_types").get(i).equals("SAMPLE")) {
-                displayNames.add(fullHeader.get("display_names").get(i));
-                descriptions.add(fullHeader.get("descriptions").get(i));
-                datatypes.add(fullHeader.get("datatypes").get(i));
-                priorities.add(fullHeader.get("priorities").get(i));
-                header.add(fullHeader.get("header").get(i));
-            }
-        }
-        fullSampleHeader.put("display_names", displayNames);
-        fullSampleHeader.put("descriptions", descriptions);
-        fullSampleHeader.put("datatypes", datatypes);
-        fullSampleHeader.put("priorities", priorities);
-        fullSampleHeader.put("header", header);
-        return fullSampleHeader;
     }
 
     private List<String> readClinicalFile(File file) throws IOException {

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/MetadataManagerRedcapImpl.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/MetadataManagerRedcapImpl.java
@@ -73,6 +73,26 @@ public class MetadataManagerRedcapImpl implements MetadataManager {
         return makeHeader(combinedAttributeMap);
     }
 
+    /**
+     * Generates list of patient attributes from the passed in fullHeader
+     * @param fullHeader
+     * @return
+     */
+    @Override
+    public Map<String, List<String>> getFullPatientHeader(Map<String, List<String>> fullHeader) {
+        return filterFullHeader(fullHeader, "attribute_types", "PATIENT");
+    }
+
+    /**
+     * Generates list of sample attributes from the passed in fullHeader
+     * @param fullHeader
+     * @return
+     */
+    @Override
+    public Map<String, List<String>> getFullSampleHeader(Map<String, List<String>> fullHeader) {
+        return filterFullHeader(fullHeader, "attribute_types", "SAMPLE");
+    }
+
     @Override
     public boolean allHeadersAreValidClinicalAttributes(List<String> headers) {
         ArrayList<String> invalidHeaders = new ArrayList<>();
@@ -91,6 +111,33 @@ public class MetadataManagerRedcapImpl implements MetadataManager {
             throw new RuntimeException(message.toString());
         }
         return true;
+    }
+
+    private Map<String, List<String>> filterFullHeader(Map<String, List<String>> fullHeader, String metadataAttributeKey, String metadataAttributeValue) {
+        List<String> displayNames = new ArrayList<>();
+        List<String> descriptions = new ArrayList<>();
+        List<String> datatypes = new ArrayList<>();
+        List<String> priorities = new ArrayList<>();
+        List<String> header = new ArrayList<>();
+        if (fullHeader != null) {
+            List<String> metadataAttributeValues = fullHeader.get(metadataAttributeKey);
+            for (int i=0; i<fullHeader.get("header").size(); i++) {
+                if (metadataAttributeValues == null || metadataAttributeValues.get(i).equals(metadataAttributeValue)) {
+                    displayNames.add(fullHeader.get("display_names").get(i));
+                    descriptions.add(fullHeader.get("descriptions").get(i));
+                    datatypes.add(fullHeader.get("datatypes").get(i));
+                    priorities.add(fullHeader.get("priorities").get(i));
+                    header.add(fullHeader.get("header").get(i));
+                }
+            }
+        }
+        Map<String, List<String>> filteredFullHeader = new HashMap<>();
+        filteredFullHeader.put("display_names", displayNames);
+        filteredFullHeader.put("descriptions", descriptions);
+        filteredFullHeader.put("datatypes", datatypes);
+        filteredFullHeader.put("priorities", priorities);
+        filteredFullHeader.put("header", header);
+        return filteredFullHeader;
     }
 
     private List<RedcapAttributeMetadata> getMetadata() {

--- a/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepository.java
+++ b/redcap/redcap_source/src/main/java/org/mskcc/cmo/ks/redcap/source/internal/RedcapRepository.java
@@ -93,6 +93,18 @@ public class RedcapRepository {
         return redcapSessionManager.getTimelineTokenMapByStableId(stableId);
     }
 
+    public ListIterator<String> getClinicalProjectTitleIterator(String stableId) {
+        Map<String, String> clinicalTokenMap = redcapSessionManager.getClinicalTokenMapByStableId(stableId);
+        List<String> clinicalProjectTitleList = new ArrayList<>(clinicalTokenMap.keySet());
+        return clinicalProjectTitleList.listIterator();
+    }
+
+    public ListIterator<String> getTimelineProjectTitleIterator(String stableId) {
+        Map<String, String> timelineTokenMap = redcapSessionManager.getTimelineTokenMapByStableId(stableId);
+        List<String> timelineProjectTitleList = new ArrayList<>(timelineTokenMap.keySet());
+        return timelineProjectTitleList.listIterator();
+    }
+
     /** dataForImport : first element is a tab delimited string holding the headers from the file, additional elements are tab delimited records
     */
     public void importClinicalData(String projectToken, List<String> dataForImport, boolean keepExistingProjectData) throws Exception {


### PR DESCRIPTION
- added command line option "--mask-redcap-projects"
- added validation checks for use of option
- added checks that project names passed in to --mask-redcap-projects exist for stable_id
- altered check mode so that masked projects are not counted in response
- altered export mode : add skipping of masked project titles in readers
moved function for filtering metadata header items to metadata manager
- made common function for filtering (patient or sample)
refactoring
- create project name iterator access functions (does not set or consume project tokens)
- check for existence of data for a given stable-id can be done with new project name iterator
- consolidate context creation in RedcapPipeline.main() and set static references for needed beans

Rebase of #329 