### PR TITLE
Update import-genie-data.sh

### DIFF
--- a/import-scripts/import-genie-data.sh
+++ b/import-scripts/import-genie-data.sh
@@ -12,7 +12,7 @@ IMPORTER_JAR_FILENAME="$PORTAL_HOME/lib/genie-importer.jar"
 JAVA_DEBUG_ARGS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27186"
 JAVA_IMPORTER_ARGS="$JAVA_PROXY_ARGS $JAVA_DEBUG_ARGS -Dspring.profiles.active=dbcp -Djava.io.tmpdir=$tmp -ea -cp $IMPORTER_JAR_FILENAME org.mskcc.cbio.importer.Admin"
 genie_portal_notification_file=$(mktemp $tmp/genie-portal-update-notification.$now.XXXXXX)
-ONCOTREE_VERSION_TO_USE=oncotree_latest_stable
+ONCOTREE_VERSION_TO_USE=oncotree_2018_06_01
 
 # refresh cdd and oncotree cache
 CDD_ONCOTREE_RECACHE_FAIL=0


### PR DESCRIPTION
genie-6.1 import will require the oncotree_2018_06_01 version