### PR TITLE
ARCHER linked cases update sanity check

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
@@ -146,6 +146,7 @@ public class BatchConfiguration {
     public Flow cvrJsonJobFlow() {
         return new FlowBuilder<Flow>("cvrJsonJobFlow")
                 .start(cvrSampleListsStep())
+                .next(linkedMskimpactCaseFlow())
                 .next(clinicalStep())
                 .next(mutationsStepFlow())
                 .next(cnaStepFlow())

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/linkedimpactcase/LinkedMskimpactCaseReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/linkedimpactcase/LinkedMskimpactCaseReader.java
@@ -5,6 +5,7 @@
  */
 package org.cbioportal.cmo.pipelines.cvr.linkedimpactcase;
 
+import com.google.common.base.Strings;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
 import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
 import org.cbioportal.cmo.pipelines.cvr.model.*;
@@ -12,6 +13,7 @@ import org.cbioportal.cmo.pipelines.cvr.model.*;
 import java.io.*;
 import java.util.*;
 import org.apache.log4j.Logger;
+import org.cbioportal.cmo.pipelines.common.util.EmailUtil;
 
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.FlatFileItemReader;
@@ -26,6 +28,16 @@ import org.springframework.core.io.FileSystemResource;
  * @author heinsz
  */
 public class LinkedMskimpactCaseReader implements ItemStreamReader<LinkedMskimpactCaseRecord> {
+
+    @Value("${dmp.email.sender}")
+    private String sender;
+
+    @Value("${dmp.email.recipient}")
+    private String dmpRecipient;
+
+    @Value("${email.recipient}")
+    private String defaultRecipient;
+
     @Value("#{jobParameters[stagingDirectory]}")
     private String stagingDirectory;
 
@@ -35,12 +47,55 @@ public class LinkedMskimpactCaseReader implements ItemStreamReader<LinkedMskimpa
     @Autowired
     public CvrSampleListUtil cvrSampleListUtil;
 
+    @Autowired
+    private EmailUtil emailUtil;
+
+    private final Double DROP_THRESHOLD = 0.9;
+    private Map<String, LinkedMskimpactCaseRecord> existingLinkedIdsMap = new HashMap<>();
+    private Map<String, LinkedMskimpactCaseRecord> compiledLinkedIdsMap = new HashMap<>();
     private List<LinkedMskimpactCaseRecord> linkedIds = new ArrayList<>();
 
     private static final Logger LOG = Logger.getLogger(LinkedMskimpactCaseReader.class);
 
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
+        // load new linked ARCHER sample data
+        loadNewLinkedIds();
+        // load existing linked ARCHER sample data
+        loadExistingLinkedIds();
+
+        // if size of linkedIds is significantly lower than count of existing records
+        // then there might be an issue with the CVR JSON returned - we do not want
+        // to override the linked_cases.txt file with empty data
+        if (compiledLinkedIdsMap.isEmpty() || compiledLinkedIdsMap.size() < (DROP_THRESHOLD * existingLinkedIdsMap.size())) {
+            StringBuilder message = new StringBuilder();
+            String subject;
+            // different message and body for email/logger based on condition met
+            if (compiledLinkedIdsMap.isEmpty()) {
+                subject = "[URGENT] CVR Pipeline: MSKARCHER 'linked_mskimpact_case' data missing";
+                message.append("MSKARCHER meta-data is missing 'linked_mskimpact_case' data for all ARCHER samples - please address ASAP!");
+            }
+            else {
+                subject = "[WARNING] CVR Pipeline: MSKARCHER significant drop in 'linked_mskimpact_case' data";
+                message.append("ARCHER linked IDs update dropped > 90% of current linked IDs count: ")
+                    .append("\n\tExisting linked IDs count = ")
+                    .append(existingLinkedIdsMap.size())
+                    .append("\n\tLinked IDs count from latest CVR update = ")
+                    .append(compiledLinkedIdsMap.size());
+            }
+            // send email and log message
+            String[] recipients = {defaultRecipient, dmpRecipient};
+            emailUtil.sendEmail(sender, recipients, subject, message.toString());
+            LOG.error(message.toString());
+
+            // add the existing linked ids to the list of records to be passed to processor/writer
+            // existing linkages will override data for any overlapping sample ids
+            compiledLinkedIdsMap.putAll(existingLinkedIdsMap);
+        }
+        this.linkedIds = Arrays.asList((LinkedMskimpactCaseRecord[]) compiledLinkedIdsMap.values().toArray());
+    }
+
+    private void loadNewLinkedIds() {
         CVRData cvrData = new CVRData();
         // load cvr data from cvr_data.json file
         File cvrFile = new File(stagingDirectory, cvrUtilities.CVR_FILE);
@@ -51,12 +106,13 @@ public class LinkedMskimpactCaseReader implements ItemStreamReader<LinkedMskimpa
             throw new ItemStreamException(e);
         }
         for (CVRMergedResult result : cvrData.getResults()) {
-            linkedIds.add(new LinkedMskimpactCaseRecord(result.getMetaData().getDmpSampleId(), result.getMetaData().getLinkedMskimpactCase()));
+            String linkedId = result.getMetaData().getLinkedMskimpactCase();
+            if (!Strings.isNullOrEmpty(linkedId) && !linkedId.equals("NA")) {
+                compiledLinkedIdsMap.put(result.getMetaData().getDmpSampleId(), 
+                        new LinkedMskimpactCaseRecord(result.getMetaData().getDmpSampleId(), linkedId));
+            }
         }
-        // load existing linked ARCHER sample data
-        loadExistingLinkedIds();
     }
-
     private void loadExistingLinkedIds() {
         File stagingFile = new File(stagingDirectory, cvrUtilities.CORRESPONDING_ID_FILE);
         if (!stagingFile.exists()) {
@@ -80,8 +136,10 @@ public class LinkedMskimpactCaseReader implements ItemStreamReader<LinkedMskimpa
             while ((to_add = reader.read()) != null) {
                 // only add samples that are not in the new dmp sample list
                 if (!cvrSampleListUtil.getNewDmpSamples().contains(to_add.getSAMPLE_ID())) {
-                    linkedIds.add(to_add);
+                    compiledLinkedIdsMap.put(to_add.getSAMPLE_ID(), to_add);
                 }
+                // keep a backup in case JSON returned dropped all "linked_mskimpact_case" data
+                existingLinkedIdsMap.put(to_add.getSAMPLE_ID(), to_add);
             }
         }
         catch (Exception e) {


### PR DESCRIPTION
Sanity check the upated list of `linkedIds` for ARCHER `cvr/linked_cases.txt`. 

If the updated list of `linkedIds` is < 90% of what is currently checked into `cvr/linked_cases.txt` then alert/email and add all of the existing linked ids to the list of ids that will get written to the `cvr/linked_cases.txt` file. 

This is to prevent the pipeline from overwriting `cvr/linked_cases.txt` with empty list (leaving just the header written to the file).

Also added the `.next(linkedMskimpactCaseFlow())` step to the `cvrJsonJobFlow()` in `BatchConfiguration`