### PR TITLE
Override 'Tumor_Seq_Allele1' with 'Reference_Allele' value

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataProcessor.java
@@ -52,10 +52,18 @@ public class CVRMutationDataProcessor implements ItemProcessor<AnnotatedRecord, 
     @Autowired
     private CVRUtils cvrUtils;
 
+    private final String REFERENCE_ALLELE_COLUMN = "REFERENCE_ALLELE";
+    private final String TUMOR_SEQ_ALLELE1_COLUMN = "TUMOR_SEQ_ALLELE1";
+
     @Override
     public String process(AnnotatedRecord i) throws Exception {
         List<String> record = new ArrayList<>();
         for (String field : header) {
+            // always override 'Tumor_Seq_Allele1' with value of 'Reference_Allele'
+            // these fields should always match for our internal datasets
+            if (field.equalsIgnoreCase(TUMOR_SEQ_ALLELE1_COLUMN)) {
+                field = REFERENCE_ALLELE_COLUMN;
+            }
             try {
                 record.add(cvrUtils.convertWhitespace(i.getClass().getMethod("get" + field.toUpperCase()).invoke(i).toString()));
             } catch (Exception e) {


### PR DESCRIPTION
`Reference_Allele` and `Tumor_Seq_Allele1` should always match for our internal datasets. 

When a `DEL` variant is submitted to GN for annotation, GN may adjust the coordinates in cases such as the following where the alt allele provided starts with a substring of the ref allele provided.


|        source       | chr |  start  |   end   | ref  | tum1 | tum2 |
| ------------------- | --- | ------- | ------- | ---- | ---- | ---- |
| CVR SNP record      | 17  | 7578268 |   --    | AGAT |  --  | A    |
| Parsed MAF record   | 17  | 7578268 | 7578271 | AGAT | AGAT | A    |
| GN Annotated record | 17  | 7578269 | 7578271 | GAT  | AGAT | -    |

Due to a previous issue with GN annotator, we had decided to not modify the value of `Tumor_Seq_Allele1` for ALL variants annotated by GN. The annotator was initially making `Reference_Allele` and `Tumor_Seq_Allele1` match automatically since this is what we were doing for the MSKIMPACT studies. However, in many data sets, `Tumor_Seq_Allele1` is meant to be a distinct value from `Reference_Allele` and therefore the annotator no longer automatically makes `Tumor_Seq_Allele1` match whatever value is in `Reference_Allele`. Instead, the annotator leaves `Tumor_Seq_Allele1` alone and does not modify it in any way.


This explains _why_  our MSKIMPACT `DEL` variant annotations are being returned with mismatching `Reference_Allele` and `Tumor_Seq_Allele1`. This bug fix ensures that we are always using the value in `Reference_Allele` for the `Tumor_Seq_Allele1` field. 


Additional work required for this to be fully resolved will be make `Reference_Allele` and `Tumor_Seq_Allele1` values match in RAINDANCE, IMPACT, and HEMEPACT regular MAFs and unfiltered MAFs. The affiliate and subset cohort MAFs will resolve themselves since  they are regenerated daily.




Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>