### PR TITLE
define global variable used in dmp fetch script

### DIFF
--- a/import-scripts/dmp-import-vars-functions.sh
+++ b/import-scripts/dmp-import-vars-functions.sh
@@ -4,6 +4,7 @@
 
 ONCOTREE_VERSION_TO_USE=oncotree_candidate_release
 CVR_TEST_MODE_ARGS=""
+PERFORM_CRDB_FETCH=0
 CRDB_FETCHER_JAR_FILENAME="$PORTAL_HOME/lib/crdb_fetcher.jar"
 CVR_FETCHER_JAR_FILENAME="$PORTAL_HOME/lib/cvr_fetcher.jar"
 DARWIN_FETCHER_JAR_FILENAME="$PORTAL_HOME/lib/darwin_fetcher.jar"


### PR DESCRIPTION
This will reduce error logging in the dmp import scripts such as:
/data/portal-cron/scripts/fetch-dmp-data-for-import.sh: line 554: [: -gt: unary operator expected