### PR TITLE
Unit tests for project masking option during redcap export

### DIFF
--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/RedcapPipeline.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/RedcapPipeline.java
@@ -41,6 +41,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.log4j.Logger;
 import org.mskcc.cmo.ks.redcap.pipeline.BatchConfiguration;
+import org.mskcc.cmo.ks.redcap.pipeline.util.JobParameterUtils;
 import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
 import org.mskcc.cmo.ks.redcap.source.MetadataManager;
 import org.springframework.batch.core.*;
@@ -60,6 +61,7 @@ public class RedcapPipeline {
 
     private static ClinicalDataSource clinicalDataSource;
     private static MetadataManager metadataManager;
+    private static JobParameterUtils jobParameterUtils;
 
     private static Set<String> maskProjectArgument = new HashSet<String>();
     private static Set<String> projectSetForStableId = new HashSet<String>();
@@ -193,7 +195,8 @@ public class RedcapPipeline {
             }
             builder.addString(OPTION_DIRECTORY, commandLine.getOptionValue(OPTION_DIRECTORY));
             builder.addString("rawData", String.valueOf(commandLine.hasOption(OPTION_RAW_DATA)));
-            builder.addString("maskRedcapProjects", String.join(",", maskProjectArgument));
+            List<String> listOfMaskedProjects = new ArrayList<>(maskProjectArgument);
+            jobParameterUtils.setListOfMaskedProjects(listOfMaskedProjects);
             if (commandLine.hasOption(OPTION_RAW_DATA)) {
                 redcapJob = ctx.getBean(BatchConfiguration.REDCAP_RAW_EXPORT_JOB, Job.class);
             } else {
@@ -378,6 +381,7 @@ public class RedcapPipeline {
         // get necessary beans from context
         clinicalDataSource = ctx.getBean(ClinicalDataSource.class);
         metadataManager = ctx.getBean(MetadataManager.class);
+        jobParameterUtils = ctx.getBean(JobParameterUtils.class);
         exitIfMaskProjectsAreNotFound(commandLine);
         if (executionMode == CHECK_MODE) {
             checkIfProjectOrStableIdExistsAndExit(commandLine);

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReader.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReader.java
@@ -37,6 +37,7 @@ import org.apache.log4j.Logger;
 import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
 import org.mskcc.cmo.ks.redcap.source.MetadataManager;
 import org.mskcc.cmo.ks.redcap.pipeline.util.ConflictingAttributeValuesException;
+import org.mskcc.cmo.ks.redcap.pipeline.util.JobParameterUtils;
 import org.mskcc.cmo.ks.redcap.pipeline.util.RedcapUtils;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -54,6 +55,9 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
     private ClinicalDataSource clinicalDataSource;
 
     @Autowired
+    private JobParameterUtils jobParameterUtils;
+
+    @Autowired
     private MetadataManager metadataManager;
 
     @Autowired
@@ -67,9 +71,6 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
 
     @Value("#{jobParameters[stableId]}")
     private String stableId;
-
-    @Value("#{jobParameters[maskRedcapProjects]}")
-    private String maskRedcapProjects;
 
     private Map<String, List<String>> fullSampleHeader = new HashMap<>();
     private Map<String, List<String>> fullPatientHeader = new HashMap<>();
@@ -140,8 +141,7 @@ public class ClinicalDataReader implements ItemStreamReader<Map<String, String>>
 
     private void parseMaskRedcapProjectSet() {
         maskRedcapProjectSet.clear();
-        String[] projectNameArgument = maskRedcapProjects.split(",");
-        for (String projectName : projectNameArgument) {
+        for (String projectName : jobParameterUtils.getListOfMaskedProjects()) {
             String trimmedProjectName = projectName.trim();
             if (trimmedProjectName.length() > 0) {
                 maskRedcapProjectSet.add(trimmedProjectName);

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineReader.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineReader.java
@@ -35,6 +35,7 @@ package org.mskcc.cmo.ks.redcap.pipeline;
 import java.util.*;
 import org.apache.log4j.Logger;
 import org.mskcc.cmo.ks.redcap.source.*;
+import org.mskcc.cmo.ks.redcap.pipeline.util.JobParameterUtils;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
@@ -50,6 +51,9 @@ public class TimelineReader implements ItemStreamReader<Map<String, String>> {
     @Autowired
     public ClinicalDataSource clinicalDataSource;
 
+    @Autowired
+    public JobParameterUtils jobParameterUtils;
+
     @Value("#{jobParameters[rawData]}")
     private Boolean rawData;
 
@@ -59,10 +63,7 @@ public class TimelineReader implements ItemStreamReader<Map<String, String>> {
     @Value("#{jobParameters[stableId]}")
     public String stableId;
 
-    @Value("#{jobParameters[maskRedcapProjects]}")
-    private String maskRedcapProjects;
-
-    private final Logger log = Logger.getLogger(ClinicalDataReader.class);
+    private final Logger log = Logger.getLogger(TimelineReader.class);
 
     public List<Map<String, String>> timelineRecords = new ArrayList<>();
     private List<String> timelineHeader = new ArrayList<>();
@@ -108,8 +109,7 @@ public class TimelineReader implements ItemStreamReader<Map<String, String>> {
 
     private void parseMaskRedcapProjectSet() {
         maskRedcapProjectSet.clear();
-        String[] projectNameArgument = maskRedcapProjects.split(",");
-        for (String projectName : projectNameArgument) {
+        for (String projectName : jobParameterUtils.getListOfMaskedProjects()) {
             String trimmedProjectName = projectName.trim();
             if (trimmedProjectName.length() > 0) {
                 maskRedcapProjectSet.add(trimmedProjectName);

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/util/JobParameterUtils.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/util/JobParameterUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.redcap.pipeline.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+/**
+ *
+ * @author Avery Wang
+ */
+@Repository
+public class JobParameterUtils {
+    
+    private List<String> listOfMaskedProjects = new ArrayList<String>();
+   
+    public void setListOfMaskedProjects(List<String> listOfMaskedProjects) {
+        this.listOfMaskedProjects = listOfMaskedProjects;
+    }
+ 
+    public List<String> getListOfMaskedProjects() {
+        return listOfMaskedProjects;
+    }
+}

--- a/redcap/redcap_pipeline/src/test/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReaderTestConfiguration.java
+++ b/redcap/redcap_pipeline/src/test/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalDataReaderTestConfiguration.java
@@ -41,7 +41,9 @@ import org.mockito.Mockito;
 import org.mskcc.cmo.ks.redcap.models.RedcapAttributeMetadata;
 import org.mskcc.cmo.ks.redcap.models.RedcapProjectAttribute;
 import org.mskcc.cmo.ks.redcap.pipeline.ClinicalDataReader;
+import org.mskcc.cmo.ks.redcap.pipeline.TimelineReader;
 import org.mskcc.cmo.ks.redcap.pipeline.util.RedcapUtils;
+import org.mskcc.cmo.ks.redcap.pipeline.util.JobParameterUtils;
 import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
 import org.mskcc.cmo.ks.redcap.source.internal.ClinicalDataSourceRedcapImpl;
 import org.mskcc.cmo.ks.redcap.source.internal.CDDSessionManager;
@@ -53,6 +55,7 @@ import org.mskcc.cmo.ks.redcap.source.MetadataManager;
 import org.mskcc.cmo.ks.redcap.util.ValueNormalizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.*;
 
 @Configuration
 public class ClinicalDataReaderTestConfiguration {
@@ -68,6 +71,23 @@ public class ClinicalDataReaderTestConfiguration {
     public static final String MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TITLE = "GbmPatientProjectTitle";
     public static final String MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TOKEN = "GbmPatientProjectToken";
     public static final String MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_INSTRUMENT_NAME = "my_first_instrument";
+    public static final String MSKIMPACT_MASKED_CLINICAL_PROJECT_TITLE = "ExcludedClinicalProjectTitle";
+    public static final String MSKIMPACT_MASKED_CLINICAL_PROJECT_TOKEN = "ExcludedClinicalProjectToken";
+    public static final String MSKIMPACT_MASKED_CLINICAL_PROJECT_INSTRUMENT_NAME = "my_first_instrument";
+    public static final String MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_TITLE = "SecondExcludedClinicalProjectTitle";
+    public static final String MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_TOKEN = "SecondExcludedClinicalProjectToken";
+    public static final String MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_INSTRUMENT_NAME = "my_first_instrument";
+    public static final String MSKIMPACT_TIMELINE_PROJECT_TITLE = "TimelineProjectTitle";
+    public static final String MSKIMPACT_TIMELINE_PROJECT_TOKEN = "TimelineProjectToken";
+    public static final String MSKIMPACT_TIMELINE_PROJECT_INSTRUMENT_NAME = "my_first_instrument";
+    public static final String MSKIMPACT_MASKED_TIMELINE_PROJECT_TITLE = "MaskedTimelineProjectTitle";
+    public static final String MSKIMPACT_MASKED_TIMELINE_PROJECT_TOKEN = "MaskedTimelineProjectToken";
+    public static final String MSKIMPACT_MASKED_TIMELINE_INSTRUMENT_NAME = "my_first_instrument";
+
+    @Bean
+    public JobParameterUtils jobParameterUtils() {
+        return new JobParameterUtils();
+    }
 
     @Bean
     public ClinicalDataReader clinicalDataReader() {
@@ -75,20 +95,17 @@ public class ClinicalDataReaderTestConfiguration {
     }
 
     @Bean
-    public Properties jobParameters(){
-        Properties properties = new Properties();
-        properties.setProperty("rawData", "false");
-        properties.setProperty("stableId", REDCAP_STABLE_ID);
-        properties.setProperty("maskRedcapProjects", "");
-        return properties;
-     }
-
+    public TimelineReader timelineReader() {
+        return new TimelineReader();
+    }
+    
     @Bean
     public MetadataManager metadataManager() {
         return new MetadataManagerRedcapImpl();
     }
 
-    @Bean CDDSessionManager cddSesssionManager() {
+    @Bean 
+    public CDDSessionManager cddSesssionManager() {
         CDDSessionManager cddSessionManager = Mockito.mock(CDDSessionManager.class);
         RedcapAttributeMetadata[] mockReturnForGetMetadata = makeMockMetadata();
         Mockito.when(cddSessionManager.getRedcapMetadata()).thenReturn(mockReturnForGetMetadata);
@@ -126,36 +143,66 @@ public class ClinicalDataReaderTestConfiguration {
     public ValueNormalizer valueNormalizer() {
         return new ValueNormalizer();
     }
+    
+    @Bean
+    public Properties jobParameters() {
+        Properties properties = new Properties();
+        properties.setProperty("rawData", "false");
+        properties.setProperty("stableId", REDCAP_STABLE_ID);
+        return properties;
+    }
 
     private void configureMockRedcapSessionManager(RedcapSessionManager mockRedcapSessionManager) {
         //configure token requests
         Mockito.when(mockRedcapSessionManager.getTokenByProjectTitle(ArgumentMatchers.eq(MSKIMPACT_GBM_SAMPLE_CLINICAL_PROJECT_TITLE))).thenReturn(MSKIMPACT_GBM_SAMPLE_CLINICAL_PROJECT_TOKEN);
         Mockito.when(mockRedcapSessionManager.getTokenByProjectTitle(ArgumentMatchers.eq(MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TITLE))).thenReturn(MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TOKEN);
+        Mockito.when(mockRedcapSessionManager.getTokenByProjectTitle(ArgumentMatchers.eq(MSKIMPACT_MASKED_CLINICAL_PROJECT_TITLE))).thenReturn(MSKIMPACT_MASKED_CLINICAL_PROJECT_TOKEN);
+        Mockito.when(mockRedcapSessionManager.getTokenByProjectTitle(ArgumentMatchers.eq(MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_TITLE))).thenReturn(MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_TOKEN);
+        Mockito.when(mockRedcapSessionManager.getTokenByProjectTitle(ArgumentMatchers.eq(MSKIMPACT_TIMELINE_PROJECT_TITLE))).thenReturn(MSKIMPACT_TIMELINE_PROJECT_TOKEN);
+        Mockito.when(mockRedcapSessionManager.getTokenByProjectTitle(ArgumentMatchers.eq(MSKIMPACT_MASKED_TIMELINE_PROJECT_TITLE))).thenReturn(MSKIMPACT_MASKED_TIMELINE_PROJECT_TOKEN);
         Mockito.when(mockRedcapSessionManager.getTimelineTokenMapByStableId(ArgumentMatchers.eq(REDCAP_STABLE_ID))).thenReturn(makeMockTimelineTokenMap());
         Mockito.when(mockRedcapSessionManager.getClinicalTokenMapByStableId(ArgumentMatchers.eq(REDCAP_STABLE_ID))).thenReturn(makeMockClinicalTokenMap());
         //configure redcap data requests
         Mockito.when(mockRedcapSessionManager.getRedcapAttributeByToken(ArgumentMatchers.eq(MSKIMPACT_GBM_SAMPLE_CLINICAL_PROJECT_TOKEN))).thenReturn(makeMockGbmSampleAttributesData());
         Mockito.when(mockRedcapSessionManager.getRedcapAttributeByToken(ArgumentMatchers.eq(MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TOKEN))).thenReturn(makeMockGbmPatientAttributesData());
+        Mockito.when(mockRedcapSessionManager.getRedcapAttributeByToken(ArgumentMatchers.eq(MSKIMPACT_MASKED_CLINICAL_PROJECT_TOKEN))).thenReturn(makeMockGbmSampleAttributesData());
+        Mockito.when(mockRedcapSessionManager.getRedcapAttributeByToken(ArgumentMatchers.eq(MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_TOKEN))).thenReturn(makeMockGbmSampleAttributesData());
+        Mockito.when(mockRedcapSessionManager.getRedcapAttributeByToken(ArgumentMatchers.eq(MSKIMPACT_TIMELINE_PROJECT_TOKEN))).thenReturn(makeMockTimelineAttributesData());
+        Mockito.when(mockRedcapSessionManager.getRedcapAttributeByToken(ArgumentMatchers.eq(MSKIMPACT_MASKED_TIMELINE_PROJECT_TOKEN))).thenReturn(makeMockTimelineAttributesData());
+
         Mockito.when(mockRedcapSessionManager.redcapDataTypeIsTimeline(ArgumentMatchers.eq(MSKIMPACT_GBM_SAMPLE_CLINICAL_PROJECT_TITLE))).thenReturn(false);
         Mockito.when(mockRedcapSessionManager.redcapDataTypeIsTimeline(ArgumentMatchers.eq(MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TITLE))).thenReturn(false);
+        Mockito.when(mockRedcapSessionManager.redcapDataTypeIsTimeline(ArgumentMatchers.eq(MSKIMPACT_MASKED_CLINICAL_PROJECT_TITLE))).thenReturn(false);
+        Mockito.when(mockRedcapSessionManager.redcapDataTypeIsTimeline(ArgumentMatchers.eq(MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_TITLE))).thenReturn(false);
+        Mockito.when(mockRedcapSessionManager.redcapDataTypeIsTimeline(ArgumentMatchers.eq(MSKIMPACT_TIMELINE_PROJECT_TITLE))).thenReturn(true);
+        Mockito.when(mockRedcapSessionManager.redcapDataTypeIsTimeline(ArgumentMatchers.eq(MSKIMPACT_MASKED_TIMELINE_PROJECT_TITLE))).thenReturn(true);
+
         Mockito.when(mockRedcapSessionManager.getRedcapDataForProjectByToken(ArgumentMatchers.eq(MSKIMPACT_GBM_SAMPLE_CLINICAL_PROJECT_TOKEN))).thenReturn(makeMockGbmSampleData());
         Mockito.when(mockRedcapSessionManager.getRedcapDataForProjectByToken(ArgumentMatchers.eq(MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TOKEN))).thenReturn(makeMockGbmPatientData());
+        Mockito.when(mockRedcapSessionManager.getRedcapDataForProjectByToken(ArgumentMatchers.eq(MSKIMPACT_MASKED_CLINICAL_PROJECT_TOKEN))).thenReturn(makeMockMaskedSampleData());
+        Mockito.when(mockRedcapSessionManager.getRedcapDataForProjectByToken(ArgumentMatchers.eq(MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_TOKEN))).thenReturn(makeSecondMockMaskedSampleData());
+        Mockito.when(mockRedcapSessionManager.getRedcapDataForProjectByToken(ArgumentMatchers.eq(MSKIMPACT_TIMELINE_PROJECT_TOKEN))).thenReturn(makeMockTimelineData());
+        Mockito.when(mockRedcapSessionManager.getRedcapDataForProjectByToken(ArgumentMatchers.eq(MSKIMPACT_MASKED_TIMELINE_PROJECT_TOKEN))).thenReturn(makeMockMaskedTimelineData());    
     }
 
     private Map<String, String> makeMockClinicalTokenMap() {
         Map<String, String> returnMap = new HashMap<>();
         returnMap.put(MSKIMPACT_GBM_SAMPLE_CLINICAL_PROJECT_TITLE, MSKIMPACT_GBM_SAMPLE_CLINICAL_PROJECT_TOKEN);
         returnMap.put(MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TITLE, MSKIMPACT_GBM_PATIENT_CLINICAL_PROJECT_TOKEN);
+        returnMap.put(MSKIMPACT_MASKED_CLINICAL_PROJECT_TITLE, MSKIMPACT_MASKED_CLINICAL_PROJECT_TOKEN);
+        returnMap.put(MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_TITLE, MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_TOKEN);
         return returnMap;
     }
 
     private Map<String, String> makeMockTimelineTokenMap() {
         Map<String, String> returnMap = new HashMap<>();
+        returnMap.put(MSKIMPACT_TIMELINE_PROJECT_TITLE, MSKIMPACT_TIMELINE_PROJECT_TOKEN);
+        returnMap.put(MSKIMPACT_MASKED_TIMELINE_PROJECT_TITLE, MSKIMPACT_MASKED_TIMELINE_PROJECT_TOKEN);
         return returnMap;
     }
 
     private RedcapAttributeMetadata[] makeMockMetadata() {
-        RedcapAttributeMetadata[] metadata = new RedcapAttributeMetadata[4];
+        RedcapAttributeMetadata[] metadata = new RedcapAttributeMetadata[6];
         metadata[0] = new RedcapAttributeMetadata();
         metadata[0].setNormalizedColumnHeader("PATIENT_ID");
         metadata[0].setAttributeType("PATIENT");
@@ -185,6 +232,20 @@ public class ClinicalDataReaderTestConfiguration {
         metadata[3].setDisplayName("Sample Id");
         metadata[3].setDatatype("STRING");
         metadata[3].setDescriptions("This identifies a sample");
+        metadata[4] = new RedcapAttributeMetadata();
+        metadata[4].setNormalizedColumnHeader("START_DATE");
+        metadata[4].setAttributeType("PATIENT");
+        metadata[4].setPriority("1");
+        metadata[4].setDisplayName("Start Date");
+        metadata[4].setDatatype("NUMBER");
+        metadata[4].setDescriptions("start date");
+        metadata[5] = new RedcapAttributeMetadata();
+        metadata[5].setNormalizedColumnHeader("STOP_DATE");
+        metadata[5].setAttributeType("PATIENT");
+        metadata[5].setPriority("1");
+        metadata[5].setDisplayName("Stop Date");
+        metadata[5].setDatatype("NUMBER");
+        metadata[5].setDescriptions("stop date");
         return metadata;
     }
 
@@ -231,6 +292,24 @@ public class ClinicalDataReaderTestConfiguration {
         return attributeArray;
     }
 
+    private RedcapProjectAttribute[] makeMockTimelineAttributesData() {
+        RedcapProjectAttribute[] attributeArray = new RedcapProjectAttribute[3];
+        RedcapProjectAttribute patientIdAttribute = new RedcapProjectAttribute();
+        patientIdAttribute.setFieldName("patient_id");
+        patientIdAttribute.setFormName("my_first_instrument");
+        attributeArray[0] = patientIdAttribute;
+        RedcapProjectAttribute startDateAttribute = new RedcapProjectAttribute();
+        startDateAttribute.setFieldName("start_date");
+        startDateAttribute.setFormName("my_first_instrument");
+        attributeArray[1] = startDateAttribute;
+        RedcapProjectAttribute stopDateAttribute = new RedcapProjectAttribute();
+        stopDateAttribute.setFieldName("stop_date");
+        stopDateAttribute.setFormName("my_first_instrument");
+        attributeArray[2] = stopDateAttribute;
+        return attributeArray;
+    }
+
+ 
     private JsonNode[] makeMockGbmSampleData() {
         String mockReturnJsonString =
                 "[" +
@@ -241,12 +320,52 @@ public class ClinicalDataReaderTestConfiguration {
         return makeMockReturnForGetData(mockReturnJsonString);
     }
 
+    private JsonNode[] makeMockMaskedSampleData() {
+        String mockReturnJsonString =
+                "[" +
+                    "{\"sample_id\":\"P-0000004-T01-IM6\",\"patient_id\":\"P-0000004\",\"cancer_type\":\"GBM\"}," +
+                    "{\"sample_id\":\"P-0000005-T01-IM6\",\"patient_id\":\"P-0000005\",\"cancer_type\":\"GBM\"}," +
+                    "{\"sample_id\":\"P-0000006-T01-IM6\",\"patient_id\":\"P-0000006\",\"cancer_type\":\"GBM\"}" +
+                "]";
+        return makeMockReturnForGetData(mockReturnJsonString);
+    }
+   
+    private JsonNode[] makeSecondMockMaskedSampleData() {
+        String mockReturnJsonString =
+                "[" +
+                    "{\"sample_id\":\"P-0000007-T01-IM6\",\"patient_id\":\"P-0000007\",\"cancer_type\":\"GBM\"}," +
+                    "{\"sample_id\":\"P-0000008-T01-IM6\",\"patient_id\":\"P-0000008\",\"cancer_type\":\"GBM\"}," +
+                    "{\"sample_id\":\"P-0000009-T01-IM6\",\"patient_id\":\"P-0000009\",\"cancer_type\":\"GBM\"}" +
+                "]";
+        return makeMockReturnForGetData(mockReturnJsonString);
+    }
+   
+    private JsonNode[] makeMockTimelineData() {
+        String mockReturnJsonString =
+                "[" +
+                    "{\"patient_id\":\"P-0000001\",\"start_date\":\"5\",\"stop_date\":\"20\"}," +
+                    "{\"patient_id\":\"P-0000002\",\"start_date\":\"12\",\"stop_date\":\"87\"}," +
+                    "{\"patient_id\":\"P-0000003\",\"start_date\":\"13\",\"stop_date\":\"24\"}" +
+                "]";
+        return makeMockReturnForGetData(mockReturnJsonString);
+    }
+
     private JsonNode[] makeMockGbmPatientData() {
         String mockReturnJsonString =
                 "[" +
                     "{\"patient_id\":\"P-0000001\",\"age\":\"29\"}," +
                     "{\"patient_id\":\"P-0000002\",\"age\":\"48\"}," +
                     "{\"patient_id\":\"P-0000003\",\"age\":\"71\"}" +
+                "]";
+        return makeMockReturnForGetData(mockReturnJsonString);
+    }
+
+    private JsonNode[] makeMockMaskedTimelineData() {
+        String mockReturnJsonString =
+                "[" +
+                    "{\"patient_id\":\"P-0000004\",\"start_date\":\"5\",\"stop_date\":\"20\"}," +
+                    "{\"patient_id\":\"P-0000005\",\"start_date\":\"12\",\"stop_date\":\"87\"}," +
+                    "{\"patient_id\":\"P-0000006\",\"start_date\":\"13\",\"stop_date\":\"24\"}" +
                 "]";
         return makeMockReturnForGetData(mockReturnJsonString);
     }

--- a/redcap/redcap_pipeline/src/test/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineReaderTest.java
+++ b/redcap/redcap_pipeline/src/test/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineReaderTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2017-2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.redcap.pipeline;
+
+import java.io.*;
+import java.lang.StringBuilder;
+import java.util.*;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.Test;
+import org.mskcc.cmo.ks.redcap.pipeline.TimelineReader;
+import org.mskcc.cmo.ks.redcap.pipeline.ClinicalDataReaderTestConfiguration;
+import org.mskcc.cmo.ks.redcap.pipeline.util.JobParameterUtils;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.beans.factory.config.BeanExpressionContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.*;
+
+@ContextConfiguration(classes=ClinicalDataReaderTestConfiguration.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+public class TimelineReaderTest {
+
+    @Autowired
+    private TimelineReader timelineReader;
+
+    @Autowired
+    private JobParameterUtils jobParameterUtils;
+   
+    @Test
+    public void testTimelineReaderWithOneMaskedProject() {
+        List<String> listOfMaskedProjects = new ArrayList<>();
+        listOfMaskedProjects.add(ClinicalDataReaderTestConfiguration.MSKIMPACT_SECOND_MASKED_CLINICAL_PROJECT_TITLE);
+        listOfMaskedProjects.add(ClinicalDataReaderTestConfiguration.MSKIMPACT_MASKED_TIMELINE_PROJECT_TITLE);
+        jobParameterUtils.setListOfMaskedProjects(listOfMaskedProjects);
+        compareReturnedToExpectedTimelineRecords(makeMaskedTimelineProjectsExpectedPatientToRecordMap());
+    }
+
+    public void compareReturnedToExpectedTimelineRecords(Map<String, Map<String, String>> expectedPatientToRecordMap) {
+        ExecutionContext ec = new ExecutionContext();
+        timelineReader.open(ec);
+        StringBuilder errorMessage = new StringBuilder("\nFailures:\n");
+        int failCount = 0;
+        Map<String, Map<String, String>> returnedPatientToRecordMap = new HashMap<>();
+        // compare returned values to expected
+        while (true) {
+            Map<String, String> returnedRecord = null;
+            try {
+                returnedRecord = timelineReader.read();
+            } catch (Exception e) {
+                Assert.fail("Exception thrown from TimelineReader.read() : " + e.getMessage());
+            }
+            if (returnedRecord == null) {
+                break;
+            }
+            String patient_id = returnedRecord.get("PATIENT_ID");
+            if (patient_id == null) {
+                failCount = failCount + 1;
+                errorMessage.append("TimelineReader.read() returned record with null PATIENT_ID : " + recordToString(returnedRecord) + "\n");
+                continue;
+            }
+            returnedPatientToRecordMap.put(patient_id, returnedRecord);
+        }
+        for (String returnedPatientId : returnedPatientToRecordMap.keySet()) {
+            if (returnedPatientId == null) {
+                continue; //already reported above
+            }
+            Map<String, String> returnedRecord = returnedPatientToRecordMap.get(returnedPatientId);
+            Map<String, String> expectedRecord = expectedPatientToRecordMap.get(returnedPatientId);
+            if (expectedRecord == null) {
+                failCount = failCount + 1;
+                errorMessage.append("Record from TimelineReader.read() has unexpected PATIENT_ID : " + recordToString(returnedRecord) + "\n");
+                continue;
+            }
+            Set<String> returnedRecordKeys = returnedRecord.keySet();
+            Set<String> expectedRecordKeys = expectedRecord.keySet();
+            for (String key : returnedRecordKeys) {
+                String returnedRecordValue = returnedRecord.get(key);
+                String expectedRecordValue = expectedRecord.get(key);
+                if (expectedRecordValue == null) {
+                    failCount = failCount + 1;
+                    errorMessage.append("Record from TimelineReader.read() has unexpected field " + key + " : " + recordToString(returnedRecord) + "\n");
+                    continue;
+                }
+                expectedRecordKeys.remove(key);
+                if (returnedRecordValue != null && !returnedRecordValue.equals(expectedRecordValue)) {
+                    failCount = failCount + 1;
+                    errorMessage.append("Record from TimelineReader.read() has unexpected value (expected: " + expectedRecordValue + ") in field " + key + " : " + recordToString(returnedRecord) + "\n");
+                    continue;
+                }
+            }
+            if (!expectedRecordKeys.isEmpty()) {
+                failCount = failCount + 1;
+                errorMessage.append("Record from TimelineReader.read() has missing fields ( ");
+                for (String key : expectedRecordKeys) {
+                    errorMessage.append(key + " ");
+                }
+                errorMessage.append(") " + recordToString(returnedRecord) + "\n");
+            }
+        }
+        for (String expectedPatientId : expectedPatientToRecordMap.keySet()) {
+            if (!returnedPatientToRecordMap.containsKey(expectedPatientId)) {
+                failCount = failCount + 1;
+                errorMessage.append("Record expected from TimelineReader.read() was not seen : " + recordToString(expectedPatientToRecordMap.get(expectedPatientId)) + "\n");
+                continue;
+            }
+        }
+        if (failCount > 0) {
+            Assert.fail(errorMessage.toString());
+        }
+    }
+
+    private String recordToString(Map<String, String> record) {
+        StringBuilder returnString = new StringBuilder("[");
+        int initialStringLength = returnString.length();
+        LinkedHashSet<String> keys = new LinkedHashSet<>(record.keySet());
+        if (keys.contains("patient_id")) {
+            addToRecordToStringOutput(returnString, "patient_id", record, initialStringLength);
+            keys.remove("patient_id");
+        }
+        if (keys.contains("patient_id")) {
+            addToRecordToStringOutput(returnString, "patient_id", record, initialStringLength);
+            keys.remove("patient_id");
+        }
+        for (String key : record.keySet()) {
+            addToRecordToStringOutput(returnString, key, record, initialStringLength);
+        }
+        returnString.append("]");
+        return returnString.toString();
+    }
+
+    private void addToRecordToStringOutput(StringBuilder returnString, String key, Map<String, String> record, int initialStringLength) {
+        if (returnString.length() > initialStringLength) {
+            returnString.append(",");
+        }
+        returnString.append(key + ":" + record.get(key));
+    }
+
+    private Map<String, Map<String, String>> makeMaskedTimelineProjectsExpectedPatientToRecordMap() {
+        Map<String, Map<String, String>> expectedRecordMap = new HashMap<>(3);
+        Map<String, String> nextRecord = new HashMap<>();
+        nextRecord.put("PATIENT_ID", "P-0000001");
+        nextRecord.put("START_DATE", "5");
+        nextRecord.put("STOP_DATE", "20");
+        expectedRecordMap.put(nextRecord.get("PATIENT_ID"), nextRecord);
+        nextRecord = new HashMap<>();
+        nextRecord.put("PATIENT_ID", "P-0000002");
+        nextRecord.put("START_DATE", "12");
+        nextRecord.put("STOP_DATE", "87");
+        expectedRecordMap.put(nextRecord.get("PATIENT_ID"), nextRecord);
+        nextRecord = new HashMap<>();
+        nextRecord.put("PATIENT_ID", "P-0000003");
+        nextRecord.put("START_DATE", "13");
+        nextRecord.put("STOP_DATE", "24");
+        expectedRecordMap.put(nextRecord.get("PATIENT_ID"), nextRecord);
+        return expectedRecordMap;
+    }
+}


### PR DESCRIPTION
- previous test changed to general function for comparing expected records to returned records
- tests based on comparing expected vs returned for different "jobs" (masking one project, masking two projects)
- masked projects should not have records written out
- projects with patient-only data which do not map to a sample should not be written out
- similar tests added for TimelineReader
- masking timeline project should not affect ClinicalReader output at all (and vice versa)
- masked projects list now stored in a JobParameterUtils bean which is autowired in to the readers
- additional mocked projects