### PR TITLE
Set CRDBPipeline Exit Code According to Pipeline Success/Failure

### DIFF
--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/CRDBPipeline.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/CRDBPipeline.java
@@ -82,6 +82,10 @@ public class CRDBPipeline {
         JobExecution jobExecution = jobLauncher.run(crdbJob, jobParameters);
         System.out.println("Shutting down CRDBPipeline.");
         ctx.close();
+        if (!jobExecution.getExitStatus().equals(ExitStatus.COMPLETED)) {
+            System.out.println("CRDBPipeline job failed with exit status: " + jobExecution.getExitStatus().getExitCode());
+            System.exit(1);
+        }
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
check JobExecution exit status and set exit code accordingly
CRDB Pipeline will exit with return code 1 if pipeline fails (to set flags in import-scripts)