### PR TITLE
Timeline reference date as DOB, not first diagnosis date

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineChemoProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineChemoProcessor.java
@@ -57,14 +57,13 @@ public class TimelineChemoProcessor implements ItemProcessor<DDPCompositeRecord,
     public List<String> process(DDPCompositeRecord compositeRecord) throws Exception {
         // we can't generate chemo timeline records without a reference date or if patient
         // hasn't had any chemo procedures - return null
-        String firstTumorDiagnosisDate = DDPUtils.getFirstTumorDiagnosisDate(compositeRecord.getPatientDiagnosis());
-        if (Strings.isNullOrEmpty(firstTumorDiagnosisDate) ||
+        if (Strings.isNullOrEmpty(compositeRecord.getPatientBirthDate()) ||
                 compositeRecord.getChemoProcedures()== null ||
                 compositeRecord.getChemoProcedures().isEmpty()) {
             return null;
         }
         // convert chemo procedures into timeline records
-        List<TimelineChemoRecord> timelineChemoRecords = convertTimelineChemoRecords(compositeRecord.getDmpPatientId(), firstTumorDiagnosisDate, compositeRecord.getChemoProcedures());
+        List<TimelineChemoRecord> timelineChemoRecords = convertTimelineChemoRecords(compositeRecord.getDmpPatientId(), compositeRecord.getPatientBirthDate(), compositeRecord.getChemoProcedures());
         if (timelineChemoRecords ==  null || timelineChemoRecords.isEmpty()) {
             LOG.error("Failed to convert any chemo procedures into timeline records for patient: " + compositeRecord.getDmpPatientId());
             return null;
@@ -87,16 +86,16 @@ public class TimelineChemoProcessor implements ItemProcessor<DDPCompositeRecord,
      * Converts chemo procedures into timeline chemo records.
      *
      * @param dmpPatientId
-     * @param firstTumorDiagnosisDate
+     * @param referenceDate - the date of birth
      * @param chemoProcedures
      * @return
      */
-    private List<TimelineChemoRecord> convertTimelineChemoRecords(String dmpPatientId, String firstTumorDiagnosisDate, List<Chemotherapy> chemoProcedures) {
+    private List<TimelineChemoRecord> convertTimelineChemoRecords(String dmpPatientId, String referenceDate, List<Chemotherapy> chemoProcedures) {
         List<TimelineChemoRecord> timelineChemoRecords = new ArrayList<>();
         for (Chemotherapy procedure : chemoProcedures) {
             TimelineChemoRecord record;
             try {
-                record = new TimelineChemoRecord(dmpPatientId, firstTumorDiagnosisDate, procedure);
+                record = new TimelineChemoRecord(dmpPatientId, referenceDate, procedure);
             }
             catch (ParseException e) {
                 LOG.error("Error converting chemo procedure into timeline chemo record: " +

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineRadiationProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineRadiationProcessor.java
@@ -57,14 +57,13 @@ public class TimelineRadiationProcessor implements ItemProcessor<DDPCompositeRec
     public List<String> process(DDPCompositeRecord compositeRecord) throws Exception {
         // we can't generate radiation timeline records without a reference date or if patient
         // hasn't had any radiation procedures - return null
-        String firstTumorDiagnosisDate = DDPUtils.getFirstTumorDiagnosisDate(compositeRecord.getPatientDiagnosis());
-        if (Strings.isNullOrEmpty(firstTumorDiagnosisDate) ||
+        if (Strings.isNullOrEmpty(compositeRecord.getPatientBirthDate()) ||
                 compositeRecord.getRadiationProcedures() == null ||
                 compositeRecord.getRadiationProcedures().isEmpty()) {
             return null;
         }
         // convert radiation procedures into timeline records
-        List<TimelineRadiationRecord> timelineRadiationRecords = convertTimelineRadiationRecords(compositeRecord.getDmpPatientId(), firstTumorDiagnosisDate, compositeRecord.getRadiationProcedures());
+        List<TimelineRadiationRecord> timelineRadiationRecords = convertTimelineRadiationRecords(compositeRecord.getDmpPatientId(), compositeRecord.getPatientBirthDate(), compositeRecord.getRadiationProcedures());
         if (timelineRadiationRecords ==  null || timelineRadiationRecords.isEmpty()) {
             LOG.error("Failed to convert any radiation procedures into timeline records for patient: " + compositeRecord.getDmpPatientId());
             return null;
@@ -87,16 +86,16 @@ public class TimelineRadiationProcessor implements ItemProcessor<DDPCompositeRec
      * Converts radiation procedures into timeline radiation records.
      *
      * @param dmpPatientId
-     * @param firstTumorDiagnosisDate
+     * @param referenceDate - the date of birth
      * @param radiationProcedures
      * @return
      */
-    private List<TimelineRadiationRecord> convertTimelineRadiationRecords(String dmpPatientId, String firstTumorDiagnosisDate, List<Radiation> radiationProcedures) {
+    private List<TimelineRadiationRecord> convertTimelineRadiationRecords(String dmpPatientId, String referenceDate, List<Radiation> radiationProcedures) {
         List<TimelineRadiationRecord> timelineRadiationRecords = new ArrayList<>();
         for (Radiation procedure : radiationProcedures) {
             TimelineRadiationRecord record;
             try {
-                record = new TimelineRadiationRecord(dmpPatientId, firstTumorDiagnosisDate, procedure);
+                record = new TimelineRadiationRecord(dmpPatientId, referenceDate, procedure);
             }
             catch (ParseException e) {
                 LOG.error("Error converting radiation procedure into timeline radiation record: " +

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineSurgeryProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineSurgeryProcessor.java
@@ -57,14 +57,13 @@ public class TimelineSurgeryProcessor implements ItemProcessor<DDPCompositeRecor
     public List<String> process(DDPCompositeRecord compositeRecord) throws Exception {
         // we can't generate surgery timeline records without a reference date or if patient
         // hasn't had any surgery procedures - return null
-        String firstTumorDiagnosisDate = DDPUtils.getFirstTumorDiagnosisDate(compositeRecord.getPatientDiagnosis());
-        if (Strings.isNullOrEmpty(firstTumorDiagnosisDate) ||
+        if (Strings.isNullOrEmpty(compositeRecord.getPatientBirthDate()) ||
                 compositeRecord.getSurgicalProcedures()== null ||
                 compositeRecord.getSurgicalProcedures().isEmpty()) {
             return null;
         }
         // convert surgery procedures into timeline records
-        List<TimelineSurgeryRecord> timelineSurgeryRecords = convertTimelineSurgeryRecords(compositeRecord.getDmpPatientId(), firstTumorDiagnosisDate, compositeRecord.getSurgicalProcedures());
+        List<TimelineSurgeryRecord> timelineSurgeryRecords = convertTimelineSurgeryRecords(compositeRecord.getDmpPatientId(), compositeRecord.getPatientBirthDate(), compositeRecord.getSurgicalProcedures());
         if (timelineSurgeryRecords ==  null || timelineSurgeryRecords.isEmpty()) {
             LOG.error("Failed to convert any surgical procedures into timeline records for patient: " + compositeRecord.getDmpPatientId());
             return null;
@@ -86,16 +85,16 @@ public class TimelineSurgeryProcessor implements ItemProcessor<DDPCompositeRecor
      * Converts surgery procedures into timeline surgery records.
      *
      * @param dmpPatientId
-     * @param firstTumorDiagnosisDate
+     * @param referenceDate - the date of birth
      * @param surgicalProcedures
      * @return
      */
-    private List<TimelineSurgeryRecord> convertTimelineSurgeryRecords(String dmpPatientId, String firstTumorDiagnosisDate, List<Surgery> surgicalProcedures) {
+    private List<TimelineSurgeryRecord> convertTimelineSurgeryRecords(String dmpPatientId, String referenceDate, List<Surgery> surgicalProcedures) {
         List<TimelineSurgeryRecord> timelineSurgeryRecords = new ArrayList<>();
         for (Surgery procedure : surgicalProcedures) {
             TimelineSurgeryRecord record;
             try {
-                record = new TimelineSurgeryRecord(dmpPatientId, firstTumorDiagnosisDate, procedure);
+                record = new TimelineSurgeryRecord(dmpPatientId, referenceDate, procedure);
             }
             catch (ParseException e) {
                 LOG.error("Error converting surgical procedure into timeline surgery record: " +

--- a/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtilsTestConfiguration.java
+++ b/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtilsTestConfiguration.java
@@ -32,26 +32,11 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline.util;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.base.Strings;
-import java.io.*;
-import java.util.*;
-import org.mockito.*;
-import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
-import org.mskcc.cmo.ks.ddp.source.internal.DDPRepository;
-import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
 import org.mskcc.cmo.ks.ddp.source.internal.DDPSourceTestConfiguration;
-import org.mskcc.cmo.ks.ddp.source.model.*;
-import org.mskcc.cmo.ks.ddp.source.util.AuthenticationUtil;
-import org.mskcc.cmo.ks.ddp.source.util.DDPResponseUtil;
 import org.springframework.context.annotation.*;
 
 @Configuration
 @Import(DDPSourceTestConfiguration.class)
 public class DDPUtilsTestConfiguration {
-
-    @Bean DDPUtils ddpUtils() {
-        return new DDPUtils();
-    }
-
+    // TO-DO: Get rid of DDPUtilsTestConfiguration if not going to be expanded
 }


### PR DESCRIPTION
Use DOB as reference date when calculating timeline events in days instead of first tumor diagnosis date.

- Added check to explicitly check if patient sex value is F/FEMALE instead of assuming that if not M/MALE then sex must be Female

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>