### PR TITLE
Update gene ref filename

### DIFF
--- a/import-scripts/update-gene-data.sh
+++ b/import-scripts/update-gene-data.sh
@@ -14,9 +14,9 @@ cd $tmp
 echo "Downloading gene data resources from NCBI..."
 export http_proxy='http://jxi2.mskcc.org:8080'
 wget ftp.ncbi.nih.gov:gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz
-wget ftp.ncbi.nih.gov:/genomes/Homo_sapiens/GFF/ref_GRCh38.p7_top_level.gff3.gz
+wget ftp.ncbi.nih.gov:/genomes/Homo_sapiens/GFF/ref_GRCh38.p12_top_level.gff3.gz
 gunzip $tmp/Homo_sapiens.gene_info.gz
-gunzip $tmp/ref_GRCh38.p7_top_level.gff3.gz
+gunzip $tmp/ref_GRCh38.p12_top_level.gff3.gz
 echo "Finished!"
 
 sed -i 's/^#//; s/\"//' $tmp/Homo_sapiens.gene_info
@@ -25,8 +25,8 @@ if [[ !  -f $tmp/Homo_sapiens.gene_info || $(wc -l < $tmp/Homo_sapiens.gene_info
     exit 1
 fi
 
-if [[ !  -f $tmp/ref_GRCh38.p7_top_level.gff3 || $(wc -l < $tmp/ref_GRCh38.p7_top_level.gff3) -eq 0 ]]; then
-    echo "Error downloading ref_GRCh38.p7_top_level.gff3 from NCBI. Exiting..."
+if [[ !  -f $tmp/ref_GRCh38.p12_top_level.gff3 || $(wc -l < $tmp/ref_GRCh38.p12_top_level.gff3) -eq 0 ]]; then
+    echo "Error downloading ref_GRCh38.p12_top_level.gff3 from NCBI. Exiting..."
     exit 1
 fi
 
@@ -40,7 +40,7 @@ function runGeneUpdatePipeline {
     export DATABASE_NAME=$DATABASE_NAME
 
     echo "Starting gene data update job on database: $DATABASE_NAME"
-    $JAVA_HOME/bin/java $JAVA_PROXY_ARGS -jar $PORTAL_HOME/lib/gene_data_updater.jar -d $tmp/Homo_sapiens.gene_info -l $tmp/ref_GRCh38.p7_top_level.gff3 -n $tmp/gene-update-notification.txt
+    $JAVA_HOME/bin/java $JAVA_PROXY_ARGS -jar $PORTAL_HOME/lib/gene_data_updater.jar -d $tmp/Homo_sapiens.gene_info -l $tmp/ref_GRCh38.p12_top_level.gff3 -n $tmp/gene-update-notification.txt
     if [ $? -ne 0 ]; then 
         echo "Error updating gene data"
         echo -e "Error updating gene data." | mail -s "Gene Data Update Failure: $DATABASE_NAME" $email_list
@@ -139,4 +139,4 @@ fi
 
 echo "Removing gene data files downloaded..."
 rm $tmp/Homo_sapiens.gene_info
-rm $tmp/ref_GRCh38.p7_top_level.gff3
+rm $tmp/ref_GRCh38.p12_top_level.gff3


### PR DESCRIPTION
Simple fix - filename needed updating. 
`ref_GRCh38.p7_top_level.gff3.gz` no longer exists in NCBI ftp server. File format for updated file is still the same.
Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>