### PR TITLE
Bug fix: resolve whole slide viewer url

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRClinicalRecord.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRClinicalRecord.java
@@ -32,6 +32,7 @@
 
 package org.cbioportal.cmo.pipelines.cvr.model;
 
+import com.mysql.jdbc.StringUtils;
 import java.util.*;
 
 /**
@@ -71,7 +72,7 @@ public class CVRClinicalRecord {
 
     private final String DEFAULT_SAMPLE_CLASS = "Tumor";
 
-    public CVRClinicalRecord(CVRMetaData metaData) {
+    public CVRClinicalRecord(CVRMetaData metaData, String wholeSlideViewerBaseURL) {
         this.sampleId = metaData.getDmpSampleId();
         this.patientId = metaData.getDmpPatientId();
         this.cancerType = metaData.getTumorTypeName();
@@ -99,7 +100,7 @@ public class CVRClinicalRecord {
         this.cvrTmbCohortPercentile = (metaData.getTmbCohortPercentile()!= null) ? String.valueOf(metaData.getTmbCohortPercentile()) : "NA";
         this.cvrTmbScore = (metaData.getTmbScore()!= null) ? String.valueOf(metaData.getTmbScore()) : "NA";
         this.cvrTmbTtPercentile = (metaData.getTmbTtPercentile()!= null) ? String.valueOf(metaData.getTmbTtPercentile()) : "NA";
-        this.wholeSlideViewerURL = metaData.getWholeSlideViewerURL();
+        this.wholeSlideViewerURL = resolveWholeSlideViewerURL(wholeSlideViewerBaseURL, metaData.getWholeSlideViewerId());
     }
 
     public CVRClinicalRecord(GMLMetaData metaData) {
@@ -361,6 +362,13 @@ public class CVRClinicalRecord {
             return isMetastasis == 0 ? "Primary" : "Metastasis";
         return "";
 
+    }
+
+    private String resolveWholeSlideViewerURL(String wholeSlideViewerBaseURL, String wholeSlideViewerId) {
+        if (!StringUtils.isNullOrEmpty(wholeSlideViewerId)) {
+            return wholeSlideViewerBaseURL.replace("IMAGE_ID", wholeSlideViewerId);
+        }
+        return "";
     }
 
     public static List<String> getFieldNames() {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRMetaData.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/CVRMetaData.java
@@ -164,9 +164,6 @@ public class CVRMetaData {
     private String wholeSlideViewerId;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
-    @JsonIgnore
-    @Value("${comppath.wsv.baseurl}")
-    private String wholeSlideViewerBaseURL;
 
     /**
     * No args constructor for use in serialization
@@ -973,18 +970,6 @@ public class CVRMetaData {
     @JsonProperty("slide-viewer-id")
     public void setWholeSlideViewerId(String wholeSlideViewerId) {
         this.wholeSlideViewerId = wholeSlideViewerId;
-    }
-
-    /**
-     *
-     * @return
-     * The wholeSlideViewerURL
-     */
-    public String getWholeSlideViewerURL() {
-        if (!StringUtils.isNullOrEmpty(wholeSlideViewerId)) {
-            return wholeSlideViewerBaseURL.replace("IMAGE_ID", wholeSlideViewerId);
-        }
-        return "";
     }
 
     @JsonAnyGetter


### PR DESCRIPTION
`CVRMetaData` is not a spring managed component so whole slide viewer URL cannot be autowired with `@Value`. Property now autowired in `CVRClinicalDataReader` and passed to `CVRClinicalRecord` constructor.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>