### PR TITLE
changes to CVR AGE_AT_SEQ_REPORT and darwin AGE

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -418,12 +418,10 @@ public class CVRUtilities {
                 Double diffYears = (referenceCalculationDate.getTime() - cvrDateSequenced.getTime()) / 1000L / 60L / 60L / 24L / 365.2422;
                 Double ageAtSeqReport = Math.ceil(Integer.parseInt(patientAge) - diffYears);
                 if (ageAtSeqReport > 90) {
-                    ageAtSeqReport = 90D;
+                    record.setAGE_AT_SEQ_REPORT(">90");
+                } else {
+                    record.setAGE_AT_SEQ_REPORT(String.valueOf(ageAtSeqReport.intValue()));
                 }
-                if (ageAtSeqReport < 15) {
-                    ageAtSeqReport = 15D;
-                }
-                record.setAGE_AT_SEQ_REPORT(String.valueOf(ageAtSeqReport.intValue()));
             }
             else {
                 record.setAGE_AT_SEQ_REPORT("NA");

--- a/cvr/src/test/java/org/cbioportal/cmo/pipelines/cvr/CalculateAgeAtSeqReportForPatientTest.java
+++ b/cvr/src/test/java/org/cbioportal/cmo/pipelines/cvr/CalculateAgeAtSeqReportForPatientTest.java
@@ -135,8 +135,8 @@ public class CalculateAgeAtSeqReportForPatientTest {
 
     private Map<String, String> makeMockYearOldFileExpectedAge() {
         Map<String, String> map = new HashMap<>();
-        map.put("P-0000001-T01-IM5", "90");
-        map.put("P-0000002-T01-IM5", "15");
+        map.put("P-0000001-T01-IM5", ">90");
+        map.put("P-0000002-T01-IM5", "10");
         map.put("P-0000003-T01-IM5", "44");
         map.put("P-0000003-T02-IM5", "45");
         map.put("P-0000005-T01-IM5", "NA");
@@ -145,8 +145,8 @@ public class CalculateAgeAtSeqReportForPatientTest {
 
     private Map<String, String> makeMockCurrentFileExpectedAge() {
         Map<String, String> map = new HashMap<>();
-        map.put("P-0000001-T01-IM5", "90");
-        map.put("P-0000002-T01-IM5", "15");
+        map.put("P-0000001-T01-IM5", ">90");
+        map.put("P-0000002-T01-IM5", "10");
         map.put("P-0000003-T01-IM5", "43");
         map.put("P-0000003-T02-IM5", "44");
         map.put("P-0000005-T01-IM5", "NA");

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientDemographics.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientDemographics.java
@@ -304,21 +304,15 @@ public class MskimpactPatientDemographics {
             if(this.PT_DEATH_YEAR>-1){
                 Integer i = this.PT_DEATH_YEAR-this.PT_BIRTH_YEAR;
                 //Age > 90 is considered identifying
-                if (i >= 90){
-                    return "90";
-                }
-                else if (i <= 18) {
-                    return "18";
+                if (i > 90){
+                    return ">90";
                 }
                 return i.toString();
             }
             Integer i = currentYear-this.PT_BIRTH_YEAR;
             //Age > 90 is considered identifying
-            if (i >= 90) {
-                return "90";
-            }
-            else if (i <= 18) {
-                return "18";
+            if (i > 90) {
+                return ">90";
             }
             return i.toString();
         }


### PR DESCRIPTION
In these cases, calculated ages >90 will be displayed as ">90" instead of "90"
calculated ages < 18 or < 15 will still be displayed