### PR TITLE
Auto-pull IMPACT data into PDX pipeline + Bug Fixes

### DIFF
--- a/import-scripts/add_clinical_records.py
+++ b/import-scripts/add_clinical_records.py
@@ -1,0 +1,114 @@
+import argparse
+import sys
+import csv
+import os
+import subprocess
+import re
+from clinicalfile_utils import *
+
+ERROR_FILE = sys.stderr
+OUTPUT_FILE = sys.stdout
+
+PATIENT_ID_KEY="PATIENT_ID"
+SAMPLE_ID_KEY="SAMPLE_ID"
+
+METADATA_PREFIX="#"
+
+# updates existing records with information from supplemental file
+# will add new records for those found in supplemental file but not in clinical file
+def expand_clinical_data(clinical_filename, supplemental_data_map, fields, patient_mode):
+    key = SAMPLE_ID_KEY
+    if patient_mode:
+        key = PATIENT_ID_KEY
+
+    clinical_file_header = get_header(clinical_filename)
+    # loop through fields specified by user and add to existing header
+    for supplemental_header_field in fields:
+        if supplemental_header_field in supplemental_data_map.values()[0].keys() and supplemental_header_field not in clinical_file_header:
+	    clinical_file_header.append(supplemental_header_field)
+    output_data = ['\t'.join(clinical_file_header)]
+
+    original_header = get_header(clinical_filename)
+    clinical_file = open(clinical_filename, 'rU')
+    data_reader = [line for line in clinical_file.readlines() if not line.startswith(METADATA_PREFIX)]
+    for line in data_reader[1:]:
+        line = dict(zip(original_header, map(str.strip, line.split('\t'))))
+        # load data from clinical_filename and write data to output directory
+        # updates existing record with corresponding record from supplemental data
+        # removes corresponding record from supplemtnal data
+        line.update(supplemental_data_map.get(line[key].strip(), {}))
+        supplemental_data_map.pop(line[key], None)
+        data = map(lambda v: line.get(v,''), clinical_file_header)
+        output_data.append('\t'.join(data))
+    clinical_file.close()
+
+    # add new records (everything in supplemental file) - existing records were removed in previous step
+    for record in supplemental_data_map.values():
+        data = map(lambda v: record.get(v,''), clinical_file_header)
+        output_data.append('\t'.join(data))
+
+    # write data to output file
+    output_file = open(clinical_filename, 'w')
+    output_file.write('\n'.join(output_data))
+    output_file.close()
+
+# loads data from supplemental clinical file into a dictionary
+# keys are SAMPLE_ID/PATIENT_ID depending on mode its run i.e PATIENT v SAMPLE ID as primary key
+def load_supplemental_clinical_data(supplemental_clinical_filename, fields, patient_mode):
+    supplemental_data_dictionary = {}
+    key = SAMPLE_ID_KEY
+    if patient_mode:
+        key = PATIENT_ID_KEY
+    header = get_header(supplemental_clinical_filename)
+    if not all([True if field in header else False for field in fields]):
+        print "Specified fields could not be found in supplemental file, aborting..."
+        exit(1)
+    supplemental_clinical_file = open(supplemental_clinical_filename, 'rU')
+    data_reader = [line for line in supplemental_clinical_file.readlines() if not line.startswith('#')]
+    for line in data_reader[1:]:
+	line = dict(zip(header, map(str.strip, line.split('\t'))))
+	supplemental_data_dictionary[line[key].strip()] = dict({(k,v) for k,v in line.items() if k in fields})
+    supplemental_clinical_file.close()
+    return supplemental_data_dictionary
+
+def generate_add_metadata_header_call(clinical_file, lib):
+    add_metadata_header_call = 'python ' + lib + '/add_clinical_attribute_metadata_headers.py -f ' + clinical_file
+    return add_metadata_header_call
+
+def add_metadata_header(clinical_file, lib):
+    add_metadata_headers_call = generate_add_metadata_header_call(clinical_file, lib)
+    add_metadata_headers_status = subprocess.call(add_metadata_headers_call, shell = True)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--clinical-file", help = "file to be altered", required = True)
+    parser.add_argument("-s", "--supplemental-file", help = "source for supplemental data", required = True)
+    parser.add_argument("-p", "--patient-mode", help = "patient mode if clinical files have patient as unique identifiers", action = "store_true")
+    parser.add_argument("-f", "--fields", help = "fields to be added to clinical-file")
+    parser.add_argument("-l", "--lib", help = "directory with data curation tools", required = True)
+    args = parser.parse_args()
+
+    clinical_file = args.clinical_file
+    supplemental_file = args.supplemental_file
+    patient_mode = args.patient_mode
+    fields = args.fields.split(",")
+    lib = args.lib
+
+    if not os.path.isfile(clinical_file):
+        print "clinical-file, " + clinical_file + " cannot be found, aborting..."
+        exit(1)
+    if not os.path.isfile(supplemental_file):
+        print "supplemental-file, " + supplemental_file + " cannot be found, aborting..."
+        exit(1)
+    if not os.path.isdir(lib):
+        print "scripts directory, " + lib + " cannot be found, aborting..."
+        exit(1)
+
+    # load supplemental data from the clinical supp file
+    supplemental_data_map = load_supplemental_clinical_data(supplemental_file, fields, patient_mode)
+    expand_clinical_data(clinical_file, supplemental_data_map, fields, patient_mode)
+    # re-add metadata headers - must be called seperately since new fields might also be added
+    add_metadata_header(clinical_file, lib)
+
+if __name__ == '__main__':
+	main()

--- a/import-scripts/merge.py
+++ b/import-scripts/merge.py
@@ -358,10 +358,16 @@ def data_okay_to_add(is_clinical_or_timeline_file, file_header, reference_set, d
             # want to explicitly check if sample in reference set if SAMPLE_ID in header
             # to avoid filtering out samples with clin attr's that may contain other patient/sample IDs
             # that may be linked to the current sample but we do not want to filter out of the final dataset
-            #
+            # 
+            # default behavior will use sample-id to evaluate timeline records
+            # in the case of a patient-based timeline record (null sample id) --
+            # timeline record will be included as long as patient exists in the output set
+            # 
             # Ex: OTHER_SAMPLE_ID/OTHER_PATIENT_ID, or similar attr's like RNA_ID, METHYLATION_ID
             #     which indicate what other sample IDs are linked to current sample record
             sample_id = data_values[file_header.index('SAMPLE_ID')]
+            if not sample_id:
+                return patient_id in PATIENT_SAMPLE_MAP.keys()
             found = (sample_id in reference_set)
     elif len([True for val in data_values if val in reference_set]) > 0:
         found = True

--- a/import-scripts/subset-and-merge-crdb-pdx-studies.py
+++ b/import-scripts/subset-and-merge-crdb-pdx-studies.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 import sys
+from clinicalfile_utils import *
 
 PATIENT_ID_KEY = "PATIENT_ID"
 SOURCE_STUDY_ID_KEY = "SOURCE_STUDY_ID"
@@ -191,6 +192,11 @@ def generate_merge_call(lib, cancer_study_id, destination_directory, subdirector
     merge_call = 'python ' + lib + '/merge.py -d ' + destination_directory + ' -i ' + cancer_study_id + ' -m "true" ' + subdirectory_list
     return merge_call
 
+# used in sample-mode because data_clinical_sample.txt is being extended - sample id should be used as primary key for each record
+def generate_add_clinical_records_call(lib, destination_directory, impact_source_subdirectory):
+    add_clinical_records_call = 'python ' + lib + '/add_clinical_records.py -c ' + destination_directory + '/data_clinical_sample.txt -s ' + impact_source_subdirectory + '/data_clinical_sample.txt -f "PATIENT_ID,SAMPLE_ID,ONCOTREE_CODE" -l' + lib
+    return add_clinical_records_call
+
 # generates files containing sample-ids linked to specified patient-ids (by destination-source)
 # placed in corresponding directories - multiple source per destination
 # i.e (/home/destination_study/source_1/subset_list, home/destination_study/source_2/subset_list)
@@ -229,6 +235,7 @@ def subset_genomic_files(destination_to_source_mapping, source_id_to_path_mappin
                 # studies which cannot be subsetted are marked to be skipped when mergin
                 if subset_genomic_files_status != 0:
                     SKIPPED_SOURCE_STUDIES[destination].add(source)
+                    shutil.rmtree(destination_directory)
             else:
                 print "Error, source path for " + source + " could not be found, skipping..."
 
@@ -246,9 +253,47 @@ def merge_genomic_files(destination_to_source_mapping, root_directory, lib):
         merge_source_subdirectories_status = subprocess.call(merge_source_subdirectories_call, shell = True)
         if merge_source_subdirectories_status == 0:
             DESTINATION_STUDY_STATUS_FLAGS[destination][MERGE_GENOMIC_FILES_SUCCESS] = True
+
+# needed because IMPACT study is being automatically pulled in and need to be added to the existing data_clinical_sample.txt
+# data_clinical_sample.txt per destination study  is originally subsetted from CRDB-PDX fetched file and does not contain IMPACT samples
+# unmapped IMPACT samples are not mapped to their patients/shown as seperate patients in the portal
+def add_patient_sample_records(destination_to_source_mapping, root_directory, lib):
+    for destination in destination_to_source_mapping:
+        destination_directory = os.path.join(root_directory, destination)
+        impact_source_subdirectory = os.path.join(root_directory, destination, IMPACT_STUDY_ID)
+        add_clinical_records_call = generate_add_clinical_records_call(lib, destination_directory, impact_source_subdirectory)
+        add_clinical_records_status = subprocess.call(add_clinical_records_call, shell = True)
+       
+def remove_source_subdirectories(destination_to_source_mapping, root_directory):
+    for destination, source_to_patients_map in destination_to_source_mapping.items():
+        source_subdirectories = [os.path.join(root_directory, destination, source) for source in source_to_patients_map if source not in SKIPPED_SOURCE_STUDIES[destination]]
         for source_subdirectory in source_subdirectories:
             shutil.rmtree(source_subdirectory)
 
+# needed because CMO studies are unannotated but IMPACT studies are
+# a merge of CMO + IMPACT studies results in a partially annotated MAF
+# (IMPACT study is pulled in whenever patient-ids are DMP ids)
+# annotator assumes MAF is annotated because HGVSp_short column is present - CMO samples never annotated
+def remove_hgvsp_short_column(destination_to_source_mapping, root_directory):
+    for destination in destination_to_source_mapping:
+        destination_directory = os.path.join(root_directory, destination)
+        maf = os.path.join(destination_directory, "data_mutations_extended.txt")
+        if "HGVSp_Short" in get_header(maf):
+            hgvsp_short_index = get_header(maf).index("HGVSp_Short")
+            maf_to_write = []
+            maf_file = open(maf, "rU")
+            for line in maf_file:
+                if line.startswith("#"):
+                    maf_to_write.append(line.rstrip("\n"))
+                else:
+                    record = line.rstrip("\n").split('\t')
+                    maf_to_write.append('\t'.join(record[0:hgvsp_short_index] + record[hgvsp_short_index + 1:]))
+            maf_file.close()
+
+            new_file = open(maf, "w")
+            new_file.write('\n'.join(maf_to_write))
+            new_file.close()
+ 
 def remove_merged_clinical_timeline_files(destination_to_source_mapping, root_directory):
     for destination in destination_to_source_mapping:
         destination_directory = os.path.join(root_directory, destination)
@@ -386,6 +431,9 @@ def main():
     merge_genomic_files(destination_to_source_mapping, root_directory, lib)
     remove_merged_clinical_timeline_files(destination_to_source_mapping, root_directory)
     subset_clinical_timeline_files(destination_to_source_mapping, source_id_to_path_mapping, root_directory, crdb_fetch_directory, lib)
+    add_patient_sample_records(destination_to_source_mapping, root_directory, lib)
+    remove_source_subdirectories(destination_to_source_mapping, root_directory)
+    remove_hgvsp_short_column(destination_to_source_mapping, root_directory)
     filter_temp_subset_files(destination_to_source_mapping, root_directory)
     get_all_destination_to_missing_metafiles_mapping(destination_to_source_mapping, root_directory)
     generate_import_trigger_files(destination_to_source_mapping, temp_directory)


### PR DESCRIPTION
Impact data is automatically pulled in. 
Fixes for missed annotations due to partially annotated MAFs (annotated IMPACT merged with unannotated CMO)
Fixes for missing samples in portal frontend (add records to clinical_sample file)

Updated version of #460 