### PR TITLE
fix syntax for injecting value from step execution context

### DIFF
--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXTimelineProcessor.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXTimelineProcessor.java
@@ -47,7 +47,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 public class CRDBPDXTimelineProcessor implements ItemProcessor<CRDBPDXTimelineDataset, String> {
 
-    @Value("#stepExecutionContext['crdbPdxFieldOrder']")
+    @Value("#{stepExecutionContext['crdbPdxFieldOrder']}")
     private List<String> crdbPdxTimelineFieldOrder;
 
     @Autowired

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXTimelineWriter.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXTimelineWriter.java
@@ -57,7 +57,7 @@ public class CRDBPDXTimelineWriter implements ItemStreamWriter<String> {
     @Value("${crdb.pdx_timeline_dataset_filename}")
     private String pdxTimelineDatasetFilename;
 
-    @Value("#stepExecutionContext['crdbPdxFieldOrder']")
+    @Value("#{stepExecutionContext['crdbPdxFieldOrder']}")
     private List<String> crdbPdxTimelineFieldOrder;
 
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<String>();


### PR DESCRIPTION
#{ previously just read as a string (w/o injection) and breaking processor/writer } because of missing curly brackets