### PR TITLE
Added '-f' to xargs for removing untracked files in HG repo

### DIFF
--- a/import-scripts/datasource-repo-cleanup.sh
+++ b/import-scripts/datasource-repo-cleanup.sh
@@ -52,8 +52,8 @@ function cleanupMercurialRepository {
 
     MERCURIAL_REPOSITORY_PATH=$1
     cd $MERCURIAL_REPOSITORY_PATH
-    echo "hg status -un | xargs rm"
-    $HG_BINARY status -un | xargs rm ; return_value=$?
+    echo "hg status -un | xargs rm -f"
+    $HG_BINARY status -un | xargs rm -f ; return_value=$?
     $HG_BINARY update -C
     return $return_value
 }


### PR DESCRIPTION
If there are no untracked files to cleanup then  `$HG_BINARY status -un | xargs rm` exits with non-zero code. Adding `-f` to the command resolves the issue.


Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>