### PR TITLE
DDP Pipeline exits when unable to generate authentication token

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
@@ -35,6 +35,7 @@ package org.mskcc.cmo.ks.ddp.pipeline;
 import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
 import org.mskcc.cmo.ks.ddp.pipeline.util.DDPPatientListUtil;
 import org.mskcc.cmo.ks.ddp.source.DDPDataSource;
+import org.mskcc.cmo.ks.ddp.source.exception.InvalidAuthenticationException;
 
 import com.google.common.base.Strings;
 import org.apache.log4j.Logger;
@@ -73,6 +74,8 @@ public class DDPCompositeProcessor implements ItemProcessor<DDPCompositeRecord, 
         // are null because an exception will be thrown in that case too (by the repository)
         try {
             compositeRecord.setPatientDemographics(ddpDataSource.getPatientDemographics(compositeRecord.getDmpPatientId()));
+        } catch (InvalidAuthenticationException e) {
+            throw new RuntimeException(e.getMessage());
         } catch (Exception e) {
             // demographics is necessary to calculate/resolve clinical fields so save
             // dmp patient id and return null so that writer skips this record

--- a/ddp/ddp_source/src/main/java/org/mskcc/cmo/ks/ddp/source/exception/InvalidAuthenticationException.java
+++ b/ddp/ddp_source/src/main/java/org/mskcc/cmo/ks/ddp/source/exception/InvalidAuthenticationException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.source.exception;
+
+import com.google.common.base.Joiner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InvalidAuthenticationException extends RuntimeException {
+
+    private static final Logger logger = LoggerFactory.getLogger(InvalidAuthenticationException.class);
+
+    public InvalidAuthenticationException(String errorMessage) {
+        super(errorMessage);
+    }
+
+}
+


### PR DESCRIPTION
generation of authentication token is attempted max 3 times (1 minute intervals)
failure to generate an authentication token throws a special exception which is handled differently
InvalidAuthenticationException will cause job to exit (with non-zero exit status)