### PR TITLE
Start supporting ARCHER gene matrix import

### DIFF
--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -446,8 +446,6 @@ if [ $IMPORT_STATUS_ARCHER -eq 0 ] ; then
             IMPORT_STATUS_ARCHER=1
         else
             FETCH_CVR_ARCHER_FAIL=0
-            # renaming gene matrix file until we get the mskarcher gene panel imported
-            cd $MSK_ARCHER_UNFILTERED_DATA_HOME ; mv data_gene_matrix.txt ignore_data_gene_matrix.txt
             cd $MSK_ARCHER_UNFILTERED_DATA_HOME ; $HG_BINARY commit -m "Latest ARCHER_UNFILTERED dataset"
         fi
     fi


### PR DESCRIPTION
We can stop ignoring the `data_gene_matrix.txt` from the ARCHER CVR run now that the ARCHER gene panels are available and imported into the databases.

The corresponding `meta_gene_matrix.txt` was added to the ARCHER study directory in mercurial.
Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>