### PR TITLE
Additional step for sorting DDP records in output files

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/BatchConfiguration.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/BatchConfiguration.java
@@ -125,6 +125,7 @@ public class BatchConfiguration {
     public Job ddpCohortJob() {
         return jobBuilderFactory.get(DDP_COHORT_JOB)
                 .start(ddpStep())
+                .next(ddpSortStep())
                 .next(ddpEmailStep())
                 .build();
     }
@@ -186,6 +187,19 @@ public class BatchConfiguration {
         delegates.add(timelineSurgeryWriter());
         writer.setDelegates(delegates);
         return writer;
+    }
+
+    @Bean
+    public Step ddpSortStep() {
+        return stepBuilderFactory.get("ddpSortStep")
+        .tasklet(ddpSortTasklet())
+        .build();
+    }
+
+    @Bean
+    @StepScope
+    public Tasklet ddpSortTasklet() {
+        return new DDPSortTasklet();
     }
 
     @Bean

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
@@ -72,7 +72,6 @@ public class DDPCompositeProcessor implements ItemProcessor<DDPCompositeRecord, 
 
     @Override
     public CompositeResult process(DDPCompositeRecord compositeRecord) throws Exception {
-        LOG.info("Processing " + compositeRecord.getDmpPatientId());
         // all get methods are asynchrnous - won't wait for completion before completing
         CompletableFuture<PatientDemographics> futurePatientDemographics = ddpDataSource.getPatientDemographics(compositeRecord.getDmpPatientId());
         CompletableFuture<List<PatientDiagnosis>> futurePatientDiagnosis = ddpDataSource.getPatientDiagnoses(compositeRecord.getDmpPatientId());

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSortTasklet.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSortTasklet.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.ddp.pipeline;
+
+import org.mskcc.cmo.ks.ddp.pipeline.model.ClinicalRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineChemoRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineRadiationRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineSurgeryRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+
+import org.apache.commons.lang.StringUtils;
+import java.nio.file.Paths;
+import java.util.*;
+
+/**
+ *
+ * @author Avery Wang
+ */
+public class DDPSortTasklet implements Tasklet {
+
+    Logger log = Logger.getLogger(DDPSortTasklet.class);
+
+    @Value("#{jobParameters[outputDirectory]}")
+    private String outputDirectory;
+
+    private final String clinicalFilename = "data_clinical_ddp.txt";
+    private final String timelineChemotherapyFilename = "data_timeline_ddp_chemotherapy.txt";
+    private final String timelineRadiationFilename = "data_timeline_ddp_radiation.txt";
+    private final String timelineSurgeryFilename = "data_timeline_ddp_surgery.txt";
+
+    @Override
+    public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext) throws Exception {
+
+        String clinicalFilePath = Paths.get(outputDirectory, clinicalFilename).toString();
+        String clinicalHeader = StringUtils.join(ClinicalRecord.getFieldNames(), "\t");
+        log.info("Sorting and overwriting " + clinicalFilePath);
+        DDPUtils.sortAndWrite(clinicalFilePath, clinicalHeader);
+
+        String timelineChemotherapyFilePath = Paths.get(outputDirectory, timelineChemotherapyFilename).toString();
+        String timelineChemotherapyHeader = StringUtils.join(TimelineChemoRecord.getFieldNames(), "\t");
+        log.info("Sorting and overwriting " + timelineChemotherapyFilePath);
+        DDPUtils.sortAndWrite(timelineChemotherapyFilePath, timelineChemotherapyHeader);
+
+        String timelineRadiationFilePath = Paths.get(outputDirectory, timelineRadiationFilename).toString();
+        String timelineRadiationHeader = StringUtils.join(TimelineRadiationRecord.getFieldNames(), "\t");
+        log.info("Sorting and overwriting " + timelineRadiationFilePath);
+        DDPUtils.sortAndWrite(timelineRadiationFilePath, timelineRadiationHeader);
+
+        String timelineSurgeryFilePath = Paths.get(outputDirectory, timelineSurgeryFilename).toString();
+        String timelineSurgeryHeader = StringUtils.join(TimelineSurgeryRecord.getFieldNames(), "\t");
+        log.info("Sorting and overwriting " + timelineSurgeryFilePath);
+        DDPUtils.sortAndWrite(timelineSurgeryFilePath, timelineSurgeryHeader);
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -39,6 +39,7 @@ import com.google.common.base.Strings;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.io.*;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -302,5 +303,43 @@ public class DDPUtils {
      */
     public static Boolean isNullEmptyValue(String value) {
         return (Strings.isNullOrEmpty(value) || NULL_EMPTY_VALUES.contains(value.trim()));
+    }
+
+    /**
+     * Reads a file into a list, sorts, and overwrites original file with sorted records
+     */
+    public static void sortAndWrite(String filename, String header) throws IOException {
+        List<String> recordsInFile = readRecordsFromFile(filename);
+        Collections.sort(recordsInFile);
+        writeRecordsToFile(filename, header, recordsInFile);
+    }
+
+    /**
+     * Returns a list where each index contains a row from a given file
+     * first line is skipped under the assumption it is a header
+     * @param filename
+     */
+    public static List<String> readRecordsFromFile(String filename) throws IOException {
+        List<String> recordsInFile = new ArrayList<String>();
+        BufferedReader reader = new BufferedReader(new FileReader(filename));
+        // skip first line (header)
+        reader.readLine();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            recordsInFile.add(line);
+        }
+        reader.close();
+        return recordsInFile;
+    }
+
+    public static void writeRecordsToFile(String filename, String header, List<String> records) throws IOException {
+        BufferedWriter writer = new BufferedWriter(new FileWriter(filename));
+        writer.write(header);
+        writer.newLine();
+        for (String record : records) {
+            writer.write(record);
+            writer.newLine();
+        }
+        writer.close();
     }
 }


### PR DESCRIPTION
- new DDPSortTasklet after initial ddpStep
- new functions in DDPUtils for opening/sorting/writing records in a file

Added to preserve order so that each day's fetch is not registered as a "new file" with changes