### PR TITLE
import scripts can skip topbraid recaching

### DIFF
--- a/import-scripts/automation-environment.sh
+++ b/import-scripts/automation-environment.sh
@@ -10,9 +10,9 @@ export JAVA_PROXY_ARGS="-Dhttp.proxyHost=jxi2.mskcc.org -Dhttp.proxyPort=8080 -D
 export JAVA_BINARY=$JAVA_HOME/bin/java
 export PYTHON_BINARY=/data/tools/python2.7/bin/python
 export PYTHON3_BINARY=/data/tools/python3.4.10/bin/python3
-export MAVEN_BINARY=/data/portal-cron/bin/mvn
+export MAVEN_BINARY=/data/tools/mvn
 export HG_BINARY=/usr/bin/hg
-export PATH=/data/tools:/data/tools/python2.7/bin:/data/tools/python3.4.10/bin:/home/grossb/local/bin:$PATH
+export PATH=/data/tools:/data/tools/python2.7/bin:/data/tools/python3.4.10/bin:$PATH
 
 #######################
 # environment variables for top-level data repositories / code bases
@@ -50,6 +50,12 @@ export DMP_DATA_HOME=$PORTAL_DATA_HOME/dmp
 export FOUNDATION_DATA_HOME=$PORTAL_DATA_HOME/foundation
 export IMPACT_DATA_HOME=$PORTAL_DATA_HOME/impact
 export DATAHUB_DATA_HOME=$PORTAL_DATA_HOME/datahub/public
+
+#######################
+# environment variables used across import scripts
+#######################
+#export INHIBIT_RECACHING_FROM_TOPBRAID=true
+
 #######################
 # environment variables used in the fetch-and-import-dmp-impact-data script
 #######################

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -70,29 +70,32 @@ if [ -z $JAVA_BINARY ] | [ -z $HG_BINARY ] | [ -z $PORTAL_HOME ] | [ -z $MSK_IMP
     exit 2
 fi
 
-# refresh cdd and oncotree cache - by default this script will attempt to
-# refresh the CDD and ONCOTREE cache but we should check both exit codes
-# independently because of the various dependencies we have for both services
-CDD_RECACHE_FAIL=0; ONCOTREE_RECACHE_FAIL=0
-bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh --cdd-only
-if [ $? -gt 0 ]; then
-    message="Failed to refresh CDD cache!"
-    echo $message
-    echo -e "$message" | mail -s "CDD cache failed to refresh" $email_list
-    sendPreImportFailureMessageMskPipelineLogsSlack "$message"
-    CDD_RECACHE_FAIL=1
-fi
-bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh --oncotree-only
-if [ $? -gt 0 ]; then
-    message="Failed to refresh ONCOTREE cache!"
-    echo $message
-    echo -e "$message" | mail -s "ONCOTREE cache failed to refresh" $email_list
-    sendPreImportFailureMessageMskPipelineLogsSlack "$message"
-    ONCOTREE_RECACHE_FAIL=1
-fi
-if [[ $CDD_RECACHE_FAIL -gt 0 || $ONCOTREE_RECACHE_FAIL -gt 0 ]] ; then
-    echo "Oncotree and/or CDD recache failed! Exiting..."
-    exit 2
+if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
+    # refresh cdd and oncotree cache - by default this script will attempt to
+    # refresh the CDD and ONCOTREE cache but we should check both exit codes
+    # independently because of the various dependencies we have for both services
+    CDD_RECACHE_FAIL=0;
+    ONCOTREE_RECACHE_FAIL=0
+    bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh --cdd-only
+    if [ $? -gt 0 ]; then
+        message="Failed to refresh CDD cache!"
+        echo $message
+        echo -e "$message" | mail -s "CDD cache failed to refresh" $email_list
+        sendPreImportFailureMessageMskPipelineLogsSlack "$message"
+        CDD_RECACHE_FAIL=1
+    fi
+    bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh --oncotree-only
+    if [ $? -gt 0 ]; then
+        message="Failed to refresh ONCOTREE cache!"
+        echo $message
+        echo -e "$message" | mail -s "ONCOTREE cache failed to refresh" $email_list
+        sendPreImportFailureMessageMskPipelineLogsSlack "$message"
+        ONCOTREE_RECACHE_FAIL=1
+    fi
+    if [[ $CDD_RECACHE_FAIL -gt 0 || $ONCOTREE_RECACHE_FAIL -gt 0 ]] ; then
+        echo "Oncotree and/or CDD recache failed! Exiting..."
+        exit 2
+    fi
 fi
 
 # fetch clinical data mercurial

--- a/import-scripts/import-cmo-data-msk.sh
+++ b/import-scripts/import-cmo-data-msk.sh
@@ -19,15 +19,16 @@ msk_automation_notification_file=$(mktemp $tmp/msk-automation-portal-update-noti
 ONCOTREE_VERSION_TO_USE=oncotree_candidate_release
 CANCERSTUDIESLOGFILENAME="$PORTAL_HOME/logs/update-studies-dashi-gdac.log"
 
-
-# refresh cdd and oncotree cache
 CDD_ONCOTREE_RECACHE_FAIL=0
-bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
-if [ $? -gt 0 ]; then
-    CDD_ONCOTREE_RECACHE_FAIL=1
-    message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
-    echo $message
-    echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $pipeline_email_list
+if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
+    # refresh cdd and oncotree cache
+    bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
+    if [ $? -gt 0 ]; then
+        CDD_ONCOTREE_RECACHE_FAIL=1
+        message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
+        echo $message
+        echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $pipeline_email_list
+    fi
 fi
 
 # fetch updates in CMO repository

--- a/import-scripts/import-cmo-data-triage.sh
+++ b/import-scripts/import-cmo-data-triage.sh
@@ -16,14 +16,16 @@ JAVA_IMPORTER_ARGS="$JAVA_PROXY_ARGS $JAVA_DEBUG_ARGS -Dspring.profiles.active=d
 triage_notification_file=$(mktemp $tmp/triage-portal-update-notification.$now.XXXXXX)
 ONCOTREE_VERSION_TO_USE=oncotree_candidate_release
 
-# refresh cdd and oncotree cache
 CDD_ONCOTREE_RECACHE_FAIL=0
-bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
-if [ $? -gt 0 ]; then
-    CDD_ONCOTREE_RECACHE_FAIL=1
-    message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
-    echo $message
-    echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $pipeline_email_list
+if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
+    # refresh cdd and oncotree cache
+    bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
+    if [ $? -gt 0 ]; then
+        CDD_ONCOTREE_RECACHE_FAIL=1
+        message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
+        echo $message
+        echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $pipeline_email_list
+    fi
 fi
 
 # fetch updates in CMO repository

--- a/import-scripts/import-genie-data.sh
+++ b/import-scripts/import-genie-data.sh
@@ -14,14 +14,16 @@ JAVA_IMPORTER_ARGS="$JAVA_PROXY_ARGS $JAVA_DEBUG_ARGS -Dspring.profiles.active=d
 genie_portal_notification_file=$(mktemp $tmp/genie-portal-update-notification.$now.XXXXXX)
 ONCOTREE_VERSION_TO_USE=oncotree_2018_06_01
 
-# refresh cdd and oncotree cache
 CDD_ONCOTREE_RECACHE_FAIL=0
-bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
-if [ $? -gt 0 ]; then
-    CDD_ONCOTREE_RECACHE_FAIL=1
-    message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
-    echo $message
-    echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $email_list
+if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
+    # refresh cdd and oncotree cache
+    bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
+    if [ $? -gt 0 ]; then
+        CDD_ONCOTREE_RECACHE_FAIL=1
+        message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
+        echo $message
+        echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $email_list
+    fi
 fi
 
 DB_VERSION_FAIL=0

--- a/import-scripts/import-pdx-data.sh
+++ b/import-scripts/import-pdx-data.sh
@@ -190,14 +190,16 @@ ALL_HG_FETCH_SUCCESS=0
 IMPORT_SUCCESS=0
 TOMCAT_SERVER_RESTART_SUCCESS=0
 
-# refresh cdd and oncotree cache
 CDD_ONCOTREE_RECACHE_FAIL=0
-bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
-if [ $? -gt 0 ]; then
-    CDD_ONCOTREE_RECACHE_FAIL=1
-    message="Failed to refresh CDD and/or ONCOTREE cache during CRDB PDX import!"
-    echo $message
-    echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $pipelines_email_list
+if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
+    # refresh cdd and oncotree cache
+    bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
+    if [ $? -gt 0 ]; then
+        CDD_ONCOTREE_RECACHE_FAIL=1
+        message="Failed to refresh CDD and/or ONCOTREE cache during CRDB PDX import!"
+        echo $message
+        echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $pipelines_email_list
+    fi
 fi
 
 DB_VERSION_FAIL=0

--- a/import-scripts/import-public-aws-data.sh
+++ b/import-scripts/import-public-aws-data.sh
@@ -18,15 +18,16 @@ JAVA_IMPORTER_ARGS="$JAVA_PROXY_ARGS $JAVA_DEBUG_ARGS -Dspring.profiles.active=d
 public_aws_portal_notification_file=$(mktemp $tmp/aws-public-portal-update-notification.$now.XXXXXX)
 ONCOTREE_VERSION_TO_USE=oncotree_latest_stable
 
-
-# refresh cdd and oncotree cache
 CDD_ONCOTREE_RECACHE_FAIL=0
-bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
-if [ $? -gt 0 ]; then
-    CDD_ONCOTREE_RECACHE_FAIL=1
-    message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
-    echo $message
-    echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $email_list
+if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
+    # refresh cdd and oncotree cache
+    bash $PORTAL_HOME/scripts/refresh-cdd-oncotree-cache.sh
+    if [ $? -gt 0 ]; then
+        CDD_ONCOTREE_RECACHE_FAIL=1
+        message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
+        echo $message
+        echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $email_list
+    fi
 fi
 
 DB_VERSION_FAIL=0

--- a/import-scripts/refresh-cdd-oncotree-cache.sh
+++ b/import-scripts/refresh-cdd-oncotree-cache.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
 MAX_ATTEMPTS=5
 

--- a/import-scripts/restart-aws-public-portal.sh
+++ b/import-scripts/restart-aws-public-portal.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+KUBECTL_BINARY=kubectl
+if ! which $KUBECTL_BINARY > /dev/null 2>&1 ; then
+    echo "Error : restart-aws-public-portal.sh requires $KUBECTL_BINARY, which was not found in the current PATH"
+    exit 1
+fi
+
+$KUBECTL_BINARY set env deployment cbioportal-spring-boot --env="LAST_RESTART=$(date)"


### PR DESCRIPTION
- environment variable introduced: INHIBIT_RECACHING_FROM_TOPBRAID, when set, no recaching is attempted
- also consolidate PATH to use /data/tools ... delete /data/portal-cron/bin and path reference to grossb/local/bin
- check in kubernetes restart script for pulic aws