### PR TITLE
Add CNA gene panel column to data_gene_matrix.txt

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -94,6 +94,17 @@ public class CVRUtilities {
         return map;
     }
 
+    public static List<String> DEFAULT_GENETIC_PROFILES = new LinkedList(Arrays.asList(new String[]{"mutations"}));
+    public static Map<String, List<String>> GENETIC_PROFILES_BY_STUDY = geneticProfilesByStudy();
+    private static Map<String, List<String>> geneticProfilesByStudy() {
+        Map<String, List<String>> map = new HashMap<>();
+        map.put("mskimpact", new LinkedList(Arrays.asList(new String[]{"mutations", "cna"})));
+        map.put("mskimpact_heme", new LinkedList(Arrays.asList(new String[]{"mutations", "cna"})));
+        map.put("mskarcher", new LinkedList(Arrays.asList(new String[]{"mutations"})));
+        map.put("mskraindance", new LinkedList(Arrays.asList(new String[]{"mutations"})));
+        return map;
+    }
+
     public CVRUtilities() {}
 
     public CVRData readJson(File cvrFile) throws IOException {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelProcessor.java
@@ -38,6 +38,7 @@ import org.cbioportal.cmo.pipelines.cvr.model.*;
 import org.cbioportal.cmo.pipelines.util.CVRUtils;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  *
@@ -48,13 +49,15 @@ public class CVRGenePanelProcessor implements ItemProcessor<CVRGenePanelRecord, 
     @Autowired
     private CVRUtils cvrUtils;
 
+    @Value("#{stepExecutionContext['geneticProfiles']}")
+    private List<String> geneticProfiles;
+
     @Override
     public String process(CVRGenePanelRecord i) throws Exception {
         List<String> record = new ArrayList<>();
         record.add(cvrUtils.convertWhitespace(i.getSAMPLE_ID()));
-        Collection<String> values = i.getPanelMap().values();
-        for (String value : values) {
-            record.add(cvrUtils.convertWhitespace(value));
+        for (String profile : geneticProfiles) {
+            record.add(cvrUtils.convertWhitespace(i.getPanelMap().get(profile)));
         }
         return StringUtils.join(record, "\t");
     }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelWriter.java
@@ -36,13 +36,11 @@ import java.io.*;
 import java.util.*;
 import org.apache.commons.lang.StringUtils;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
-import org.cbioportal.cmo.pipelines.cvr.model.CVRClinicalRecord;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.*;
-import org.cbioportal.cmo.pipelines.cvr.model.CompositeClinicalRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRGenePanelRecord.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRGenePanelRecord.java
@@ -43,11 +43,12 @@ public class CVRGenePanelRecord {
 
     public CVRGenePanelRecord() {}
 
-    public CVRGenePanelRecord(CVRMetaData metaData) {
+    public CVRGenePanelRecord(CVRMetaData metaData, List<String> geneticProfiles) {
         this.sampleId = metaData.getDmpSampleId();
         panelMap = new LinkedHashMap<>();
-        // We could have more profiles in the future - for now only mutation is supported
-        panelMap.put("mutations", metaData.getGenePanel());
+        for (String profile : geneticProfiles) {
+            panelMap.put(profile, metaData.getGenePanel());
+        }
     }
 
     public String getSAMPLE_ID() {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/util/CVRUtils.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/util/CVRUtils.java
@@ -32,12 +32,42 @@
 
 package org.cbioportal.cmo.pipelines.util;
 
+import java.io.*;
+import java.util.*;
+
 public class CVRUtils {
+
+    private String METADATA_PREFIX = "#";
+    private String DELIMITER = "\t";
 
     public CVRUtils() {}
 
     public String convertWhitespace(String s) {
         return s.replaceAll("^[\\t|\\n|\\r]+", "").replaceAll("[\\t|\\n|\\r]+$", "").replaceAll("[\\t|\\n|\\r]+", " ");
     }
-    
+
+    public String[] getFileHeader(File dataFile) throws IOException {
+        String[] columnNames;
+
+        try (FileReader reader = new FileReader(dataFile)) {
+            BufferedReader buff = new BufferedReader(reader);
+            String line = buff.readLine();
+
+            // keep reading until line does not start with meta data prefix
+            while (line.startsWith(METADATA_PREFIX)) {
+                line = buff.readLine();
+            }
+            // extract the maf file header
+            columnNames = splitDataFields(line);
+            reader.close();
+        }
+
+        return columnNames;
+    }
+
+    private String[] splitDataFields(String line) {
+        line = line.replaceAll("^" + METADATA_PREFIX + "+", "");
+        String[] fields = line.split(DELIMITER, -1);
+        return fields;
+    }
 }


### PR DESCRIPTION
Tested the following scenarios:

- updating an existing data_gene_matrix.txt file (provided that the existing file contains all genetic profiles for current study)
- creating new data_gene_matrix.txt file with cna and mutations profiles columns
- creating new data_gene_matrix.txt file with only mutations profile column
- CVR pipeline files if the existing data_gene_matrix.txt file is missing a genetic profile column that should be there


Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>