### PR TITLE
General JSON converter for cohorts outside of primary clinical seq cohorts

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -70,6 +70,8 @@ public class CVRUtilities {
     public static final String CNA_HEADER_HUGO_SYMBOL = "Hugo_Symbol";
     public static final Integer DEFAULT_MAX_NUM_SAMPLES_TO_REMOVE = -1;
     public static final SimpleDateFormat CVR_DATE_FORMAT = new SimpleDateFormat("EEE, dd MMM yyyy kk:mm:ss zzz");
+    public static final Set<String> INVALID_PATIENT_IDS = new HashSet<String>(Arrays.asList(new String[] {"P-0000000"}));
+    public static final String UNKNOWN_GENE_PANEL = "UNKNOWN";
 
     private static final String CENTER_MSKCC = "MSKCC";
     private static final String DEFAULT_BUILD_NUMBER = "37";

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataListener.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataListener.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.cmo.pipelines.cvr.clinical;
+
+import java.io.File;
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.ItemStreamException;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class CVRClinicalDataListener implements StepExecutionListener {
+
+    private static Logger log = Logger.getLogger(CVRClinicalDataListener.class);
+
+    @Override
+    public void beforeStep(StepExecution se) {}
+
+    @Override
+    public ExitStatus afterStep(StepExecution se) {
+        File clinicalFile = (File) se.getExecutionContext().get("clinicalFile");
+        int clinicalRecordsWritten = se.getExecutionContext().getInt("clinicalRecordsWritten");
+        if (clinicalRecordsWritten == 0) {
+            String errorMessage = "No data written to clinical file! '" + clinicalFile.getName() + "'" +
+                    " - check JSON for invalid patient IDs and/or masterlist for applicable studies. " +
+                    "Removing file and exiting...";
+            log.error(errorMessage);
+            clinicalFile.delete();
+            throw new ItemStreamException(errorMessage);
+        }
+        return ExitStatus.COMPLETED;
+    }
+
+}

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
@@ -62,6 +62,9 @@ public class CVRClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
     @Value("#{jobParameters[clinicalFilename]}")
     private String clinicalFilename;
 
+    @Value("#{jobParameters[extractTransformJsonMode]}")
+    private Boolean extractTransformJsonMode;
+
     @Autowired
     public CVRUtilities cvrUtilities;
 
@@ -77,13 +80,15 @@ public class CVRClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
     public void open(ExecutionContext ec) throws ItemStreamException {
         processClinicalFile(ec);
         processJsonFile();
-        if (studyId.equals("mskimpact")) {
-            processSeqDateFile(ec);
-            processAgeFile(ec);
+        if (!extractTransformJsonMode) {
+            if (studyId.equals("mskimpact")) {
+                processSeqDateFile(ec);
+                processAgeFile(ec);
+            }
+            // updates portalSamplesNotInDmpList and dmpSamplesNotInPortal sample lists
+            // portalSamples list is only updated if threshold check for max num samples to remove passes
+            cvrSampleListUtil.updateSampleLists();
         }
-        // updates portalSamplesNotInDmpList and dmpSamplesNotInPortal sample lists
-        // portalSamples list is only updated if threshold check for max num samples to remove passes
-        cvrSampleListUtil.updateSampleLists();
     }
 
     @Override

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/cna/CVRCnaDataListener.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/cna/CVRCnaDataListener.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.cmo.pipelines.cvr.cna;
+
+import java.io.*;
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class CVRCnaDataListener implements StepExecutionListener {
+
+    private static Logger log = Logger.getLogger(CVRCnaDataListener.class);
+
+    @Override
+    public void beforeStep(StepExecution se) {}
+
+    @Override
+    public ExitStatus afterStep(StepExecution se) {
+        File cnaFile = (File) se.getExecutionContext().get("cnaFile");
+        int cnaRecordsWritten = se.getExecutionContext().getInt("cnaRecordsWritten");
+        if (cnaRecordsWritten == 0) {
+            log.warn("No records written to '" + cnaFile.getName() + " - removing file...");
+            cnaFile.delete();
+        }
+        return ExitStatus.COMPLETED;
+    }
+
+}

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataListener.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataListener.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.cmo.pipelines.cvr.fusion;
+
+import java.io.*;
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class CVRFusionDataListener implements StepExecutionListener {
+
+    private static Logger log = Logger.getLogger(CVRFusionDataListener.class);
+
+    @Override
+    public void beforeStep(StepExecution se) {}
+
+    @Override
+    public ExitStatus afterStep(StepExecution se) {
+        File fusionFile = (File) se.getExecutionContext().get("fusionFile");
+        int fusionRecordsWritten = se.getExecutionContext().getInt("fusionRecordsWritten");
+        if (fusionRecordsWritten == 0) {
+            log.warn("No records written to '" + fusionFile.getName() + " - removing file...");
+            fusionFile.delete();
+        }
+        return ExitStatus.COMPLETED;
+    }
+
+}

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/fusion/CVRFusionDataWriter.java
@@ -33,11 +33,11 @@
 package org.cbioportal.cmo.pipelines.cvr.fusion;
 
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
-import org.cbioportal.cmo.pipelines.cvr.model.CVRFusionRecord;
 
 import java.io.*;
 import java.util.*;
 import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
 
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
@@ -63,11 +63,15 @@ public class CVRFusionDataWriter implements ItemStreamWriter<String> {
     @Autowired
     public CVRUtilities cvrUtilities;
 
+    private int fusionRecordsWritten;
+    private File stagingFile;
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
+
+    private static Logger log = Logger.getLogger(CVRFusionDataWriter.class);
 
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
-        File stagingFile = new File(stagingDirectory, fusionsFilename);
+        stagingFile = new File(stagingDirectory, fusionsFilename);
         PassThroughLineAggregator aggr = new PassThroughLineAggregator();
         flatFileItemWriter.setLineAggregator(aggr);
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
@@ -82,6 +86,8 @@ public class CVRFusionDataWriter implements ItemStreamWriter<String> {
 
     @Override
     public void update(ExecutionContext ec) throws ItemStreamException {
+        ec.put("fusionRecordsWritten", fusionRecordsWritten);
+        ec.put("fusionFile", stagingFile);
     }
 
     @Override
@@ -95,6 +101,7 @@ public class CVRFusionDataWriter implements ItemStreamWriter<String> {
         for (String item : items) {
             writeList.add(item);
         }
+        fusionRecordsWritten += writeList.size();
         flatFileItemWriter.write(writeList);
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelListener.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelListener.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.cmo.pipelines.cvr.genepanel;
+
+import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+
+import java.io.*;
+import java.util.*;
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class CVRGenePanelListener implements StepExecutionListener {
+
+    private static Logger log = Logger.getLogger(CVRGenePanelListener.class);
+
+    @Override
+    public void beforeStep(StepExecution se) {}
+
+    @Override
+    public ExitStatus afterStep(StepExecution se) {
+        File genePanelFile = (File) se.getExecutionContext().get("genePanelFile");
+        List<String> genePanels = (List<String>) se.getExecutionContext().get("genePanels");
+        int genePanelRecordsWritten = se.getExecutionContext().getInt("genePanelRecordsWritten");
+        if (genePanelRecordsWritten == 0) {
+            log.warn("No records written to '" + genePanelFile.getName() + " - removing file...");
+            genePanelFile.delete();
+        }
+        if (genePanels.size() == 1 && genePanels.get(0).equalsIgnoreCase(CVRUtilities.UNKNOWN_GENE_PANEL)) {
+            log.warn("All gene panels for this study are '" + CVRUtilities.UNKNOWN_GENE_PANEL + "' - removing file...");
+            genePanelFile.delete();
+        }
+        return ExitStatus.COMPLETED;
+    }
+
+}

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelReader.java
@@ -37,7 +37,6 @@ import org.cbioportal.cmo.pipelines.cvr.model.*;
 
 import java.io.*;
 import java.util.*;
-import java.util.logging.Level;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.cbioportal.cmo.pipelines.util.CVRUtils;
@@ -71,6 +70,7 @@ public class CVRGenePanelReader implements ItemStreamReader<CVRGenePanelRecord> 
     private List<CVRGenePanelRecord> genePanelRecords = new ArrayList();
     private Set<String> processedRecords = new HashSet();
     List<String> geneticProfiles;
+    private Set<String> genePanels = new HashSet<>();
 
     Logger log = Logger.getLogger(CVRGenePanelReader.class);
 
@@ -117,6 +117,7 @@ public class CVRGenePanelReader implements ItemStreamReader<CVRGenePanelRecord> 
                 while ((to_add = reader.read()) != null) {
                     if (!cvrSampleListUtil.getNewDmpSamples().contains(to_add.getSAMPLE_ID()) && to_add.getSAMPLE_ID() != null) {
                         genePanelRecords.add(to_add);
+                        genePanels.addAll(to_add.getPanelMap().values());
                     }
                 }
             }
@@ -130,11 +131,13 @@ public class CVRGenePanelReader implements ItemStreamReader<CVRGenePanelRecord> 
         for (CVRMergedResult result : cvrData.getResults()) {
             CVRGenePanelRecord record = new CVRGenePanelRecord(result.getMetaData(), geneticProfiles);
             genePanelRecords.add(record);
+            genePanels.addAll(record.getPanelMap().values());
         }
         // only try setting header and genetic profiles if gene panel records list is not empty
         if (!genePanelRecords.isEmpty()) {
             setGenePanelHeader(ec);
             ec.put("geneticProfiles", geneticProfiles);
+            ec.put("genePanels", new ArrayList<>(genePanels));
         }
     }
 

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelWriter.java
@@ -32,10 +32,11 @@
 
 package org.cbioportal.cmo.pipelines.cvr.genepanel;
 
+import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+
 import java.io.*;
 import java.util.*;
 import org.apache.commons.lang.StringUtils;
-import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
@@ -59,11 +60,13 @@ public class CVRGenePanelWriter implements ItemStreamWriter<String>{
     @Autowired
     public CVRUtilities cvrUtilities;
 
+    private int genePanelRecordsWritten;
+    private File stagingFile;
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
 
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
-        File stagingFile = new File(stagingDirectory, cvrUtilities.GENE_PANEL_FILE);
+        stagingFile = new File(stagingDirectory, cvrUtilities.GENE_PANEL_FILE);
         PassThroughLineAggregator aggr = new PassThroughLineAggregator();
         flatFileItemWriter.setLineAggregator(aggr);
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
@@ -78,6 +81,8 @@ public class CVRGenePanelWriter implements ItemStreamWriter<String>{
 
     @Override
     public void update(ExecutionContext ec) throws ItemStreamException {
+        ec.put("genePanelRecordsWritten", genePanelRecordsWritten);
+        ec.put("genePanelFile", stagingFile);
     }
 
     @Override
@@ -88,5 +93,6 @@ public class CVRGenePanelWriter implements ItemStreamWriter<String>{
     @Override
     public void write(List<? extends String> items) throws Exception {
         flatFileItemWriter.write(items);
+        genePanelRecordsWritten += items.size();
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataListener.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataListener.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.cmo.pipelines.cvr.mutation;
+
+import java.io.*;
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class CVRMutationDataListener implements StepExecutionListener {
+
+    private static Logger log = Logger.getLogger(CVRMutationDataListener.class);
+
+    @Override
+    public void beforeStep(StepExecution se) {}
+
+    @Override
+    public ExitStatus afterStep(StepExecution se) {
+        File mutationFile = (File) se.getExecutionContext().get("mutationFile");
+        int mutationRecordsWritten = se.getExecutionContext().getInt("mutationRecordsWritten");
+        if (mutationRecordsWritten == 0) {
+            log.warn("No records written to '" + mutationFile.getName() + " - removing file...");
+            mutationFile.delete();
+        }
+        return ExitStatus.COMPLETED;
+    }
+
+}

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/seg/CVRSegDataListener.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/seg/CVRSegDataListener.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.cmo.pipelines.cvr.seg;
+
+import java.io.*;
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class CVRSegDataListener implements StepExecutionListener {
+
+    private static Logger log = Logger.getLogger(CVRSegDataListener.class);
+
+    @Override
+    public void beforeStep(StepExecution se) {}
+
+    @Override
+    public ExitStatus afterStep(StepExecution se) {
+        File segFile = (File) se.getExecutionContext().get("segFile");
+        int segRecordsWritten = se.getExecutionContext().getInt("segRecordsWritten");
+        if (segRecordsWritten == 0) {
+            log.warn("No records written to '" + segFile.getName() + " - removing file...");
+            segFile.delete();
+        }
+        return ExitStatus.COMPLETED;
+    }
+
+}

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/sv/CVRSvDataListener.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/sv/CVRSvDataListener.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.cmo.pipelines.cvr.sv;
+
+import java.io.*;
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class CVRSvDataListener implements StepExecutionListener {
+
+    private static Logger log = Logger.getLogger(CVRSvDataListener.class);
+
+    @Override
+    public void beforeStep(StepExecution se) {}
+
+    @Override
+    public ExitStatus afterStep(StepExecution se) {
+        File svFile = (File) se.getExecutionContext().get("svFile");
+        int svRecordsWritten = se.getExecutionContext().getInt("svRecordsWritten");
+        if (svRecordsWritten == 0) {
+            log.warn("No records written to '" + svFile.getName() + " - removing file...");
+            svFile.delete();
+        }
+        return ExitStatus.COMPLETED;
+    }
+
+}


### PR DESCRIPTION
- Takes a raw JSON output from CVR web service (or provided file) and converts the data into cBio staging formats.

Removes files with no records written to them to prevent "bad" data files from getting checked in.

Adds a check to see whether gene panels from JSON are not all "UNKNOWN". If so then removes gene panel matrix file since there isn't any useful data in it.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>