### PR TITLE
Fix GML variant allele reads

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -326,10 +326,10 @@ public class CVRUtilities {
         String sequencer = "";
         String tumorSampleUUID = "";
         String matchedNormSampleUUID = "";
-        String tRefCount = "";
-        String nRefCount = String.valueOf(snp.getDepth() - snp.getAlleleDepth());
-        String tAltCount = "";
-        String nAltCount = String.valueOf(snp.getAlleleDepth());
+        String tRefCount = String.valueOf(snp.getDepth() - snp.getAlleleDepth());
+        String nRefCount = "";
+        String tAltCount = String.valueOf(snp.getAlleleDepth());
+        String nAltCount = "";
         String cDNA_Change = snp.getCDNAChange();
         String aminoAcidChange = snp.getAaChange();
         String transcript = snp.getTranscriptId();


### PR DESCRIPTION
- needs thorough testing to make sure we aren't duplicating germline evens in maf (i.e., same variant with the read counts in the wrong column + same variant with fixed columns)

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>