### PR TITLE
Added 'Fusion_Status' column.

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataProcessor.java
@@ -39,6 +39,7 @@ import org.cbioportal.cmo.pipelines.cvr.model.CVRFusionRecord;
 import org.cbioportal.cmo.pipelines.util.CVRUtils;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  *
@@ -46,13 +47,16 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class CVRFusionDataProcessor implements ItemProcessor<CVRFusionRecord, String> {
 
+    @Value("#{stepExecutionContext['fusionHeader']}")
+    private List<String> header;
+
     @Autowired
     private CVRUtils cvrUtils;
 
     @Override
     public String process(CVRFusionRecord i) throws Exception {
         List<String> record = new ArrayList<>();
-        for (String field : CVRFusionRecord.getFieldNames()) {
+        for (String field : header) {
             record.add(cvrUtils.convertWhitespace(i.getClass().getMethod("get" + field).invoke(i).toString()));
         }
         return StringUtils.join(record, "\t");

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataReader.java
@@ -73,8 +73,9 @@ public class CVRFusionDataReader implements ItemStreamReader<CVRFusionRecord> {
         // merge existing and new fusion records
         processJsonFile();
 
-        // set fusion file to write to for writer
+        // set fusion file and header to write to for processor, writer
         ec.put("fusionsFilename", CVRUtilities.FUSION_FILE);
+        ec.put("fusionHeader", CVRFusionRecord.getFieldNames());
     }
 
     private void processFusionsFile() {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataWriter.java
@@ -57,6 +57,9 @@ public class CVRFusionDataWriter implements ItemStreamWriter<String> {
     @Value("#{stepExecutionContext['fusionsFilename']}")
     private String fusionsFilename;
 
+    @Value("#{stepExecutionContext['fusionHeader']}")
+    private List<String> header;
+
     @Autowired
     public CVRUtilities cvrUtilities;
 
@@ -70,7 +73,7 @@ public class CVRFusionDataWriter implements ItemStreamWriter<String> {
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
            @Override
            public void writeHeader(Writer writer) throws IOException {
-               writer.write(StringUtils.join(CVRFusionRecord.getFieldNames(),"\t"));
+               writer.write(StringUtils.join(header, "\t"));
            }
         });
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/GMLFusionDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/GMLFusionDataReader.java
@@ -79,8 +79,9 @@ public class GMLFusionDataReader implements ItemStreamReader<CVRFusionRecord> {
         // load existing germline fusions
         processGmlFusionsFile();
 
-        // set fusion file to write to for writer
+        // set fusion file and header to write to for processor, writer
         ec.put("fusionsFilename", CVRUtilities.FUSION_GML_FILE);
+        ec.put("fusionHeader", CVRFusionRecord.getGermlineFieldNames());
     }
 
     private void processJsonFile() {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRFusionRecord.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRFusionRecord.java
@@ -52,6 +52,7 @@ public class CVRFusionRecord {
     private String method;
     private String frame;
     private String comments;
+    private String fusionStatus;
 
     public CVRFusionRecord() {
     }
@@ -96,6 +97,7 @@ public class CVRFusionRecord {
         this.frame = "unknown";
         // comments do not get imported into db so length of this field won't throw a MysqlDataTruncation exception
         this.comments = (!StringUtils.isNullOrEmpty(variant.getInterpretation())) ? variant.getInterpretation().replaceAll("[\\t\\n\\r]+"," ") : "";
+        this.fusionStatus = "GERMLINE";
     }
 
     public String getHugo_Symbol() {
@@ -177,6 +179,15 @@ public class CVRFusionRecord {
     public void setComments(String comments) {
         this.comments = comments;
     }
+
+    public String getFusion_Status() {
+        return fusionStatus != null ? fusionStatus : "";
+    }
+
+    public void setFusion_Status(String fusionStatus) {
+        this.fusionStatus = fusionStatus;
+    }
+
     public static List<String> getFieldNames() {
         List<String> fieldNames = new ArrayList<String>();
         fieldNames.add("Hugo_Symbol");
@@ -189,6 +200,12 @@ public class CVRFusionRecord {
         fieldNames.add("Method");
         fieldNames.add("Frame");
         fieldNames.add("Comments");
+        return fieldNames;
+    }
+
+    public static List<String> getGermlineFieldNames() {
+        List<String> fieldNames = getFieldNames();
+        fieldNames.add("Fusion_Status");
         return fieldNames;
     }
 }


### PR DESCRIPTION
Fusion data readers now add the appropriate header to the step execution context for `CVRFusionDataProcessor.java` and `CVRFusionDataWriter.java` to use. (similar to how the filename to use is added)

The new `Fusion_Status` column is optional during import. See [cbioportal pr 4441](https://github.com/cBioPortal/cbioportal/pull/4441) for reference