### PR TITLE
fix emails from import-portal-users.sh

### DIFF
--- a/import-scripts/import-portal-users.sh
+++ b/import-scripts/import-portal-users.sh
@@ -23,5 +23,7 @@ echo "### Starting import" >> "$CANCERSTUDIESLOGFILENAME"
 date >> "$CANCERSTUDIESLOGFILENAME"
 $PYTHON_BINARY $PORTAL_HOME/scripts/updateCancerStudies.py --secrets-file $PORTAL_DATA_HOME/portal-configuration/google-docs/client_secrets.json --creds-file $PORTAL_DATA_HOME/portal-configuration/google-docs/creds.dat --properties-file $PORTAL_HOME/cbio-portal-data/portal-configuration/properties/import-users/portal.properties.dashi.gdac --send-email-confirm true >> "$CANCERSTUDIESLOGFILENAME" 2>&1
 
-restartMSKTomcats
-restartSchultzTomcats
+restartMSKTomcats > /dev/null 2>&1
+restartSchultzTomcats > /dev/null 2>&1
+
+exit 0


### PR DESCRIPTION
- prevent stdout or stderr reports from tomcat restart functions

we are getting daily cron user emails from the import-portal-users.sh script because all stdout or stderr content from crontab commands is automatically emailed to the MAILTO contact in crontab, and this script was generating logging lines to stdout such as: 
Requesting redeployment of msk portal war...
Sat Dec 22 10:01:20 EST 2018
Requesting redeployment of schultz portal war...
Sat Dec 22 10:01:20 EST 2018

Because the import-portal-users.sh script does not detect or branch based on failure of the restart functions, and because the restart functions themselves send emails on failure to restart (see dmp-import-vars-functions.sh), the output streams from the function calls are redirected to /dev/null.