### PR TITLE
Check exit status after temp study import

### DIFF
--- a/import-scripts/import-temp-study.sh
+++ b/import-scripts/import-temp-study.sh
@@ -147,7 +147,7 @@ $JAVA_BINARY -Xmx64g $JAVA_IMPORTER_ARGS --update-study-data --portal $PORTAL_NA
 # we do not have to check the exit status here because if num_studies_updated != 1 we consider the import to have failed (we check num_studies_updated next)
 
 # check number of studies updated before continuing
-if [ -f "$TMP_DIRECTORY/num_studies_updated.txt" ]; then
+if [[ $? -eq 0 && -f "$TMP_DIRECTORY/num_studies_updated.txt" ]]; then
     num_studies_updated=`cat $TMP_DIRECTORY/num_studies_updated.txt`
 else
     num_studies_updated=0


### PR DESCRIPTION
If the temp study import fails during the `--update-study-data` step but the `num_studies_updated.txt` exists (from the previous temp study's import), then the script will mistakenly believe that the current temp study succeeded import and proceed with validation where it will fail due to not being able to find the temp study in the database. 

This change helps ensure that the `num_studies_updated.txt` file is from the current _successful_ temp study import attempt.


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>