### PR TITLE
ARCHER fusions merger fixes

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -57,7 +57,7 @@ public class CVRUtilities {
     public static final String DEFAULT_CLINICAL_FILE = "data_clinical.txt";
     public static final String SEQ_DATE_CLINICAL_FILE = "cvr/seq_date.txt";
     public static final String DARWIN_AGE_FILE = "darwin/darwin_age.txt";
-    public static final String CORRESPONDING_ID_FILE = "linked_mskimpact_cases.txt";
+    public static final String CORRESPONDING_ID_FILE = "cvr/linked_cases.txt";
     public static final String CNA_FILE = "data_CNA.txt";
     public static final String SEG_FILE = "_data_cna_hg19.seg";
     public static final String FUSION_FILE = "data_fusions.txt";

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/linkedimpactcase/LinkedImpactCaseFieldSetMapper.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/linkedimpactcase/LinkedImpactCaseFieldSetMapper.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.cmo.pipelines.cvr.linkedimpactcase;
+
+import org.cbioportal.cmo.pipelines.cvr.model.LinkedMskimpactCaseRecord;
+
+import java.util.*;
+import org.apache.log4j.Logger;
+import org.springframework.batch.item.file.mapping.FieldSetMapper;
+import org.springframework.batch.item.file.transform.FieldSet;
+import org.springframework.validation.BindException;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class LinkedImpactCaseFieldSetMapper implements FieldSetMapper<LinkedMskimpactCaseRecord> {
+
+    Logger log = Logger.getLogger(LinkedImpactCaseFieldSetMapper.class);
+
+    @Override
+    public LinkedMskimpactCaseRecord mapFieldSet(FieldSet fs) throws BindException {
+        LinkedMskimpactCaseRecord record = new LinkedMskimpactCaseRecord();
+        List<String> fields = LinkedMskimpactCaseRecord.getFieldNames();
+
+        for (int i = 0; i < fields.size(); i++) {
+            String field = fields.get(i);
+            try {
+                record.getClass().getMethod("set" + field, String.class).invoke(record, fs.readString(i));
+            } catch (Exception e) {
+                if (e.getClass().equals(NoSuchMethodException.class)) {
+                    log.info("No set method exists for " + field);
+                }
+            }
+        }
+        return record;
+    }
+}

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/linkedimpactcase/LinkedMskimpactCaseReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/linkedimpactcase/LinkedMskimpactCaseReader.java
@@ -5,19 +5,21 @@
  */
 package org.cbioportal.cmo.pipelines.cvr.linkedimpactcase;
 
+import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
+import org.cbioportal.cmo.pipelines.cvr.model.*;
+
 import java.io.*;
 import java.util.*;
 import org.apache.log4j.Logger;
-import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
-import org.cbioportal.cmo.pipelines.cvr.model.*;
-import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.item.ItemStreamException;
-import org.springframework.batch.item.ItemStreamReader;
-import org.springframework.batch.item.NonTransientResourceException;
-import org.springframework.batch.item.ParseException;
-import org.springframework.batch.item.UnexpectedInputException;
+
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.FlatFileItemReader;
+import org.springframework.batch.item.file.mapping.DefaultLineMapper;
+import org.springframework.batch.item.file.transform.DelimitedLineTokenizer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
 
 /**
  *
@@ -29,11 +31,14 @@ public class LinkedMskimpactCaseReader implements ItemStreamReader<LinkedMskimpa
 
     @Autowired
     public CVRUtilities cvrUtilities;
-    
+
+    @Autowired
+    public CvrSampleListUtil cvrSampleListUtil;
+
     private List<LinkedMskimpactCaseRecord> linkedIds = new ArrayList<>();
-    
+
     private static final Logger LOG = Logger.getLogger(LinkedMskimpactCaseReader.class);
-    
+
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
         CVRData cvrData = new CVRData();
@@ -47,6 +52,44 @@ public class LinkedMskimpactCaseReader implements ItemStreamReader<LinkedMskimpa
         }
         for (CVRMergedResult result : cvrData.getResults()) {
             linkedIds.add(new LinkedMskimpactCaseRecord(result.getMetaData().getDmpSampleId(), result.getMetaData().getLinkedMskimpactCase()));
+        }
+        // load existing linked ARCHER sample data
+        loadExistingLinkedIds();
+    }
+
+    private void loadExistingLinkedIds() {
+        File stagingFile = new File(stagingDirectory, cvrUtilities.CORRESPONDING_ID_FILE);
+        if (!stagingFile.exists()) {
+            LOG.warn("File does not exist - skipping data loading from linked ARCHER samples file: " + stagingFile.getName());
+            return;
+        }
+        LOG.info("Loading linked ARCHER sample data from: " + stagingFile.getName());
+        DelimitedLineTokenizer tokenizer = new DelimitedLineTokenizer(DelimitedLineTokenizer.DELIMITER_TAB);
+        DefaultLineMapper<LinkedMskimpactCaseRecord> mapper = new DefaultLineMapper<>();
+        mapper.setLineTokenizer(tokenizer);
+        mapper.setFieldSetMapper(new LinkedImpactCaseFieldSetMapper());
+
+        FlatFileItemReader<LinkedMskimpactCaseRecord> reader = new FlatFileItemReader<>();
+        reader.setResource(new FileSystemResource(stagingFile));
+        reader.setLineMapper(mapper);
+        reader.setLinesToSkip(1);
+        reader.open(new ExecutionContext());
+
+        try {
+            LinkedMskimpactCaseRecord to_add;
+            while ((to_add = reader.read()) != null) {
+                // only add samples that are not in the new dmp sample list
+                if (!cvrSampleListUtil.getNewDmpSamples().contains(to_add.getSAMPLE_ID())) {
+                    linkedIds.add(to_add);
+                }
+            }
+        }
+        catch (Exception e) {
+            LOG.error("Error reading linked ARCHER sample data from file: " + stagingFile.getName());
+            throw new ItemStreamException(e);
+        }
+        finally {
+            reader.close();
         }
     }
 

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/LinkedMskimpactCaseRecord.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/LinkedMskimpactCaseRecord.java
@@ -12,10 +12,12 @@ import java.util.*;
  * @author heinsz
  */
 public class LinkedMskimpactCaseRecord {
-    
+
     private String sampleId;
     private String linkedMskImpactCase;
-    
+
+    public LinkedMskimpactCaseRecord() {}
+
     public LinkedMskimpactCaseRecord(String sampleId, String linkedMskImpactCase) {
         this.sampleId = sampleId;
         this.linkedMskImpactCase = linkedMskImpactCase;

--- a/import-scripts/archer_fusions_merger.py
+++ b/import-scripts/archer_fusions_merger.py
@@ -4,126 +4,248 @@ import argparse
 import csv
 import re
 import fileinput
+import smtplib
+
+from clinicalfile_utils import *
+from email.Utils import COMMASPACE, formatdate
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+# some file descriptors
+ERROR_FILE = sys.stderr
+OUTPUT_FILE = sys.stdout
+
+SMTP_SERVER = "cbio.mskcc.org"
+MESSAGE_RECIPIENTS = ["cbioportal-pipelines@cbio.mskcc.org"]
+MESSAGE_SENDER = "cbioportal@cbio.mskcc.org"
 
 ## remove from mixedpact so as to not double count
+KNOWN_SAMPLE_MASTERLIST = set()
+LINKED_ARCHER_CASES = {}
+SEEN_FUSION_EVENTS = set()
+SAMPLES_MISSING_CLINICAL_DATA = set()
 
-IMPACT_SAMPLE_PATTERN = re.compile('(P-\d*-T\d\d)-\S\S\d*')
+MSKIMPACT_STUDY_ID = "mskimpact"
+HEMEPACT_STUDY_ID = "mskimpact_heme"
+IMPACT_SAMPLE_PATTERN = re.compile('(P-\d*-T\d\d)-IM\S\d*')
+HEME_SAMPLE_PATTERN = re.compile('(P-\d*-T\d\d)-IH\S\d*')
 
-def get_archer_to_impact(archer_clinical_filename):
-	""" Get the mapping between archer -> impact samples """
-	archer_to_impact = {}
-	with open(archer_clinical_filename) as archer_clinical_file:
-		reader = csv.DictReader(archer_clinical_file, dialect = 'excel-tab')
+STUDY_SAMPLE_REGEX_PATTERNS = {
+	MSKIMPACT_STUDY_ID:IMPACT_SAMPLE_PATTERN,
+	HEMEPACT_STUDY_ID:HEME_SAMPLE_PATTERN
+}
+
+def load_study_sample_masterlist(clinical_filename):
+	"""
+		Loads samples from clinical file that are known to the study being processed.
+		This list of samples is used to ensure that any sample ids that are mapped
+		from the ARCHER dataset exist in the clinical data as well to prevent
+		assertion errors during the fusion data import.
+	"""
+	with open(clinical_filename) as clinical_file:
+		reader = csv.DictReader(clinical_file, dialect = 'excel-tab')
 		for line in reader:
-			if line['LINKED_MSKIMPACT_CASE'] is not 'NA':
-				archer_to_impact[line['SAMPLE_ID'].strip()] = line['LINKED_MSKIMPACT_CASE'].strip()
-	return archer_to_impact
+			KNOWN_SAMPLE_MASTERLIST.add(line['SAMPLE_ID'].strip())
 
 
-def get_msk_fusions(msk_fusions_filename):				
-	""" 
-		Process the msk fusions file to get all current fusions, and to populate the seen_fusions set to prevent duplicates
+def is_valid_study_sample_id(sample_id, study_id):
+	""" Simple regex to determine whether sample id matches expected sample id pattern for given study. """
+	return STUDY_SAMPLE_REGEX_PATTERNS.get(study_id).match(sample_id)
+
+def get_fusion_event_key(data):
+	""" Returns a 'key' used for identifying fusion events. """
+	return (data['Tumor_Sample_Barcode'].strip(), data['Fusion'].strip(), data['Hugo_Symbol'].strip())
+
+def load_linked_archer_cases(linked_archer_cases_filename, study_id):
+	""" Get the mapping between archer -> impact/heme samples """
+	with open(linked_archer_cases_filename) as linked_archer_cases_file:
+		reader = csv.DictReader(linked_archer_cases_file, dialect = 'excel-tab')
+		for line in reader:
+			archer_sid = line['SAMPLE_ID'].strip()
+			linked_sid = line['LINKED_MSKIMPACT_CASE'].strip()
+			# skip linked sample id if 'NA' or doesn't belong to current study being processed
+			if linked_sid is 'NA' or not is_valid_study_sample_id(linked_sid, study_id):
+				continue
+			# if linked sample id is not in clinical data then update SAMPLES_MISSING_CLINICAL_DATA and skip
+			if not linked_sid in KNOWN_SAMPLE_MASTERLIST:
+				SAMPLES_MISSING_CLINICAL_DATA.add(linked_sid)
+				continue
+
+			# update LINKED_ARCHER_CASES w/current mapping
+			LINKED_ARCHER_CASES[archer_sid] = linked_sid
+
+def get_existing_fusions(fusions_filename):
+	"""
+		Process the msk fusions file to get all current fusions, and to populate the SEEN_FUSION_EVENTS set to prevent duplicates
 		The columns that need to be looked at are the Tumor_Sample_Barcode, the Fusion, and Hugo_Symbol columns. If these are the same,
 		the two fusions are identical from the perspective of the importer/portal
 	"""
-	header = []
-	seen_fusions = set()
-	msk_fusions = []
-	for line in fileinput.input(msk_fusions_filename):
-		if len(header) == 0:
-			header = map(str.strip, line.split('\t'))
-			continue
-		data = map(str.strip, line.split('\t'))
-		seen_fusions.add(data[header.index('Tumor_Sample_Barcode')] + '\t' + data[header.index('Fusion')] + '\t' + data[header.index('Hugo_Symbol')])
-		msk_fusions.append(data)
-	return msk_fusions, header, seen_fusions
+	header = get_header(fusions_filename)
+	existing_fusions = []
+	with open(fusions_filename) as fusions_file:
+		reader = csv.DictReader(fusions_file, dialect = 'excel-tab')
+		for line in reader:
+			SEEN_FUSION_EVENTS.add(get_fusion_event_key(line))
+			existing_fusions.append(line)
+	return existing_fusions, header
 
-def get_archer_fusions(archer_fusions_filename, header, msk_fusions, seen_fusions, archer_to_impact):
+def get_archer_fusions(archer_fusions_filename, header, existing_fusions, study_id):
 	"""
-		As we process the archer fusions file, we want to associate the fusions with the corresponding impact id. 
+		As we process the ARCHER fusions file, we want to associate the fusions with the corresponding MSKIMPACT/HEMEPACT id.
 		Lookup the sample in the sample map and add a fusion for each sample we need to.
 	"""
-	archer_samples = set()
+	mapped_archer_samples = set()
+	archer_fusions_added = 0
 	with open(archer_fusions_filename) as archer_fusions_file:
 		reader = csv.DictReader(archer_fusions_file, dialect = 'excel-tab')
 		for line in reader:
-			if line['Tumor_Sample_Barcode'] in archer_to_impact:
-				archer_samples.add(line['Tumor_Sample_Barcode'])
-				archer_id = line['Tumor_Sample_Barcode']
-				line['Tumor_Sample_Barcode'] = archer_to_impact[line['Tumor_Sample_Barcode']]
-				line['Fusion'] = line['Fusion'] + ' - Archer'
-				fusion = []
-				for column in header:
-					fusion.append(line.get(column, ''))
-				if line['Tumor_Sample_Barcode'] + '\t' + line['Fusion'] + '\t' +line['Hugo_Symbol'] not in seen_fusions:
-					msk_fusions.append(fusion)
-					seen_fusions.add(line['Tumor_Sample_Barcode'] + '\t' + line['Fusion'] + '\t' + line['Hugo_Symbol'])
-					archer_samples.add(archer_id.strip())
-	return archer_samples
+			archer_sid = line['Tumor_Sample_Barcode'].strip()
+			if archer_sid in LINKED_ARCHER_CASES.keys():
+				mapped_case_id = LINKED_ARCHER_CASES[archer_sid].strip()
+				mapped_archer_samples.add(archer_sid)
 
-def write_fusions(msk_fusions_filename, header, msk_fusions):
-	""" Write out the fusions to the msk fusions file """
-	with open(msk_fusions_filename, 'w') as msk_fusions_file:
-		msk_fusions_file.write('\t'.join(header))
-		for msk_fusion in msk_fusions:
-			msk_fusions_file.write('\n' + '\t'.join(msk_fusion))
+				# check that mapped case id belongs to current study being processed
+				if is_valid_study_sample_id(mapped_case_id, study_id):
+					# update current fusion event with mapped case id and update fusion datum
+					line['Tumor_Sample_Barcode'] = mapped_case_id
+					line['Fusion'] = line['Fusion'] + ' - Archer'
 
-def add_clinical_attribute_to_clinical(clinical_filename, archer_to_impact):
-	""" Update the ARCHER clinical attribute """
-	clinical_header = []
+					# check if we've seen event already to prevent duplicates
+					if get_fusion_event_key(line) not in SEEN_FUSION_EVENTS:
+						SEEN_FUSION_EVENTS.add(get_fusion_event_key(line))
+						existing_fusions.append(line)
+						archer_fusions_added += 1
+	return mapped_archer_samples, archer_fusions_added
+
+def update_fusions_file(fusions_filename, header, existing_fusions):
+	""" Update the fusions file with the new ARCHER fusions. """
+	with open(fusions_filename, 'w') as fusions_file:
+		fusions_file.write('\t'.join(header))
+		for fusion_event in existing_fusions:
+			formatted_data = map(lambda x: fusion_event.get(x, '').strip(), header)
+			fusions_file.write('\n' + '\t'.join(formatted_data))
+
+def add_clinical_attribute_to_clinical(clinical_filename):
+	""" Update the 'ARCHER' clinical attribute """
+	clinical_header = get_header(clinical_filename)
 	for line in fileinput.input(clinical_filename, inplace = 1):
 		data = map(str.strip, line.split('\t'))
-		if len(clinical_header) == 0:
-			clinical_header = data
-		if data[clinical_header.index('SAMPLE_ID')] in archer_to_impact.values():
+		if data[clinical_header.index('SAMPLE_ID')] in LINKED_ARCHER_CASES.values():
 			data[clinical_header.index('ARCHER')] = 'YES'
 		print '\t'.join(data)
 
-def write_archer_samples_to_file(archer_samples_filename, archer_samples):
-	""" Write out the archer sample ids to a filename for them to be excluded from the mixedpact study """
+def update_mapped_archer_samples_file(mapped_archer_samples_filename, mapped_archer_samples):
+	""" Write out the archer sample ids to a filename for them to be excluded from subsequent merges or subsets involving ARCHER data """
+	compiled_archer_samples_set = set(mapped_archer_samples)
 
-	with open(archer_samples_filename, 'w') as f:
-		[f.write(sid + '\n') for sid in archer_samples]
+	# load samples from existing file and update with new archer samples to add
+	with open(mapped_archer_samples_filename) as mapped_archer_samples_file:
+		compiled_archer_samples_set.update(map(str.strip, mapped_archer_samples_file.readlines()))
 
-def merge_fusions(archer_fusions_filename, msk_fusions_filename, linked_mskimpact_cases_filename, clinical_filename, archer_samples_filename):
+	# save updated list of archer samples to file
+	with open(mapped_archer_samples_filename, 'w') as mapped_archer_samples_file:
+		mapped_archer_samples_file.write('\n'.join(compiled_archer_samples_set))
+
+def send_samples_missing_clinical_data_report(study_id, clinical_filename):
+	""" Send email reporting ARCHER-linked cases that are missing from the clinical data. """
+
+	# construct message body
+	msg = MIMEMultipart()
+	message = "** NOTE - Although these samples are linked to ARCHER fusion events, they were not "
+	message += "added to the fusions data file since they are missing from the clinical data file. "
+	message += "These samples may need to be requeued if they are not already in the DMP queue for "
+	message += "the next CVR data fetch. If a sample fails to requeue and/or does not appear in the "
+	message += "CVR JSON from the following CVR fetch then please alert the DMP team to address any issues.\n\n"
+
+	message += "Found " + str(len(SAMPLES_MISSING_CLINICAL_DATA)) + "ARCHER-linked sample(s) missing clinical data in: " + clinical_filename + "\n"
+	for sample_id in SAMPLES_MISSING_CLINICAL_DATA:
+		message += "\n\t" + sample_id
+	email_body = MIMEText(message, "plain")
+	msg.attach(email_body)
+
+	assert type(MESSAGE_RECIPIENTS)==list
+
+	msg['Subject'] = "ARCHER-linked cases missing clinical data: " + study_id
+	msg['From'] = MESSAGE_SENDER
+	msg['To'] = COMMASPACE.join(MESSAGE_RECIPIENTS)
+	msg['Date'] = formatdate(localtime=True)
+
+	print >> OUTPUT_FILE, "Sending email..."
+	# send email
+	s = smtplib.SMTP(SMTP_SERVER)
+	s.sendmail(MESSAGE_SENDER, MESSAGE_RECIPIENTS, msg.as_string())
+	s.quit()
+
+def merge_fusions(archer_fusions_filename, fusions_filename, linked_cases_filename, clinical_filename, mapped_archer_samples_filename, study_id):
 	""" Driver function that calls helper functions to merge fusion records """
-	archer_to_impact = get_archer_to_impact(linked_mskimpact_cases_filename)
-	msk_fusions, header, seen_fusions = get_msk_fusions(msk_fusions_filename)
-	archer_samples = get_archer_fusions(archer_fusions_filename, header, msk_fusions, seen_fusions, archer_to_impact)
-	write_fusions(msk_fusions_filename, header, msk_fusions)
-	add_clinical_attribute_to_clinical(clinical_filename, archer_to_impact)
-	write_archer_samples_to_file(archer_samples_filename, archer_samples)
+
+	# load masterlist of known samples for given study - check if error loading samples from file
+	load_study_sample_masterlist(clinical_filename)
+	if not KNOWN_SAMPLE_MASTERLIST:
+		print >> ERROR_FILE, "Error loading samples from clinical file: " + clinical_filename + " - exiting..."
+		sys.exit(2)
+
+	# load mapping of ARCHER - IMPACT/HEME based on given study id
+	load_linked_archer_cases(linked_cases_filename, study_id)
+
+	# get existing fusions and add any new archer fusion events if applicable
+	# if archer_fusions_added is > 0 then update existing fusions file, otherwise nothing to do
+	existing_fusions, header = get_existing_fusions(fusions_filename)
+	mapped_archer_samples, archer_fusions_added = get_archer_fusions(archer_fusions_filename, header, existing_fusions, study_id)
+	if archer_fusions_added > 0:
+		print >> OUTPUT_FILE, "Updating " + fusions_filename + " with " + str(archer_fusions_added) + " ARCHER-linked events for study '" + study_id + "'"
+		update_fusions_file(fusions_filename, header, existing_fusions)
+	else:
+		print >> OUTPUT_FILE, "No new ARCHER fusion events for '" + study_id + "' - skipping updates to: " + fusions_filename
+
+	# update clinical file and mapped archer samples file in case clin attr or mapped archer sample list udpates got missed somehow
+	add_clinical_attribute_to_clinical(clinical_filename)
+	update_mapped_archer_samples_file(mapped_archer_samples_filename, mapped_archer_samples)
+	# TODO - EMAIL IF ANY ARCHER-LINKED CASES ARE MISSING CLINICAL DATA FOR GIVEN STUDY. SAMPLES MISSING FROM CLINICAL DATA MAY NEED TO BE REQUEUED IF NOT ALREADY IN QUEUE FOR NEXT CVR FETCH
+	if len(SAMPLES_MISSING_CLINICAL_DATA) > 0:
+		print >> ERROR_FILE, "Found " + str(len(SAMPLES_MISSING_CLINICAL_DATA)) + " sample(s) missing clinical data from: " + clinical_filename
+		send_samples_missing_clinical_data_report(study_id, clinical_filename)
+		for sid in SAMPLES_MISSING_CLINICAL_DATA:
+			print >> ERROR_FILE, "\t" + sid
 
 def main():
 	parser = argparse.ArgumentParser()
 	parser.add_argument('-a', '--archer-fusions', action = 'store', dest = 'archer_fusions_filename', required = True, help = 'data_fusions.txt from the Archer dataset')
-	parser.add_argument('-l', '--linked-mskimpact-cases-filename', action = 'store', dest = 'linked_mskimpact_cases_filename' , required = True, help = 'linked_mskimpact_cases.txt from the Archer dataset')
-	parser.add_argument('-m', '--msk-fusions', action = 'store', dest = 'msk_fusions_filename', required = True, help = 'data_fusions.txt from the mskimpact dataset')
-	parser.add_argument('-c', '--clinical-filename', action = 'store', dest = 'clinical_filename', required = True, help = 'data_clinical.txt from the mskimpact dataset')
-	parser.add_argument('-s', '--archer-samples-filename', action = 'store', dest = 'archer_samples_filename', required = True, help = 'Output file storing the archer ids that need to be removed from the mixedpact study')
+	parser.add_argument('-l', '--linked-cases-filename', action = 'store', dest = 'linked_cases_filename' , required = True, help = 'linked_cases.txt from the Archer dataset')
+	parser.add_argument('-f', '--fusions-filename', action = 'store', dest = 'fusions_filename', required = True, help = 'data_fusions.txt from the mskimpact or heme dataset')
+	parser.add_argument('-c', '--clinical-filename', action = 'store', dest = 'clinical_filename', required = True, help = 'data_clinical*.txt from the mskimpact or heme CVR fetch')
+	parser.add_argument('-m', '--mapped-archer-samples-filename', action = 'store', dest = 'mapped_archer_samples_filename', required = True, help = 'Output file storing the archer ids that need to be removed from the mixedpact study')
+	parser.add_argument('-i', '--study-id', action = 'store', dest = 'study_id', required = True, help = 'Cancer study identifier [mskimpact | mskimpact_heme]')
 
 	args = parser.parse_args()
 
 	archer_fusions_filename = args.archer_fusions_filename
-	msk_fusions_filename = args.msk_fusions_filename
-	linked_mskimpact_cases_filename = args.linked_mskimpact_cases_filename
+	fusions_filename = args.fusions_filename
+	linked_cases_filename = args.linked_cases_filename
 	clinical_filename = args.clinical_filename
-	archer_samples_filename = args.archer_samples_filename
-	
+	mapped_archer_samples_filename = args.mapped_archer_samples_filename
+	study_id = args.study_id
+
 	if not os.path.exists(archer_fusions_filename):
 		print 'Archer fusions file cannot be found ' + archer_fusions_filename
 		sys.exit(2)
-	if not os.path.exists(msk_fusions_filename):
-		print 'Msk fusions file cannot be found ' + msk_fusions_filename
+	if not os.path.exists(fusions_filename):
+		print 'MSKIMPACT or HEME fusions file cannot be found ' + fusions_filename
 		sys.exit(2)
 	if not os.path.exists(clinical_filename):
-		print 'Clinical file cannot be found ' + clinical_filename
+		print 'CVR clinical file cannot be found ' + clinical_filename
 		sys.exit(2)
-	if not os.path.exists(linked_mskimpact_cases_filename):
-		print 'Linked mskimpact cases file cannot be found ' + linked_mskimpact_cases_filename
+	if not os.path.exists(linked_cases_filename):
+		print 'Linked mskimpact cases file cannot be found ' + linked_cases_filename
+		sys.exit(2)
+	if not study_id:
+		print 'Cancer study identifier must be provided!'
+		sys.exit(2)
+	if not study_id in [MSKIMPACT_STUDY_ID, HEMEPACT_STUDY_ID]:
+		print 'Invalid study id provided - only these studies supported: ' + ','.join([MSKIMPACT_STUDY_ID, HEMEPACT_STUDY_ID])
 		sys.exit(2)
 
-	merge_fusions(archer_fusions_filename, msk_fusions_filename, linked_mskimpact_cases_filename, clinical_filename, archer_samples_filename)
+	merge_fusions(archer_fusions_filename, fusions_filename, linked_cases_filename, clinical_filename, mapped_archer_samples_filename, study_id)
 
 if __name__ == '__main__':
 	main()

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -15,6 +15,10 @@ IMPORT_STATUS_HEME=0
 IMPORT_STATUS_RAINDANCE=0
 IMPORT_STATUS_ARCHER=0
 
+# Flags for ARCHER fusions merge failure
+ARCHER_MERGE_IMPACT_FAIL=0
+ARCHER_MERGE_HEME_FAIL=0
+
 # Assume export of supp date from RedCap succeded unless it failed
 EXPORT_SUPP_DATE_IMPACT_FAIL=0
 EXPORT_SUPP_DATE_HEME_FAIL=0
@@ -158,7 +162,7 @@ function import_mskimpact_cvr_to_redcap {
     return $return_value
 }
 
-# Function for importing mskimpact supp date files to redcap 
+# Function for importing mskimpact supp date files to redcap
 function import_mskimpact_supp_date_to_redcap {
     return_value=0
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_supp_date_cbioportal_added.txt mskimpact_supp_date_cbioportal_added ; then return_value=1 ; fi
@@ -169,7 +173,7 @@ function import_mskimpact_supp_date_to_redcap {
 function import_mskimpact_ddp_to_redcap {
     return_value=0
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_clinical_ddp.txt mskimpact_data_clinical_ddp_demographics ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskimpact_timeline_chemotherapy_ddp; then return_value=1 ; fi 
+    if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskimpact_timeline_chemotherapy_ddp; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_timeline_ddp_radiation.txt mskimpact_timeline_radiation_ddp ; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_timeline_ddp_surgery.txt mskimpact_timeline_surgery_ddp ; then return_value=1 ; fi
     return $return_value
@@ -200,7 +204,7 @@ function import_hemepact_supp_date_to_redcap {
 function import_hemepact_ddp_to_redcap {
     return_value=0
     if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_clinical_ddp.txt hemepact_data_clinical_ddp_demographics ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_timeline_ddp_chemotherapy.txt hemepact_timeline_chemotherapy_ddp; then return_value=1 ; fi 
+    if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_timeline_ddp_chemotherapy.txt hemepact_timeline_chemotherapy_ddp; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_timeline_ddp_radiation.txt hemepact_timeline_radiation_ddp ; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_timeline_ddp_surgery.txt hemepact_data_timeline_surgery_ddp ; then return_value=1 ; fi
     return $return_value
@@ -231,7 +235,7 @@ function import_raindance_supp_date_to_redcap {
 function import_raindance_ddp_to_redcap {
     return_value=0
     if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_clinical_ddp.txt mskraindance_data_clinical_ddp_demographics ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskraindance_timeline_chemotherapy_ddp; then return_value=1 ; fi 
+    if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskraindance_timeline_chemotherapy_ddp; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_radiation.txt mskraindance_timeline_radiation_ddp ; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_surgery.txt mskraindance_data_timeline_surgery_ddp ; then return_value=1 ; fi
     return $return_value
@@ -262,7 +266,7 @@ function import_archer_supp_date_to_redcap {
 function import_archer_ddp_to_redcap {
     return_value=0
     if ! import_project_to_redcap $MSK_ARCHER_DATA_HOME/data_clinical_ddp.txt mskarcher_data_clinical_ddp_demographics ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_ARCHER_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskarcher_timeline_chemotherapy_ddp; then return_value=1 ; fi 
+    if ! import_project_to_redcap $MSK_ARCHER_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskarcher_timeline_chemotherapy_ddp; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_ARCHER_DATA_HOME/data_timeline_ddp_radiation.txt mskarcher_timeline_radiation_ddp ; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_ARCHER_DATA_HOME/data_timeline_ddp_surgery.txt mskarcher_data_timeline_surgery_ddp ; then return_value=1 ; fi
     return $return_value
@@ -486,7 +490,7 @@ if [ $FETCH_DARWIN_IMPACT_FAIL -eq 0 ] ; then
     awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PED_IND"] == "Yes") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_supp_darwin_demographics.txt | sort | uniq > $MSK_DMP_TMPDIR/mskimpact_ped_patient_list.txt
     # For future use: when we want to replace darwin demographics attributes with ddp-fetched attributes instead of just for ped-cohort
     #awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt | sort | uniq > $MSK_DMP_TMPDIR/mskimpact_patient_list.txt
-    $JAVA_HOME/bin/java -jar $PORTAL_HOME/lib/ddp_fetcher.jar -o $MSK_IMPACT_DATA_HOME -s $MSK_DMP_TMPDIR/mskimpact_ped_patient_list.txt 
+    $JAVA_HOME/bin/java -jar $PORTAL_HOME/lib/ddp_fetcher.jar -o $MSK_IMPACT_DATA_HOME -s $MSK_DMP_TMPDIR/mskimpact_ped_patient_list.txt
     if [ $? -gt 0 ] ; then
         cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
         sendFailureMessageMskPipelineLogsSlack "MSKIMPACT DDP Fetch"
@@ -561,7 +565,7 @@ fi
 # For future use: when we want to replace darwin demographics attributes with ddp-fetched attributes
 #if [ $FETCH_CVR_HEME_FAIL -eq 0 ] ; then
 #    awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt | sort | uniq > $MSK_DMP_TMPDIR/hemepact_patient_list.txt
-#    $JAVA_HOME/bin/java -jar $PORTAL_HOME/lib/ddp_fetcher.jar -o $MSK_HEMEPACT_DATA_HOME -s $MSK_DMP_TMPDIR/hemepact_patient_list.txt 
+#    $JAVA_HOME/bin/java -jar $PORTAL_HOME/lib/ddp_fetcher.jar -o $MSK_HEMEPACT_DATA_HOME -s $MSK_DMP_TMPDIR/hemepact_patient_list.txt
 #    if [ $? -gt 0 ] ; then
 #        cd $MSK_HEMEPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
 #        sendFailureMessageMskPipelineLogsSlack "HEMEPACT DDP Fetch"
@@ -620,7 +624,7 @@ fi
 # For future use: when we want to replace darwin demographics attributes with ddp-fetched attributes
 #if [ $FETCH_CVR_RAINDANCE_FAIL -eq 0 ] ; then
 #    awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_RAINDANCE_DATA_HOME/data_clinical_mskraindance_data_clinical.txt | sort | uniq > $MSK_DMP_TMPDIR/mskraindance_patient_list.txt
-#    $JAVA_HOME/bin/java -jar $PORTAL_HOME/lib/ddp_fetcher.jar -o $MSK_RAINDANCE_DATA_HOME -s $MSK_DMP_TMPDIR/mskraindance_patient_list.txt 
+#    $JAVA_HOME/bin/java -jar $PORTAL_HOME/lib/ddp_fetcher.jar -o $MSK_RAINDANCE_DATA_HOME -s $MSK_DMP_TMPDIR/mskraindance_patient_list.txt
 #    if [ $? -gt 0 ] ; then
 #        cd $MSK_RAINDANCE_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
 #        sendFailureMessageMskPipelineLogsSlack "RAINDANCE DDP Fetch"
@@ -682,7 +686,7 @@ fi
 # For future use: when we want to replace darwin demographics attributes with ddp-fetched attributes
 #if [ $FETCH_CVR_ARCHER_FAIL -eq 0 ] ; then
 #    awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_ARCHER_DATA_HOME/data_clinical_mskarcher_data_clinical.txt | sort | uniq > $MSK_DMP_TMPDIR/mskarcher_patient_list.txt
-#    $JAVA_HOME/bin/java -jar $PORTAL_HOME/lib/ddp_fetcher.jar -o $MSK_ARCHER_DATA_HOME -s $MSK_DMP_TMPDIR/mskarcher_patient_list.txt 
+#    $JAVA_HOME/bin/java -jar $PORTAL_HOME/lib/ddp_fetcher.jar -o $MSK_ARCHER_DATA_HOME -s $MSK_DMP_TMPDIR/mskarcher_patient_list.txt
 #    if [ $? -gt 0 ] ; then
 #        cd $MSK_ARCHER_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
 #        sendFailureMessageMskPipelineLogsSlack "ARCHER DDP Fetch"
@@ -732,11 +736,32 @@ if [ $IMPORT_STATUS_ARCHER -eq 0 ] && [ $FETCH_CVR_ARCHER_FAIL -eq 0 ] ; then
 fi
 
 # -------------------------------- Additional processing -----------------------------------
+# we maintain a file with the list of ARCHER samples to exclude from any merges/subsets involving
+# ARCHER data to prevent duplicate fusion events ($MSK_ARCHER_DATA_HOME/cvr/mapped_archer_fusion_samples.txt)
+MAPPED_ARCHER_FUSION_SAMPLES_FILE=$MSK_ARCHER_DATA_HOME/cvr/mapped_archer_fusion_samples.txt
 
+# add linked ARCHER fusions to MSKIMPACT
 if [ $IMPORT_STATUS_IMPACT -eq 0 ] && [ $FETCH_CVR_ARCHER_FAIL -eq 0 ] && [ $FETCH_CVR_IMPACT_FAIL -eq 0 ] ; then
-    # Merge Archer fusion data into the impact cohort
-    $PYTHON_BINARY $PORTAL_HOME/scripts/archer_fusions_merger.py --archer-fusions $MSK_ARCHER_DATA_HOME/data_fusions.txt --linked-mskimpact-cases-filename $MSK_ARCHER_DATA_HOME/linked_mskimpact_cases.txt --msk-fusions $MSK_IMPACT_DATA_HOME/data_fusions.txt --clinical-filename $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt --archer-samples-filename $MSK_DMP_TMPDIR/archer_ids.txt
-    cd $MSK_IMPACT_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY forget data_clinical* ; $HG_BINARY forget data_timeline* ; $HG_BINARY commit -m "Adding ARCHER fusions to MSKIMPACT"
+    # Merge ARCHER fusion data into the MSKIMPACT cohort
+    $PYTHON_BINARY $PORTAL_HOME/scripts/archer_fusions_merger.py --archer-fusions $MSK_ARCHER_DATA_HOME/data_fusions.txt --linked-cases-filename $MSK_ARCHER_DATA_HOME/cvr/linked_cases.txt --fusions-filename $MSK_IMPACT_DATA_HOME/data_fusions.txt --clinical-filename $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt --mapped-archer-samples-filename $MAPPED_ARCHER_FUSION_SAMPLES_FILE --study-id "mskimpact"
+    if [ $? -gt 0 ] ; then
+        ARCHER_MERGE_IMPACT_FAIL=1
+        cd $MSK_IMPACT_DATA_HOME; $HG_BINARY update -C ; find . -name "*.orig" -delete
+    else
+        cd $MSK_IMPACT_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY forget data_clinical* ; $HG_BINARY forget data_timeline* ; $HG_BINARY commit -m "Adding ARCHER fusions to MSKIMPACT"
+    fi
+fi
+
+# add linked ARCHER fusions to HEMEPACT
+if [ $IMPORT_STATUS_HEME -eq 0 ] && [ $FETCH_CVR_ARCHER_FAIL -eq 0 ] && [ $FETCH_CVR_HEME_FAIL -eq 0 ] ; then
+    # Merge ARCHER fusion data into the HEMEPACT cohort
+    $PYTHON_BINARY $PORTAL_HOME/scripts/archer_fusions_merger.py --archer-fusions $MSK_ARCHER_DATA_HOME/data_fusions.txt --linked-cases-filename $MSK_ARCHER_DATA_HOME/cvr/linked_cases.txt --fusions-filename $MSK_HEMEPACT_DATA_HOME/data_fusions.txt --clinical-filename $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt --mapped-archer-samples-filename $MAPPED_ARCHER_FUSION_SAMPLES_FILE --study-id "mskimpact_heme"
+    if [ $? -gt 0 ] ; then
+        ARCHER_MERGE_HEME_FAIL=1
+        cd $MSK_HEMEPACT_DATA_HOME; $HG_BINARY update -C ; find . -name "*.orig" -delete
+    else
+        cd $MSK_HEMEPACT_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY forget data_clinical* ; $HG_BINARY forget data_timeline* ; $HG_BINARY commit -m "Adding ARCHER fusions to HEMEPACT"
+    fi
 fi
 
 # gets index of SAMPLE_ID from file (used in case SAMPLE_ID index changes)
@@ -924,7 +949,7 @@ if [ $IMPORT_STATUS_IMPACT -eq 0 ] ; then
             $PYTHON_BINARY $PORTAL_HOME/scripts/filter_dropped_samples_patients.py -s $MSK_IMPACT_DATA_HOME/data_clinical_sample.txt -p $MSK_IMPACT_DATA_HOME/data_clinical_patient.txt -t $MSK_IMPACT_DATA_HOME/data_timeline.txt -f $MSK_DMP_TMPDIR/sample_masterlist_for_filtering.txt
             if [ $? -ne 0 ] ; then
                 cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
-            else 
+            else
                 cd $MSK_IMPACT_DATA_HOME ; find . -name "*.orig" -delete ; $HG_BINARY add * ; $HG_BINARY commit -m "Latest MSK-IMPACT Dataset: Clinical and Timeline"
             fi
         fi
@@ -993,7 +1018,7 @@ echo "Beginning merge of MSK-IMPACT, HEMEPACT, RAINDANCE, ARCHER data for MIXEDP
 echo $(date)
 
 # MIXEDPACT merge and check exit code
-$PYTHON_BINARY $PORTAL_HOME/scripts/merge.py -d $MSK_MIXEDPACT_DATA_HOME -i mixedpact -m "true" -e $MSK_DMP_TMPDIR/archer_ids.txt $MSK_IMPACT_DATA_HOME $MSK_HEMEPACT_DATA_HOME $MSK_RAINDANCE_DATA_HOME $MSK_ARCHER_DATA_HOME
+$PYTHON_BINARY $PORTAL_HOME/scripts/merge.py -d $MSK_MIXEDPACT_DATA_HOME -i mixedpact -m "true" -e $MAPPED_ARCHER_FUSION_SAMPLES_FILE $MSK_IMPACT_DATA_HOME $MSK_HEMEPACT_DATA_HOME $MSK_RAINDANCE_DATA_HOME $MSK_ARCHER_DATA_HOME
 if [ $? -gt 0 ] ; then
     echo "MIXEDPACT merge failed! Study will not be updated in the portal."
     sendFailureMessageMskPipelineLogsSlack "MIXEDPACT merge"
@@ -1017,7 +1042,7 @@ echo "Beginning merge of MSK-IMPACT, HEMEPACT, RAINDANCE, ARCHER data for MSKSOL
 echo $(date)
 
 # MSKSOLIDHEME merge and check exit code
-$PYTHON_BINARY $PORTAL_HOME/scripts/merge.py -d $MSK_SOLID_HEME_DATA_HOME -i msk_solid_heme -m "true" -e $MSK_DMP_TMPDIR/archer_ids.txt $MSK_IMPACT_DATA_HOME $MSK_HEMEPACT_DATA_HOME $MSK_ARCHER_DATA_HOME
+$PYTHON_BINARY $PORTAL_HOME/scripts/merge.py -d $MSK_SOLID_HEME_DATA_HOME -i msk_solid_heme -m "true" -e $MAPPED_ARCHER_FUSION_SAMPLES_FILE $MSK_IMPACT_DATA_HOME $MSK_HEMEPACT_DATA_HOME $MSK_ARCHER_DATA_HOME
 if [ $? -gt 0 ] ; then
     echo "MSKSOLIDHEME merge failed! Study will not be updated in the portal."
     sendFailureMessageMskPipelineLogsSlack "MSKSOLIDHEME merge"
@@ -1133,7 +1158,7 @@ if [ $? -gt 0 ] ; then
     echo "MSKIMPACT redcap export for MSKIMPACT_PED failed! Study will not be updated in the portal"
     sendFailureMessageMskPipelineLogsSlack "MSKIMPACT_PED redcap export"
     MSKIMPACT_PED_SUBSET_FAIL=1
-else 
+else
     bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=mskimpact_ped -o=$MSKIMPACT_PED_DATA_HOME -d=$MSKIMPACT_PED_TMP_DIR -f="PED_IND=Yes" -s=$MSK_DMP_TMPDIR/mskimpact_ped_subset.txt -c=$MSKIMPACT_PED_TMP_DIR/data_clinical_patient.txt
     if [ $? -gt 0 ] ; then
         echo "MSKIMPACT_PED subset failed! Study will not be updated in the portal."
@@ -1245,7 +1270,7 @@ if [ $(wc -l < $MSK_HEMEPACT_DATA_HOME/meta_SV.txt) -eq 0 ] ; then
 fi
 #--------------------------------------------------------------
 # Email for failed processes
- 
+
 EMAIL_BODY="The MSKIMPACT study failed fetch. The original study will remain on the portal."
 # send email if fetch fails
 if [ $IMPORT_STATUS_IMPACT -gt 0 ] ; then
@@ -1272,6 +1297,18 @@ EMAIL_BODY="The ARCHER study failed fetch. The original study will remain on the
 if [ $IMPORT_STATUS_ARCHER -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
     echo -e "$EMAIL_BODY" | mail -s "archer Fetch Failure: Import" $email_list
+fi
+
+EMAIL_BODY="Failed to merge ARCHER fusion events into MSKIMPACT"
+if [ $ARCHER_MERGE_IMPACT_FAIL -gt 0 ] ; then
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" |  mail -s "MSKIMPACT-ARCHER Merge Failure: Study will be updated without new ARCHER fusion events." $email_list
+fi
+
+EMAIL_BODY="Failed to merge ARCHER fusion events into HEMEPACT"
+if [ $ARCHER_MERGE_HEME_FAIL -gt 0 ] ; then
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" |  mail -s "HEMEPACT-ARCHER Merge Failure: Study will be updated without new ARCHER fusion events." $email_list
 fi
 
 EMAIL_BODY="Failed to merge MSK-IMPACT, HEMEPACT, ARCHER, and RAINDANCE data. Merged study will not be updated."


### PR DESCRIPTION
Notes:

1. get a "master" list of samples from CVR clinical file (mskimpact, hemepact)
2. load ARCHER sample case mapping (mapping from ARCHER sid -> mskimpact,hemepact sample ids)
3. load existing/known fusion events from mskimpact/heme
4. load ARCHER fusion events (link events from ARCHER --> other cohorts based on mapping from (2))
5. updates existing/known fusion events from other cohorts w/ARCHER-linked fusion events from (4)
6. update clinical attr `ARCHER` in CVR clinical file for the successfully linked cases to ARCHER fusion events
7. Save ARCHER samples which were successfully linked to other cohort samples in a "mapped_archer_samples.txt" (to prevent duplicates forever)
8. Email out any samples that have ARCHER-linked fusion events but were not part of the CVR "master" list from (1) - these samples might need to be requeued if not failed samples or the samples might be in the current queue for the next day's run already. If failed then follow up with DMP team so that they can remove the ARCHER meta data link. 