### PR TITLE
Keep tmp directory contents for debugging

### DIFF
--- a/import-scripts/import-cmo-data-msk.sh
+++ b/import-scripts/import-cmo-data-msk.sh
@@ -101,9 +101,6 @@ echo "Cleaning up any untracked files from MSK-CMO import..."
 bash $PORTAL_HOME/scripts/datasource-repo-cleanup.sh $PORTAL_DATA_HOME $PORTAL_DATA_HOME/bic-mskcc $PORTAL_DATA_HOME/private
 
 $JAVA_BINARY $JAVA_IMPORTER_ARGS --send-update-notification --portal msk-automation-portal --notification-file "$msk_automation_notification_file"
-if [[ -d "$tmp" && "$tmp" != "/" ]]; then
-    rm -rf "$tmp"/*
-fi
 
 echo "### Starting import" >> "$CANCERSTUDIESLOGFILENAME"
 date >> "$CANCERSTUDIESLOGFILENAME"

--- a/import-scripts/import-cmo-data-triage.sh
+++ b/import-scripts/import-cmo-data-triage.sh
@@ -183,7 +183,3 @@ fi
 
 echo "Cleaning up any untracked files from MSK-TRIAGE import..."
 bash $PORTAL_HOME/scripts/datasource-repo-cleanup.sh $PORTAL_DATA_HOME $PORTAL_DATA_HOME/bic-mskcc $PORTAL_DATA_HOME/private $PORTAL_DATA_HOME/genie $PORTAL_DATA_HOME/impact $PORTAL_DATA_HOME/immunotherapy $PORTAL_DATA_HOME/datahub
-
-if [[ -d "$tmp" && "$tmp" != "/" ]]; then
-    rm -rf "$tmp"/*
-fi

--- a/import-scripts/import-genie-data.sh
+++ b/import-scripts/import-genie-data.sh
@@ -99,7 +99,3 @@ $JAVA_BINARY $JAVA_IMPORTER_ARGS --send-update-notification --portal genie-porta
 
 echo "Cleaning up any untracked files from MSK-TRIAGE import..."
 bash $PORTAL_HOME/scripts/datasource-repo-cleanup.sh $PORTAL_DATA_HOME/genie
-
-if [[ -d "$tmp" && "$tmp" != "/" ]]; then
-    rm -rf "$tmp"/*
-fi

--- a/import-scripts/import-public-aws-data.sh
+++ b/import-scripts/import-public-aws-data.sh
@@ -136,7 +136,3 @@ $JAVA_BINARY $JAVA_IMPORTER_ARGS --send-update-notification --portal public-aws-
 
 echo "Cleaning up any untracked files from CBIO-PUBLIC AWS import..."
 bash $PORTAL_HOME/scripts/datasource-repo-cleanup.sh $PORTAL_DATA_HOME $PORTAL_DATA_HOME/impact $PORTAL_DATA_HOME/private $PORTAL_DATA_HOME/datahub
-
-if [[ -d "$tmp" && "$tmp" != "/" ]]; then
-    rm -rf "$tmp"/*
-fi


### PR DESCRIPTION
Removed delete statements at end of import scripts to facilitate debugging import issues related to temp files generated. 

The contents in `tmp` directories will remain until the next time the script executes.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>