### PR TITLE
CVRMergedResult uses 'get' methods to construct 'allSnps' list

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRMergedResult.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRMergedResult.java
@@ -328,10 +328,10 @@ public class CVRMergedResult {
 
     public List<CVRSnp> getAllCvrSnps() {
         List<CVRSnp> allSnps = new ArrayList<>();
-        allSnps.addAll(snpIndelExonic);
-        allSnps.addAll(snpIndelExonicNp);
-        allSnps.addAll(snpIndelSilent);
-        allSnps.addAll(snpIndelSilentNp);
+        allSnps.addAll(getSnpIndelExonic());
+        allSnps.addAll(getSnpIndelExonicNp());
+        allSnps.addAll(getSnpIndelSilent());
+        allSnps.addAll(getSnpIndelSilentNp());
         return allSnps;
     }
 


### PR DESCRIPTION
'get' methods check for null to prevent NPE