### PR TITLE
Fixed how sample and patient ids are processed into clinical files

### DIFF
--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalReader.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalReader.java
@@ -233,7 +233,7 @@ public class Skcm_mskcc_2015_chantClinicalReader implements ItemStreamReader<Skc
         try {
             for (String field : combined.getAllVariables()) {
                     Method fieldGetter = combined.getClass().getMethod("get" + field);
-                    List<String> values = new ArrayList();
+                    Set<String> values = new HashSet<>();
                     values.add((String) fieldGetter.invoke(record1));
                     values.add((String) fieldGetter.invoke(record2));
                     combined.getClass().getMethod("set" + field, String.class).invoke(combined, StringUtils.join(values, "|"));

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalSampleProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalSampleProcessor.java
@@ -56,8 +56,8 @@ public class Skcm_mskcc_2015_chantClinicalSampleProcessor implements ItemProcess
     public Skcm_mskcc_2015_chantClinicalCompositeRecord process(final Skcm_mskcc_2015_chantNormalizedClinicalRecord melanomaClinicalRecord) throws Exception {
         List<String> record = new ArrayList<>();
         // first add sample and patient id to record then iterate through rest of sample header
-        record.add(darwinUtils.convertWhitespace(melanomaClinicalRecord.getSAMPLE_ID()).split("\\|")[0]);
-        record.add(darwinUtils.convertWhitespace(melanomaClinicalRecord.getPATIENT_ID()).split("\\|")[0]);
+        record.add(darwinUtils.convertWhitespace(melanomaClinicalRecord.getSAMPLE_ID().split("\\|")[0]));
+        record.add(darwinUtils.convertWhitespace(melanomaClinicalRecord.getPATIENT_ID().split("\\|")[0]));
         for (int i=0; i<sampleHeader.get("header").size(); i++) {
             String normColumn = sampleHeader.get("header").get(i);
             if (normColumn.equals("PATIENT_ID") || normColumn.equals("SAMPLE_ID")) {


### PR DESCRIPTION
sample and patient ids were not being processed correctly.

The output file would result in something like:

| SAMPLE_ID | PATIENT_ID |
|-|-|
|sample1 sample1 sample1 | patient1|
|sample2 sample2 | patient2 patient2|

etc. 

It looks like the  `.split("\\|")[0]` call was simply put in the wrong place when processing the clinical data. 

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>