### PR TITLE
Add JobExecutionDecider beans for each datatype

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
@@ -179,11 +179,11 @@ public class BatchConfiguration {
     @Bean
     public Flow mutationsStepFlow() {
         return new FlowBuilder<Flow>("mutationsStepFlow")
-                .start(decideStepExecutionByDatatypeForStudyId("mutations"))
+                .start(mutationsStepExecutionDecider())
                     .on("RUN")
                         .to(mutationStep())
                         .next(unfilteredMutationStep())
-                .from(decideStepExecutionByDatatypeForStudyId("mutations"))
+                .from(mutationsStepExecutionDecider())
                     .on("SKIP")
                         .end()
                 .build();
@@ -192,10 +192,10 @@ public class BatchConfiguration {
     @Bean
     public Flow cnaStepFlow() {
         return new FlowBuilder<Flow>("cnaStepFlow")
-                .start(decideStepExecutionByDatatypeForStudyId("cna"))
+                .start(cnaStepExecutionDecider())
                     .on("RUN")
                         .to(cnaStep())
-                .from(decideStepExecutionByDatatypeForStudyId("cna"))
+                .from(cnaStepExecutionDecider())
                     .on("SKIP")
                         .end()
                 .build();
@@ -204,11 +204,11 @@ public class BatchConfiguration {
     @Bean
     public Flow svFusionsStepFlow() {
         return new FlowBuilder<Flow>("svFusionsStepFlow")
-                .start(decideStepExecutionByDatatypeForStudyId("sv-fusions"))
+                .start(svFusionsStepExecutionDecider())
                     .on("RUN")
                         .to(svStep())
                         .next(fusionStep())
-                .from(decideStepExecutionByDatatypeForStudyId("sv-fusions"))
+                .from(svFusionsStepExecutionDecider())
                     .on("SKIP")
                         .end()
                 .build();
@@ -217,10 +217,10 @@ public class BatchConfiguration {
     @Bean
     public Flow segmentStepFlow() {
         return new FlowBuilder<Flow>("segmentStepFlow")
-                .start(decideStepExecutionByDatatypeForStudyId("seg"))
+                .start(segStepExecutionDecider())
                     .on("RUN")
                         .to(segStep())
-                .from(decideStepExecutionByDatatypeForStudyId("seg"))
+                .from(segStepExecutionDecider())
                     .on("SKIP")
                         .end()
                 .build();
@@ -230,10 +230,10 @@ public class BatchConfiguration {
     public Flow zeroVariantWhitelistFlow() {
         // use datatype = mutations since whitelist is for mutations data
         return new FlowBuilder<Flow>("zeroVariantWhitelistFlow")
-                .start(decideStepExecutionByDatatypeForStudyId("mutations"))
+                .start(mutationsStepExecutionDecider())
                     .on("RUN")
                         .to(zeroVariantWhitelistStep())
-                .from(decideStepExecutionByDatatypeForStudyId("mutations"))
+                .from(mutationsStepExecutionDecider())
                     .on("SKIP")
                         .end()
                 .build();
@@ -776,7 +776,6 @@ public class BatchConfiguration {
      * @param datatype
      * @return
      */
-    @Bean
     public JobExecutionDecider decideStepExecutionByDatatypeForStudyId(String datatype) {
         return new JobExecutionDecider() {
             @Override
@@ -787,10 +786,29 @@ public class BatchConfiguration {
                     return new FlowExecutionStatus("RUN");
                 }
                 else {
-                    log.info("Skipping processing of datatype '" + datatype + "' for study '" + studyId + "'...");
                     return new FlowExecutionStatus("SKIP");
                 }
             }
         };
+    }
+
+    @Bean
+    public JobExecutionDecider mutationsStepExecutionDecider() {
+        return decideStepExecutionByDatatypeForStudyId("mutations");
+    }
+
+    @Bean
+    public JobExecutionDecider cnaStepExecutionDecider() {
+        return decideStepExecutionByDatatypeForStudyId("cna");
+    }
+
+    @Bean
+    public JobExecutionDecider svFusionsStepExecutionDecider() {
+        return decideStepExecutionByDatatypeForStudyId("sv-fusions");
+    }
+
+    @Bean
+    public JobExecutionDecider segStepExecutionDecider() {
+        return decideStepExecutionByDatatypeForStudyId("seg");
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -91,7 +91,7 @@ public class CVRUtilities {
     private static Map<String, List<String>> datatypesToSkipByStudy() {
         Map<String, List<String>> map = new HashMap<>();
         map.put("mskarcher", Arrays.asList(new String[]{"mutations", "cna", "seg"}));
-        map.put("raindance", Arrays.asList(new String[]{"cna", "seg", "sv-fusions"}));
+        map.put("mskraindance", Arrays.asList(new String[]{"cna", "seg", "sv-fusions"}));
         return map;
     }
 


### PR DESCRIPTION
There should be a JobExecutionDecider bean for each datatype, otherwise the same bean is recycled each time the `decideStepExecutionByDatatypeForStudyId()` method is called meaning that the datatype string passed will always be the first one passed to that bean (in this case it was "mutations"). 

This resolves issue where raindance CNA, SEG, and Fusions/SV files were still getting generated and causing import to fail because the `meta_fusions.txt` cannot be found. 

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>