### PR TITLE
Added support for TMB clinical attributes

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRClinicalRecord.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRClinicalRecord.java
@@ -63,6 +63,11 @@ public class CVRClinicalRecord {
     private String seqDate;
     private String ageAtSeqReport;
     private String archer;
+    private String cvrTmbCohort;
+    private String cvrTmbCohortPercentile;
+    private String cvrTmbScore;
+    private String cvrTmbTtCohort;
+    private String cvrTmbTtPercentile;
 
     private final String DEFAULT_SAMPLE_CLASS = "Tumor";
 
@@ -90,6 +95,11 @@ public class CVRClinicalRecord {
         this.seqDate = metaData.getDateTumorSequencing();
         this.ageAtSeqReport = "NA";
         this.archer = "NO";
+        this.cvrTmbCohort = (metaData.getTmbCohort() != null) ? String.valueOf(metaData.getTmbCohort()) : "NA";
+        this.cvrTmbCohortPercentile = (metaData.getTmbCohortPercentile()!= null) ? String.valueOf(metaData.getTmbCohortPercentile()) : "NA";
+        this.cvrTmbScore = (metaData.getTmbScore()!= null) ? String.valueOf(metaData.getTmbScore()) : "NA";
+        this.cvrTmbTtCohort = (metaData.getTmbTtCohort()!= null) ? String.valueOf(metaData.getTmbTtCohort()) : "NA";
+        this.cvrTmbTtPercentile = (metaData.getTmbTtPercentile()!= null) ? String.valueOf(metaData.getTmbTtPercentile()) : "NA";
     }
 
     public CVRClinicalRecord(GMLMetaData metaData) {
@@ -306,6 +316,46 @@ public class CVRClinicalRecord {
         this.archer = archer;
     }    
 
+    public String getCVR_TMB_COHORT() {
+        return cvrTmbCohort;
+    }
+
+    public void setCVR_TMB_COHORT(String tmbCohort) {
+        this.cvrTmbCohort = tmbCohort;
+    }
+
+    public String getCVR_TMB_COHORT_PERCENTILE() {
+        return cvrTmbCohortPercentile;
+    }
+
+    public void setCVR_TMB_COHORT_PERCENTILE(String tmbCohortPercentile) {
+        this.cvrTmbCohortPercentile = tmbCohortPercentile;
+    }
+
+    public String getCVR_TMB_SCORE() {
+        return cvrTmbScore;
+    }
+
+    public void setCVR_TMB_SCORE(String tmbScore) {
+        this.cvrTmbScore = tmbScore;
+    }
+
+    public String getCVR_TMB_TT_COHORT() {
+        return cvrTmbTtCohort;
+    }
+
+    public void setCVR_TMB_TT_COHORT(String tmbTtCohort) {
+        this.cvrTmbTtCohort = tmbTtCohort;
+    }
+
+    public String getCVR_TMB_TT_COHORT_PERCENTILE() {
+        return cvrTmbTtPercentile;
+    }
+
+    public void setCVR_TMB_TT_COHORT_PERCENTILE(String tmbTtPercentile) {
+        this.cvrTmbTtPercentile = tmbTtPercentile;
+    }
+
     private String resolveSampleType(Integer isMetastasis) {
         if (isMetastasis != null)
             return isMetastasis == 0 ? "Primary" : "Metastasis";
@@ -337,6 +387,11 @@ public class CVRClinicalRecord {
         fieldNames.add("SOMATIC_STATUS");
         fieldNames.add("AGE_AT_SEQ_REPORT");
         fieldNames.add("ARCHER");
+        fieldNames.add("CVR_TMB_COHORT");
+        fieldNames.add("CVR_TMB_COHORT_PERCENTILE");
+        fieldNames.add("CVR_TMB_SCORE");
+        fieldNames.add("CVR_TMB_TT_COHORT");
+        fieldNames.add("CVR_TMB_TT_COHORT_PERCENTILE");
         return fieldNames;
     }
     

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRMetaData.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRMetaData.java
@@ -76,6 +76,11 @@ import javax.annotation.Generated;
     "so_comments",
     "so_status_name",
     "somatic_status",
+    "tmb_cohort",
+    "tmb_cohort_percentile",
+    "tmb_score",
+    "tmb_tt_cohort",
+    "tmb_tt_percentile",
     "tumor_purity",
     "tumor_type_code",
     "tumor_type_name"
@@ -136,6 +141,16 @@ public class CVRMetaData {
     private String soStatusName;
     @JsonProperty("somatic_status")
     private String somaticStatus;
+    @JsonProperty("tmb_cohort")
+    private Double tmbCohort;
+    @JsonProperty("tmb_cohort_percentile")
+    private Double tmbCohortPercentile;
+    @JsonProperty("tmb_score")
+    private Double tmbScore;
+    @JsonProperty("tmb_tt_cohort")
+    private Double tmbTtCohort;
+    @JsonProperty("tmb_tt_percentile")
+    private Double tmbTtPercentile;
     @JsonProperty("tumor_purity")
     private String tumorPurity;
     @JsonProperty("tumor_type_code")
@@ -153,38 +168,49 @@ public class CVRMetaData {
     }
 
     /**
-    *
-    * @param soComments
-    * @param genePanel
-    * @param dmpSampleSoId
-    * @param isMetastasis
-    * @param dmpAlysTaskId
-    * @param primarySite
-    * @param dmpSampleId
-    * @param sampleCoverage
-    * @param retrieveStatus
-    * @param tumorPurity
-    * @param soStatusName
-    * @param alys2sampleId
-    * @param cbxPatientId
-    * @param linkedMskimpactCase
-    * @param metastasisSite
-    * @param dmpPatientId
-    * @param mrevComments
-    * @param msiComment
-    * @param msiScore
-    * @param msiType
-    * @param outsideInstitute
-    * @param cbxSampleId
-    * @param dateTumorSequencing
-    * @param dmpAlysTaskName
-    * @param legacyPatientId
-    * @param gender
-    * @param tumorTypeCode
-    * @param legacySampleId
-    * @param tumorTypeName
-    */
-    public CVRMetaData(Integer alys2sampleId, Integer cbxPatientId, Integer cbxSampleId, String dateTumorSequencing, String linkedMskimpactCase, Integer dmpAlysTaskId, String dmpAlysTaskName, String dmpPatientId, String dmpSampleId, Integer dmpSampleSoId, Integer gender, String genePanel, Integer isMetastasis, String legacyPatientId, String legacySampleId, String metastasisSite, String mrevComments, String msiComment, String msiScore, String msiType, String outsideInstitute, String primarySite, Integer retrieveStatus, Integer sampleCoverage, String soComments, String soStatusName, String somaticStatus, String tumorPurity, String tumorTypeCode, String tumorTypeName) {
+     *
+     * @param alys2sampleId
+     * @param cbxPatientId
+     * @param cbxSampleId
+     * @param dateTumorSequencing
+     * @param linkedMskimpactCase
+     * @param dmpAlysTaskId
+     * @param dmpAlysTaskName
+     * @param dmpPatientId
+     * @param dmpSampleId
+     * @param dmpSampleSoId
+     * @param gender
+     * @param genePanel
+     * @param isMetastasis
+     * @param legacyPatientId
+     * @param legacySampleId
+     * @param metastasisSite
+     * @param mrevComments
+     * @param msiComment
+     * @param msiScore
+     * @param msiType
+     * @param outsideInstitute
+     * @param primarySite
+     * @param retrieveStatus
+     * @param sampleCoverage
+     * @param soComments
+     * @param soStatusName
+     * @param somaticStatus
+     * @param tmbCohort
+     * @param tmbCohortPercentile
+     * @param tmbScore
+     * @param tmbTtCohort
+     * @param tmbTtPercentile
+     * @param tumorPurity
+     * @param tumorTypeCode
+     * @param tumorTypeName
+     */
+    public CVRMetaData(Integer alys2sampleId, Integer cbxPatientId, Integer cbxSampleId, String dateTumorSequencing, String linkedMskimpactCase,
+            Integer dmpAlysTaskId, String dmpAlysTaskName, String dmpPatientId, String dmpSampleId, Integer dmpSampleSoId, Integer gender,
+            String genePanel, Integer isMetastasis, String legacyPatientId, String legacySampleId, String metastasisSite, String mrevComments,
+            String msiComment, String msiScore, String msiType, String outsideInstitute, String primarySite, Integer retrieveStatus,
+            Integer sampleCoverage, String soComments, String soStatusName, String somaticStatus, Double tmbCohort, Double tmbCohortPercentile,
+            Double tmbScore, Double tmbTtCohort, Double tmbTtPercentile, String tumorPurity, String tumorTypeCode, String tumorTypeName) {
         this.alys2sampleId = alys2sampleId;
         this.cbxPatientId = cbxPatientId;
         this.cbxSampleId = cbxSampleId;
@@ -211,6 +237,11 @@ public class CVRMetaData {
         this.soComments = soComments;
         this.soStatusName = soStatusName;
         this.somaticStatus = somaticStatus;
+        this.tmbCohort = tmbCohort;
+        this.tmbCohortPercentile = tmbCohortPercentile;
+        this.tmbScore = tmbScore;
+        this.tmbTtCohort = tmbTtCohort;
+        this.tmbTtPercentile = tmbTtPercentile;
         this.tumorPurity = tumorPurity;
         this.tumorTypeCode = tumorTypeCode;
         this.tumorTypeName = tumorTypeName;
@@ -316,7 +347,7 @@ public class CVRMetaData {
     public Integer getDmpAlysTaskId() {
         return dmpAlysTaskId;
     }
-    
+
     /**
     *
     * @return
@@ -335,7 +366,7 @@ public class CVRMetaData {
     @JsonProperty("linked_mskimpact_case")
     public void setLinkedMskimpactCase(String linkedMskimpactCase) {
         this.linkedMskimpactCase = linkedMskimpactCase;
-    }    
+    }
 
     /**
     *
@@ -745,6 +776,106 @@ public class CVRMetaData {
     @JsonProperty("so_status_name")
     public void setSoStatusName(String soStatusName) {
         this.soStatusName = soStatusName;
+    }
+
+    /**
+     *
+     * @return
+     * The tmbCohort
+     */
+    @JsonProperty("tmb_cohort")
+    public Double getTmbCohort() {
+        return tmbCohort;
+    }
+
+    /**
+     *
+     * @param tmbCohort
+     * The tmb_cohort
+     */
+    @JsonProperty("tmb_cohort")
+    public void setTmbCohort(Double tmbCohort) {
+        this.tmbCohort = tmbCohort;
+    }
+
+    /**
+     *
+     * @return
+     * The tmbCohortPercentile
+     */
+    @JsonProperty("tmb_cohort_percentile")
+    public Double getTmbCohortPercentile() {
+        return tmbCohortPercentile;
+    }
+
+    /**
+     *
+     * @param tmbCohortPercentile
+     * The tmb_cohort_percentile
+     */
+    @JsonProperty("tmb_cohort_percentile")
+    public void setTmbCohortPercentile(Double tmbCohortPercentile) {
+        this.tmbCohortPercentile = tmbCohortPercentile;
+    }
+
+    /**
+     *
+     * @return
+     * The tmbScore
+     */
+    @JsonProperty("tmb_score")
+    public Double getTmbScore() {
+        return tmbScore;
+    }
+
+    /**
+     *
+     * @param tmbScore
+     * The tmb_score
+     */
+    @JsonProperty("tmb_score")
+    public void setTmbScore(Double tmbScore) {
+        this.tmbScore = tmbScore;
+    }
+
+    /**
+     *
+     * @return
+     * The tmbTtCohort
+     */
+    @JsonProperty("tmb_tt_cohort")
+    public Double getTmbTtCohort() {
+        return tmbTtCohort;
+    }
+
+    /**
+     *
+     * @param tmbTtCohort
+     * The tmb_tt_cohort
+     */
+    @JsonProperty("tmb_tt_cohort")
+    public void setTmbTtCohort(Double tmbTtCohort) {
+        this.tmbTtCohort = tmbTtCohort;
+    }
+
+    /**
+     *
+     * @return
+     * The tmbTtPercentile
+     */
+    @JsonProperty("tmb_tt_percentile")
+    public Double getTmbTtPercentile() {
+        return tmbTtPercentile;
+    }
+
+    /**
+     *
+     * @param tmbTtPercentile
+     * The tmb_tt_percentile
+     */
+    @JsonProperty("tmb_tt_percentile")
+    public void setTmbTtPercentile(Double tmbTtPercentile) {
+        this.tmbTtPercentile = tmbTtPercentile;
     }
 
     /**

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/samplelist/CvrSampleListsTasklet.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/samplelist/CvrSampleListsTasklet.java
@@ -17,6 +17,10 @@ import org.cbioportal.cmo.pipelines.cvr.model.CVRMergedResult;
 import org.cbioportal.cmo.pipelines.cvr.model.GMLData;
 import org.cbioportal.cmo.pipelines.cvr.model.GMLResult;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.model.CVRData;
+import org.cbioportal.cmo.pipelines.cvr.model.CVRMergedResult;
+import org.cbioportal.cmo.pipelines.cvr.model.GMLData;
+import org.cbioportal.cmo.pipelines.cvr.model.GMLResult;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
@@ -35,16 +39,16 @@ public class CvrSampleListsTasklet implements Tasklet {
 
     @Autowired
     public CvrSampleListUtil cvrSampleListUtil;
-    
+
     @Value("#{jobParameters[sessionId]}")
     private String sessionId;
-    
+
     @Value("${dmp.server_name}")
     private String dmpServerName;
-    
+
     @Value("${dmp.tokens.retrieve_master_list.route}")
     private String dmpRetrieveMasterListRoute;
-    
+
     @Value("#{jobParameters[studyId]}")
     private String studyId;
 
@@ -67,7 +71,7 @@ public class CvrSampleListsTasklet implements Tasklet {
     private Map<String, String> masterListTokensMap;
 
     Logger log = Logger.getLogger(CvrSampleListsTasklet.class);
-    
+
     @Override
     public RepeatStatus execute(StepContribution sc, ChunkContext cc) throws Exception {
         // load master list from CVR
@@ -83,7 +87,7 @@ public class CvrSampleListsTasklet implements Tasklet {
             }
         }
         catch (HttpClientErrorException e) {
-            log.warn("Error occurred while retrieving master list for " + studyId + " - the default master list will be set to samples already in portal.\n" 
+            log.warn("Error occurred while retrieving master list for " + studyId + " - the default master list will be set to samples already in portal.\n"
                     + e.getLocalizedMessage());
         }
         // load whited listed samples with zero variants
@@ -146,7 +150,7 @@ public class CvrSampleListsTasklet implements Tasklet {
         }
         cvrSampleListUtil.setNewDmpSamples(newDmpSamples);
     }
-    
+
     private Set<String> loadWhitelistedSamplesWithZeroVariants() throws Exception {
         Set<String> whitedListedSamplesWithZeroVariants = new HashSet<>();
         File whitelistedSamplesFile = new File(stagingDirectory, CVRUtilities.ZERO_VARIANT_WHITELIST_FILE);
@@ -175,7 +179,7 @@ public class CvrSampleListsTasklet implements Tasklet {
         RestTemplate restTemplate = new RestTemplate();
         HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = getRequestEntity();
         ResponseEntity<CVRMasterList> responseEntity = restTemplate.exchange(dmpUrl, HttpMethod.GET, requestEntity, CVRMasterList.class);
-        
+
         Set<String> dmpSamples = new HashSet<>();
         for (Map<String, String> samples : responseEntity.getBody().getSamples()) {
             // there is only one pair per Map
@@ -194,5 +198,5 @@ public class CvrSampleListsTasklet implements Tasklet {
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         return new HttpEntity<Object>(headers);
     }
-    
+
 }


### PR DESCRIPTION
Added support for TMB clinical attributes

New clinical attributes: 
- CVR_TMB_COHORT
- CVR_TMB_COHORT_PERCENTILE
- CVR_TMB_SCORE
- CVR_TMB_TT_COHORT
- CVR_TMB_TT_COHORT_PERCENTILE

As part of this PR, the JSON modes (gml and regular) were fixed. Running in JSON mode now correctly updates the clinical file instead of adding duplicate records for sample IDs present in the JSON file.  **THIS HAS BEEN MOVED TO PR #383** 

Ex: If a sample existed already but was requeued and therefore present in the JSON downloaded from CVR, the clinical reader will drop the old record for this sample and use only the new data that came from the JSON. Before this fix the clinical reader would keep the old record and also append the data with the updates in the JSON file, thus creating 2 records in the clinical file for the same sample.

@ritikakundra @sheridancbio attached is the updated data dictionary that we'll need to use for the CVR clinical REDCap projects - note: github doesn't support `*.csv` attachments so the file will need to be converted back to `*.csv` from `*.xlsx`

[Mskimpactdataclinicalcvr_DataDictionary_2018-06-20 (1).xlsx](https://github.com/knowledgesystems/cmo-pipelines/files/2138109/Mskimpactdataclinicalcvr_DataDictionary_2018-06-20.1.xlsx)