### PR TITLE
Replace testing with production-ready code

### DIFF
--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/CRDBPipeline.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/CRDBPipeline.java
@@ -68,7 +68,6 @@ public class CRDBPipeline {
         SpringApplication app = new SpringApplication(CRDBPipeline.class);
         ConfigurableApplicationContext ctx = app.run(args);
         JobLauncher jobLauncher = ctx.getBean(JobLauncher.class);
-        String jobName;
         
         JobParameters jobParameters = new JobParametersBuilder()
                 .addString("stagingDirectory", stagingDirectory)

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/BatchConfiguration.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/BatchConfiguration.java
@@ -68,8 +68,8 @@ public class BatchConfiguration
     @Bean
     public Job crdbImpactJob() {
         return jobBuilderFactory.get(CRDB_IMPACT_JOB)
-            .start(step1())
-            .next(step2())
+            .start(crdbSurveyStep())
+            .next(crdbDatasetStep())
             .build();
     }
 
@@ -87,29 +87,29 @@ public class BatchConfiguration
      * Step 1 reads, processes, and writes the CRDB Survey query results
      */
     @Bean
-    public Step step1() {
-        return stepBuilderFactory.get("step1")
+    public Step crdbSurveyStep() {
+        return stepBuilderFactory.get("crdbSurveyStep")
             .<CRDBSurvey, String> chunk(10)
-            .reader(reader1())
-            .processor(processor1())
-            .writer(writer1())
+            .reader(crdbSurveyReader())
+            .processor(crdbSurveyProcessor())
+            .writer(crdbSurveyWriter())
             .build();
     }
 
     @Bean
     @StepScope
-	public ItemStreamReader<CRDBSurvey> reader1() {
+	public ItemStreamReader<CRDBSurvey> crdbSurveyReader() {
 		return new CRDBSurveyReader();
 	}
 
     @Bean
-    public CRDBSurveyProcessor processor1() {
+    public CRDBSurveyProcessor crdbSurveyProcessor() {
         return new CRDBSurveyProcessor();
     }
 
     @Bean
     @StepScope
-    public ItemStreamWriter<String> writer1() {
+    public ItemStreamWriter<String> crdbSurveyWriter() {
         return new CRDBSurveyWriter();
     }
 
@@ -117,29 +117,29 @@ public class BatchConfiguration
      * Step 2 reads, processes, and writes the CRDB Dataset query results
      */
     @Bean
-    public Step step2() {
-        return stepBuilderFactory.get("step2")
+    public Step crdbDatasetStep() {
+        return stepBuilderFactory.get("crdbDatasetStep")
             .<CRDBDataset, String> chunk(10)
-            .reader(reader2())
-            .processor(processor2())
-            .writer(writer2())
+            .reader(crdbDatasetReader())
+            .processor(crdbDatasetProcessor())
+            .writer(crdbDatasetWriter())
             .build();
     }
 
     @Bean
     @StepScope
-    public ItemStreamReader<CRDBDataset> reader2() {
+    public ItemStreamReader<CRDBDataset> crdbDatasetReader() {
 	return new CRDBDatasetReader();
     }
 
     @Bean
-    public CRDBDatasetProcessor processor2() {
+    public CRDBDatasetProcessor crdbDatasetProcessor() {
         return new CRDBDatasetProcessor();
     }
 
     @Bean
     @StepScope
-    public ItemStreamWriter<String> writer2() {
+    public ItemStreamWriter<String> crdbDatasetWriter() {
         return new CRDBDatasetWriter();
     }
 

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBDatasetWriter.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBDatasetWriter.java
@@ -41,6 +41,7 @@ import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.io.*;
+import java.nio.file.Paths;
 import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
@@ -60,7 +61,6 @@ public class CRDBDatasetWriter implements ItemStreamWriter<String> {
 
     private List<String> writeList = new ArrayList<String>();
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<String>();
-    private String stagingFile;
 
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
@@ -72,11 +72,7 @@ public class CRDBDatasetWriter implements ItemStreamWriter<String> {
                 writer.write(normalizeHeaders(new CRDBDataset().getFieldNames()));
             }
         });
-        if (stagingDirectory.endsWith("/")) {
-            stagingFile = stagingDirectory + datasetFilename;
-        } else{
-            stagingFile = stagingDirectory + "/" + datasetFilename;
-        }
+        String stagingFile = Paths.get(stagingDirectory, datasetFilename).toString();
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
         flatFileItemWriter.open(executionContext);
     }

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXClinicalPatientReader.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXClinicalPatientReader.java
@@ -83,8 +83,8 @@ public class CRDBPDXClinicalPatientReader implements ItemStreamReader<CRDBPDXCli
         List<CRDBPDXClinicalPatientDataset> crdbPDXClinicalPatientDatasetResults = crdbQueryFactory.selectDistinct(
                 Projections.constructor(CRDBPDXClinicalPatientDataset.class, $(qCRDBD.getPATIENT_ID()), $(qCRDBD.getDESTINATION_STUDY_ID()),
                                         $(qCRDBD.getSEX()), $(qCRDBD.getETHNICITY()), $(qCRDBD.getRACE()), $(qCRDBD.getSMOKING_HISTORY()),
-                                        $(qCRDBD.getCROHN_DISEASE()), $(qCRDBD.getULCERATIVE_COLITIS()), $(qCRDBD.getBARETT_ESOPHAGUS()),
-                                        $(qCRDBD.getH_PYLORI()), $(qCRDBD.getMDS()), $(qCRDBD.getMENOPAUSAL_STATUS()), $(qCRDBD.getUV_EXPOSURE()),
+                                        $(qCRDBD.getCROHN_DISEASE()), $(qCRDBD.getULCERATIVE_COLITIS()), $(qCRDBD.getBARRETTS_ESOPHAGUS()),
+                                        $(qCRDBD.getH_PYLORI()), $(qCRDBD.getMDS()), $(qCRDBD.getMENOPAUSE_STATUS()), $(qCRDBD.getUV_EXPOSURE()),
                                         $(qCRDBD.getRADIATION_THERAPY()), $(qCRDBD.getBREAST_IMPLANTS()), $(qCRDBD.getBRCA()),
                                         $(qCRDBD.getRETINOBLASTOMA()), $(qCRDBD.getGRADE_1()), $(qCRDBD.getGRADE_2()), $(qCRDBD.getGRADE_3()),
                                         $(qCRDBD.getPLATINUM_SENSITIVE()), $(qCRDBD.getPLATINUM_RESISTANT())))

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXClinicalPatientWriter.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXClinicalPatientWriter.java
@@ -41,7 +41,7 @@ import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.io.*;
-import java.nio.file.*;
+import java.nio.file.Paths;
 import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
@@ -60,7 +60,6 @@ public class CRDBPDXClinicalPatientWriter implements ItemStreamWriter<String> {
     private String pdxClinicalPatientDatasetFilename;
 
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<String>();
-    private String stagingFile;
 
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
@@ -72,7 +71,7 @@ public class CRDBPDXClinicalPatientWriter implements ItemStreamWriter<String> {
                 writer.write(StringUtils.join(new CRDBPDXClinicalPatientDataset().getFieldNames(), "\t"));
             }
         });
-        stagingFile = Paths.get(stagingDirectory, pdxClinicalPatientDatasetFilename).toString();
+        String stagingFile = Paths.get(stagingDirectory, pdxClinicalPatientDatasetFilename).toString();
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
         flatFileItemWriter.open(executionContext);
     }

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXClinicalSampleWriter.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXClinicalSampleWriter.java
@@ -41,7 +41,7 @@ import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.io.*;
-import java.nio.file.*;
+import java.nio.file.Paths;
 import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
@@ -60,7 +60,6 @@ public class CRDBPDXClinicalSampleWriter implements ItemStreamWriter<String> {
     private String pdxClinicalSampleDatasetFilename;
 
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<String>();
-    private String stagingFile;
 
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
@@ -72,7 +71,7 @@ public class CRDBPDXClinicalSampleWriter implements ItemStreamWriter<String> {
                 writer.write(StringUtils.join(new CRDBPDXClinicalSampleDataset().getFieldNames(), "\t"));
             }
         });
-        stagingFile = Paths.get(stagingDirectory, pdxClinicalSampleDatasetFilename).toString();
+        String stagingFile = Paths.get(stagingDirectory, pdxClinicalSampleDatasetFilename).toString();
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
         flatFileItemWriter.open(executionContext);
     }

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXSourceToDestinationMappingWriter.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXSourceToDestinationMappingWriter.java
@@ -41,7 +41,7 @@ import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.io.*;
-import java.nio.file.*;
+import java.nio.file.Paths;
 import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
@@ -60,7 +60,6 @@ public class CRDBPDXSourceToDestinationMappingWriter implements ItemStreamWriter
     private String sourceToDestinationMappingsFilename;
 
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<String>();
-    private String stagingFile;
 
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
@@ -72,7 +71,7 @@ public class CRDBPDXSourceToDestinationMappingWriter implements ItemStreamWriter
                 writer.write(StringUtils.join(new CRDBPDXSourceToDestinationMapping().getFieldNames(), "\t"));
             }
         });
-        stagingFile = Paths.get(stagingDirectory, sourceToDestinationMappingsFilename).toString();
+        String stagingFile = Paths.get(stagingDirectory, sourceToDestinationMappingsFilename).toString();
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
         flatFileItemWriter.open(executionContext);
     }

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXTimelineReader.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXTimelineReader.java
@@ -83,7 +83,7 @@ public class CRDBPDXTimelineReader implements ItemStreamReader<CRDBPDXTimelineDa
         List<CRDBPDXTimelineDataset> crdbTimelineDatasetResults = crdbQueryFactory.selectDistinct(
                 Projections.constructor(CRDBPDXTimelineDataset.class, $(qCRDBD.getPATIENT_ID()), $(qCRDBD.getSAMPLE_ID()), $(qCRDBD.getPDX_ID()),
                                         $(qCRDBD.getDESTINATION_STUDY_ID()), $(qCRDBD.getSTART_DATE()), $(qCRDBD.getSTOP_DATE()), $(qCRDBD.getEVENT_TYPE()),
-                                        $(qCRDBD.getPASSAGE_ID()), $(qCRDBD.getTREATMENT_TYPE()), $(qCRDBD.getSUB_TYPE()), $(qCRDBD.getAGENT()),
+                                        $(qCRDBD.getPASSAGE_ID()), $(qCRDBD.getTREATMENT_TYPE()), $(qCRDBD.getSUBTYPE()), $(qCRDBD.getAGENT()),
                                         $(qCRDBD.getRESPONSE()), $(qCRDBD.getRESPONSE_DURATION_MONTHS()), $(qCRDBD.getREASON_FOR_TX_DISCONTINUATION()),
                                         $(qCRDBD.getSURGERY_DETAILS()), $(qCRDBD.getEVENT_TYPE_DETAILED()), $(qCRDBD.getPROCEDURE_LOCATION()),
                                         $(qCRDBD.getPROCEDURE_LOCATION_SPECIFY()), $(qCRDBD.getDIAGNOSTIC_TYPE()), $(qCRDBD.getDIAGNOSTIC_TYPE_SITE()),

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXTimelineWriter.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXTimelineWriter.java
@@ -41,7 +41,7 @@ import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.io.*;
-import java.nio.file.*;
+import java.nio.file.Paths;
 import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
@@ -60,7 +60,6 @@ public class CRDBPDXTimelineWriter implements ItemStreamWriter<String> {
     private String pdxTimelineDatasetFilename;
 
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<String>();
-    private String stagingFile;
 
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
@@ -72,7 +71,7 @@ public class CRDBPDXTimelineWriter implements ItemStreamWriter<String> {
                 writer.write(StringUtils.join(new CRDBPDXTimelineDataset().getFieldNames(), "\t"));
             }
         });
-        stagingFile = Paths.get(stagingDirectory, pdxTimelineDatasetFilename).toString();
+        String stagingFile = Paths.get(stagingDirectory, pdxTimelineDatasetFilename).toString();
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
         flatFileItemWriter.open(executionContext);
     }

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBSurveyWriter.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBSurveyWriter.java
@@ -41,6 +41,7 @@ import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.io.*;
+import java.nio.file.Paths;
 import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
@@ -61,7 +62,6 @@ public class CRDBSurveyWriter implements ItemStreamWriter<String>
 
     private final List<String> writeList = new ArrayList<>();
     private final FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
-    private String stagingFile;
 
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException {
@@ -73,12 +73,7 @@ public class CRDBSurveyWriter implements ItemStreamWriter<String>
                 writer.write(normalizeHeaders(new CRDBSurvey().getFieldNames()));
             }
         });
-
-        if (stagingDirectory.endsWith("/")) {
-            stagingFile = stagingDirectory + surveyFilename;
-        } else{
-            stagingFile = stagingDirectory + "/" + surveyFilename;
-        }
+        String stagingFile = Paths.get(stagingDirectory, surveyFilename).toString();
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
         flatFileItemWriter.open(executionContext);
     }

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/model/CRDBPDXClinicalPatientDataset.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/model/CRDBPDXClinicalPatientDataset.java
@@ -51,10 +51,10 @@ public class CRDBPDXClinicalPatientDataset {
     private String SMOKING_HISTORY;
     private String CROHN_DISEASE;
     private String ULCERATIVE_COLITIS;
-    private String BARETT_ESOPHAGUS;
+    private String BARRETTS_ESOPHAGUS;
     private String H_PYLORI;
     private String MDS;
-    private String MENOPAUSAL_STATUS;
+    private String MENOPAUSE_STATUS;
     private String UV_EXPOSURE;
     private String RADIATION_THERAPY;
     private String BREAST_IMPLANTS;
@@ -74,8 +74,8 @@ public class CRDBPDXClinicalPatientDataset {
     }
 
     public CRDBPDXClinicalPatientDataset(String PATIENT_ID, String DESTINATION_STUDY_ID, String SEX, String ETHNICITY, String RACE, 
-                                         String SMOKING_HISTORY, String CROHN_DISEASE, String ULCERATIVE_COLITIS, String BARETT_ESOPHAGUS,
-                                         String H_PYLORI, String MDS, String MENOPAUSAL_STATUS, String UV_EXPOSURE, String RADIATION_THERAPY,
+                                         String SMOKING_HISTORY, String CROHN_DISEASE, String ULCERATIVE_COLITIS, String BARRETTS_ESOPHAGUS,
+                                         String H_PYLORI, String MDS, String MENOPAUSE_STATUS, String UV_EXPOSURE, String RADIATION_THERAPY,
                                          String BREAST_IMPLANTS, String BRCA, String RETINOBLASTOMA, String GRADE_1, String GRADE_2, 
                                          String GRADE_3, String PLATINUM_SENSITIVE, String PLATINUM_RESISTANT) {
         this.PATIENT_ID = PATIENT_ID == null ? "NA" : PATIENT_ID;
@@ -86,10 +86,10 @@ public class CRDBPDXClinicalPatientDataset {
         this.SMOKING_HISTORY = SMOKING_HISTORY == null ? "NA" : SMOKING_HISTORY;
         this.CROHN_DISEASE = CROHN_DISEASE == null ? "NA" : CROHN_DISEASE;
         this.ULCERATIVE_COLITIS = ULCERATIVE_COLITIS == null ? "NA" : ULCERATIVE_COLITIS;
-        this.BARETT_ESOPHAGUS = BARETT_ESOPHAGUS == null ? "NA" : BARETT_ESOPHAGUS;
+        this.BARRETTS_ESOPHAGUS = BARRETTS_ESOPHAGUS == null ? "NA" : BARRETTS_ESOPHAGUS;
         this.H_PYLORI = H_PYLORI == null ? "NA" : H_PYLORI;
         this.MDS = MDS == null ? "NA" : MDS;
-        this.MENOPAUSAL_STATUS = MENOPAUSAL_STATUS == null ? "NA" : MENOPAUSAL_STATUS;
+        this.MENOPAUSE_STATUS = MENOPAUSE_STATUS == null ? "NA" : MENOPAUSE_STATUS;
         this.UV_EXPOSURE = UV_EXPOSURE == null ? "NA" : UV_EXPOSURE;
         this.RADIATION_THERAPY = RADIATION_THERAPY == null ? "NA" : RADIATION_THERAPY;
         this.BREAST_IMPLANTS = BREAST_IMPLANTS == null ? "NA" : BREAST_IMPLANTS;
@@ -208,12 +208,12 @@ public class CRDBPDXClinicalPatientDataset {
         this.ULCERATIVE_COLITIS = ULCERATIVE_COLITIS;
     }
 
-    public String getBARETT_ESOPHAGUS() {
-        return BARETT_ESOPHAGUS;
+    public String getBARRETTS_ESOPHAGUS() {
+        return BARRETTS_ESOPHAGUS;
     }
 
-    public void setBARETT_ESOPHAGUS(String BARETT_ESOPHAGUS) {
-        this.BARETT_ESOPHAGUS = BARETT_ESOPHAGUS;
+    public void setBARRETTS_ESOPHAGUS(String BARRETTS_ESOPHAGUS) {
+        this.BARRETTS_ESOPHAGUS = BARRETTS_ESOPHAGUS;
     }
 
     public String getH_PYLORI() {
@@ -232,12 +232,12 @@ public class CRDBPDXClinicalPatientDataset {
         this.MDS = MDS;
     }
 
-    public String getMENOPAUSAL_STATUS() {
-        return MENOPAUSAL_STATUS;
+    public String getMENOPAUSE_STATUS() {
+        return MENOPAUSE_STATUS;
     }
 
-    public void setMENOPAUSAL_STATUS(String MENOPAUSAL_STATUS) {
-        this.MENOPAUSAL_STATUS = MENOPAUSAL_STATUS;
+    public void setMENOPAUSE_STATUS(String MENOPAUSE_STATUS) {
+        this.MENOPAUSE_STATUS = MENOPAUSE_STATUS;
     }
 
     public String getUV_EXPOSURE() {
@@ -334,10 +334,10 @@ public class CRDBPDXClinicalPatientDataset {
         fieldNames.add("SMOKING_HISTORY");
         fieldNames.add("CROHN_DISEASE");
         fieldNames.add("ULCERATIVE_COLITIS");
-        fieldNames.add("BARETT_ESOPHAGUS");
+        fieldNames.add("BARRETTS_ESOPHAGUS");
         fieldNames.add("H_PYLORI");
         fieldNames.add("MDS");
-        fieldNames.add("MENOPAUSAL_STATUS");
+        fieldNames.add("MENOPAUSE_STATUS");
         fieldNames.add("UV_EXPOSURE");
         fieldNames.add("RADIATION_THERAPY");
         fieldNames.add("BREAST_IMPLANTS");

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/model/CRDBPDXTimelineDataset.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/model/CRDBPDXTimelineDataset.java
@@ -52,7 +52,7 @@ public class CRDBPDXTimelineDataset {
     private String EVENT_TYPE;
     private String PASSAGE_ID;
     private String TREATMENT_TYPE;
-    private String SUB_TYPE;
+    private String SUBTYPE;
     private String AGENT;
     private String RESPONSE;
     private String RESPONSE_DURATION_MONTHS;
@@ -80,7 +80,7 @@ public class CRDBPDXTimelineDataset {
     }
     public CRDBPDXTimelineDataset(String PATIENT_ID, String SAMPLE_ID, String PDX_ID, String DESTINATION_STUDY_ID,
                                   String START_DATE, String STOP_DATE, String EVENT_TYPE, String PASSAGE_ID,
-                                  String TREATMENT_TYPE, String SUB_TYPE, String AGENT, String RESPONSE,
+                                  String TREATMENT_TYPE, String SUBTYPE, String AGENT, String RESPONSE,
                                   String RESPONSE_DURATION_MONTHS, String REASON_FOR_TX_DISCONTINUATION,
                                   String SURGERY_DETAILS, String EVENT_TYPE_DETAILED, String PROCEDURE_LOCATION,
                                   String PROCEDURE_LOCATION_SPECIFY, String DIAGNOSTIC_TYPE, String DIAGNOSTIC_TYPE_SITE,
@@ -97,7 +97,7 @@ public class CRDBPDXTimelineDataset {
         this.EVENT_TYPE = EVENT_TYPE == null ? "NA" : EVENT_TYPE;
         this.PASSAGE_ID = PASSAGE_ID == null ? "NA" : PASSAGE_ID;
         this.TREATMENT_TYPE = TREATMENT_TYPE == null ? "NA" : TREATMENT_TYPE;
-        this.SUB_TYPE = SUB_TYPE == null ? "NA" : SUB_TYPE;
+        this.SUBTYPE = SUBTYPE == null ? "NA" : SUBTYPE;
         this.AGENT = AGENT == null ? "NA" : AGENT;
         this.RESPONSE = RESPONSE == null ? "NA" : RESPONSE;
         this.RESPONSE_DURATION_MONTHS = RESPONSE_DURATION_MONTHS == null ? "NA" : RESPONSE_DURATION_MONTHS;
@@ -249,17 +249,17 @@ public class CRDBPDXTimelineDataset {
     }
 
     /**
-     * @return SUB_TYPE
+     * @return SUBTYPE
      */
-    public String getSUB_TYPE() {
-        return SUB_TYPE;
+    public String getSUBTYPE() {
+        return SUBTYPE;
     }
 
     /**
-     * @param SUB_TYPE
+     * @param SUBTYPE
      */
-    public void setSUB_TYPE(String SUB_TYPE) {
-        this.SUB_TYPE = SUB_TYPE;
+    public void setSUBTYPE(String SUBTYPE) {
+        this.SUBTYPE = SUBTYPE;
     }
 
     /**
@@ -569,7 +569,7 @@ public class CRDBPDXTimelineDataset {
         fieldNames.add("EVENT_TYPE");
         fieldNames.add("PASSAGE_ID");
         fieldNames.add("TREATMENT_TYPE");
-        fieldNames.add("SUB_TYPE");
+        fieldNames.add("SUBTYPE");
         fieldNames.add("AGENT");
         fieldNames.add("RESPONSE");
         fieldNames.add("RESPONSE_DURATION_MONTHS");


### PR DESCRIPTION
additional cleanup of testing code (i.e filtering non-CDD attribute) in anticipation of production release
change to use cmo-msk-importer
change to restart tomcats on dashi/dashi2
small changes to python script to use DictReader
change writers to use java.nio.file.Paths