### PR TITLE
Excluding by patient IDs

### DIFF
--- a/import-scripts/merge.py
+++ b/import-scripts/merge.py
@@ -666,6 +666,10 @@ def load_patient_sample_mapping(data_filenames, reference_set, keep_match):
                 update_map = (keep_match == (data[case_id_col] in reference_set))
                 if update_map:
                     update_patient_sample_map(data['PATIENT_ID'], data['SAMPLE_ID'], reference_set, case_id_col)
+                else:
+                    # need to exclude samples linked to patients if excluded reference set is by patient id
+                    if not keep_match and case_id_col == 'PATIENT_ID':
+                        reference_set.add(data['SAMPLE_ID'])
         data_file.close()
     print >> OUTPUT_FILE, 'Finished loading patient - sample mapping!\n'
     return reference_set


### PR DESCRIPTION
The scenario where we want to EXCLUDE by a given set of patient IDs was not supported. 

**Changes:** If excluded reference set is based on patient IDs then need to explicitly update the reference set with any sample IDs that are linked to these patients.

Now the merge script supports:
- subset by patient ids or sample ids
- exclude by patient ids or sample ids

