### PR TITLE
Added support for DDP supplemental data files for mskimpact cohort [NAACCR mappings]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **/src/main/resources/logback.xml
 import-scripts/clinicalfile_utils.pyc
 target
+**/src/main/resources/naaccr*.json

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/BatchConfiguration.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/BatchConfiguration.java
@@ -160,6 +160,24 @@ public class BatchConfiguration {
 
     @Bean
     @StepScope
+    public SuppVitalStatusProcessor suppVitalStatusProcessor() {
+        return new SuppVitalStatusProcessor();
+    }
+
+    @Bean
+    @StepScope
+    public SuppAgeProcessor suppAgeProcessor() {
+        return new SuppAgeProcessor();
+    }
+
+    @Bean
+    @StepScope
+    public SuppNaaccrMappingsProcessor suppNaaccrMappingsProcessor() {
+        return new SuppNaaccrMappingsProcessor();
+    }
+
+    @Bean
+    @StepScope
     public ItemStreamWriter<CompositeResult> clinicalWriter() {
         return new ClinicalWriter();
     }
@@ -184,6 +202,26 @@ public class BatchConfiguration {
 
     @Bean
     @StepScope
+    public ItemStreamWriter<CompositeResult> suppVitalStatusWriter() {
+        return new SuppVitalStatusWriter();
+    }
+
+
+    @Bean
+    @StepScope
+    public ItemStreamWriter<CompositeResult> suppAgeWriter() {
+        return new SuppAgeWriter();
+    }
+
+
+    @Bean
+    @StepScope
+    public ItemStreamWriter<CompositeResult> suppNaaccrMappingsWriter() {
+        return new SuppNaaccrMappingsWriter();
+    }
+
+    @Bean
+    @StepScope
     public CompositeItemWriter<CompositeResult> ddpCompositeWriter() {
         CompositeItemWriter<CompositeResult> writer = new CompositeItemWriter<>();
         List<ItemWriter<? super CompositeResult>> delegates = new ArrayList<>();
@@ -191,6 +229,9 @@ public class BatchConfiguration {
         delegates.add(timelineRadiationWriter());
         delegates.add(timelineChemoWriter());
         delegates.add(timelineSurgeryWriter());
+        delegates.add(suppVitalStatusWriter());
+        delegates.add(suppAgeWriter());
+        delegates.add(suppNaaccrMappingsWriter());
         writer.setDelegates(delegates);
         return writer;
     }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPConfiguration.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPConfiguration.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2018-2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline;
+
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URL;
+import java.util.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ResourceLoader;
+
+/**
+ *
+ * @author ochoaa
+ */
+@Configuration
+public class DDPConfiguration {
+
+    @Value("${naaccr.ethnicity}")
+    private String naaccrEthnicityFilename;
+
+    @Value("${naaccr.race}")
+    private String naaccrRaceFilename;
+
+    @Value("${naaccr.sex}")
+    private String naaccrSexFilename;
+
+    @Autowired
+    private ResourceLoader resourceLoader;
+
+    @Value("#{${ddp.cohort.map}}")
+    private Map<String, Integer> ddpCohortMap;
+
+    @Bean(name="ddpCohortMap")
+    public Map<String, Integer> ddpCohortMap(){
+        return this.ddpCohortMap;
+    }
+
+    @Bean(name="naaccrEthnicityMap")
+    public Map<String, String> naaccrEthnicityMap() throws Exception {
+        URL naaccrEthnicityFile = resourceLoader.getResource(naaccrEthnicityFilename).getURL();
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, List<String>> mapLoaded = mapper.readValue(naaccrEthnicityFile, Map.class);
+        Map<String, String> reverseMap = new HashMap<>();
+        for (Map.Entry<String, List<String>> entry : mapLoaded.entrySet()) {
+            for (String label : entry.getValue()) {
+                reverseMap.put(label.toUpperCase(), entry.getKey());
+            }
+        }
+        DDPUtils.setNaaccrEthnicityMap(reverseMap);
+        return reverseMap;
+    }
+
+    @Bean(name="naaccrRaceMap")
+    public Map<String, String> naaccrRaceMap() throws Exception {
+        URL naaccrRaceFile = resourceLoader.getResource(naaccrRaceFilename).getURL();
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, List<String>> mapLoaded = mapper.readValue(naaccrRaceFile, Map.class);
+        Map<String, String> reverseMap = new HashMap<>();
+        for (Map.Entry<String, List<String>> entry : mapLoaded.entrySet()) {
+            for (String label : entry.getValue()) {
+                reverseMap.put(label.toUpperCase(), entry.getKey());
+            }
+        }
+        DDPUtils.setNaaccrRaceMap(reverseMap);
+        return reverseMap;
+    }
+
+    @Bean(name="naaccrSexMap")
+    public Map<String, String> naaccrSexMap() throws Exception {
+        URL naaccrSexFile = resourceLoader.getResource(naaccrSexFilename).getURL();
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, List<String>> mapLoaded = mapper.readValue(naaccrSexFile, Map.class);
+        Map<String, String> reverseMap = new HashMap<>();
+        for (Map.Entry<String, List<String>> entry : mapLoaded.entrySet()) {
+            for (String label : entry.getValue()) {
+                reverseMap.put(label.toUpperCase(), entry.getKey());
+            }
+        }
+        DDPUtils.setNaaccrSexMap(reverseMap);
+        return reverseMap;
+    }
+}

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppAgeProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppAgeProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -32,28 +32,31 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.springframework.context.annotation.Bean;
-import org.springframework.stereotype.Component;
+import org.mskcc.cmo.ks.ddp.pipeline.model.SuppAgeRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
+
+import org.apache.log4j.Logger;
+import org.springframework.batch.item.ItemProcessor;
 
 /**
  *
  * @author ochoaa
  */
-@Component
-public class CohortConfiguration {
+public class SuppAgeProcessor implements ItemProcessor<DDPCompositeRecord, String> {
 
-    // hack so that we can get map before Spring app is loaded
-    private static final Map<String, Integer> cohortMapping;
-    static {
-        cohortMapping = new HashMap<>();
-        cohortMapping.put("mskimpact", 2033);
-        cohortMapping.put("mskimpact_ped", 1852);
-    }
+    private final Logger LOG = Logger.getLogger(SuppAgeProcessor.class);
 
-    @Bean(name = "cohortMapping")
-    public static Map<String, Integer> cohortMapping() {
-        return cohortMapping;
+    @Override
+    public String process(DDPCompositeRecord compositeRecord) throws Exception {
+        String record = null;
+        SuppAgeRecord suppAgeRecord = new SuppAgeRecord(compositeRecord);
+        try {
+            record = DDPUtils.constructRecord(suppAgeRecord);
+        }
+        catch (NullPointerException e) {
+            LOG.error("Error converting supplemental age record to string: " + suppAgeRecord.toString());
+        }
+        return record;
     }
 }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppAgeWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppAgeWriter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline;
+
+import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
+import org.mskcc.cmo.ks.ddp.pipeline.model.SuppAgeRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+
+import com.google.common.base.Strings;
+import java.io.*;
+import java.util.*;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.batch.item.file.transform.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class SuppAgeWriter implements ItemStreamWriter<CompositeResult> {
+
+    @Value("#{jobParameters[outputDirectory]}")
+    private String outputDirectory;
+
+    @Value("${ddp.supp.dirname}")
+    private String ddpSuppDirname;
+
+    @Value("${ddp.supp.age_filename}")
+    private String ddpSuppAgeFilename;
+
+    @Value("#{jobParameters[cohortName]}")
+    private String cohortName;
+
+    private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
+
+    @Override
+    public void open(ExecutionContext ec) throws ItemStreamException {
+        if (DDPUtils.isMskimpactCohort(cohortName)) {
+            File stagingFile = new File(outputDirectory, ddpSuppDirname + File.separator + ddpSuppAgeFilename);
+            LineAggregator<String> aggr = new PassThroughLineAggregator<>();
+            flatFileItemWriter.setLineAggregator(aggr);
+            flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
+                @Override
+                public void writeHeader(Writer writer) throws IOException {
+                    writer.write(StringUtils.join(SuppAgeRecord.getFieldNames(), "\t"));
+                }
+            });
+            flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
+            flatFileItemWriter.open(ec);
+        }
+    }
+
+    @Override
+    public void update(ExecutionContext ec) throws ItemStreamException {}
+
+    @Override
+    public void close() throws ItemStreamException {
+        if (DDPUtils.isMskimpactCohort(cohortName)) {
+            flatFileItemWriter.close();
+        }
+    }
+
+    @Override
+    public void write(List<? extends CompositeResult> compositeResults) throws Exception {
+        if (DDPUtils.isMskimpactCohort(cohortName)) {
+            List<String> records = new ArrayList<>();
+            for (CompositeResult result : compositeResults) {
+                if (Strings.isNullOrEmpty(result.getSuppAgeResult())) {
+                    continue;
+                }
+                records.add(result.getSuppAgeResult());
+            }
+            flatFileItemWriter.write(records);
+        }
+    }
+}

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppNaaccrMappingsProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppNaaccrMappingsProcessor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline;
+
+import org.mskcc.cmo.ks.ddp.pipeline.model.SuppNaaccrMappingsRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
+
+import org.apache.log4j.Logger;
+import org.springframework.batch.item.ItemProcessor;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class SuppNaaccrMappingsProcessor implements ItemProcessor<DDPCompositeRecord, String> {
+
+    private final Logger LOG = Logger.getLogger(SuppNaaccrMappingsProcessor.class);
+
+    @Override
+    public String process(DDPCompositeRecord compositeRecord) throws Exception {
+        String record = null;
+        SuppNaaccrMappingsRecord suppNaaccrMappingsRecord = new SuppNaaccrMappingsRecord(compositeRecord);
+        try {
+            record = DDPUtils.constructRecord(suppNaaccrMappingsRecord);
+        }
+        catch (NullPointerException e) {
+            LOG.error("Error converting supplemental NAACCR mappings record to string: " + suppNaaccrMappingsRecord.toString());
+        }
+        return record;
+    }
+}

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppNaaccrMappingsWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppNaaccrMappingsWriter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline;
+
+import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
+import org.mskcc.cmo.ks.ddp.pipeline.model.SuppNaaccrMappingsRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+
+import com.google.common.base.Strings;
+import java.io.*;
+import java.util.*;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.batch.item.file.transform.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class SuppNaaccrMappingsWriter implements ItemStreamWriter<CompositeResult> {
+
+    @Value("#{jobParameters[outputDirectory]}")
+    private String outputDirectory;
+
+    @Value("${ddp.supp.dirname}")
+    private String ddpSuppDirname;
+
+    @Value("${ddp.supp.naaccr_filename}")
+    private String ddpSuppNaaccrMappingsFilename;
+
+    @Value("#{jobParameters[cohortName]}")
+    private String cohortName;
+
+    private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
+
+    @Override
+    public void open(ExecutionContext ec) throws ItemStreamException {
+        if (DDPUtils.isMskimpactCohort(cohortName)) {
+            File stagingFile = new File(outputDirectory, ddpSuppDirname + File.separator + ddpSuppNaaccrMappingsFilename);
+            LineAggregator<String> aggr = new PassThroughLineAggregator<>();
+            flatFileItemWriter.setLineAggregator(aggr);
+            flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
+                @Override
+                public void writeHeader(Writer writer) throws IOException {
+                    writer.write(StringUtils.join(SuppNaaccrMappingsRecord.getFieldNames(), "\t"));
+                }
+            });
+            flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
+            flatFileItemWriter.open(ec);
+        }
+    }
+
+    @Override
+    public void update(ExecutionContext ec) throws ItemStreamException {}
+
+    @Override
+    public void close() throws ItemStreamException {
+        if (DDPUtils.isMskimpactCohort(cohortName)) {
+            flatFileItemWriter.close();
+        }
+    }
+
+    @Override
+    public void write(List<? extends CompositeResult> compositeResults) throws Exception {
+        if (DDPUtils.isMskimpactCohort(cohortName)) {
+            List<String> records = new ArrayList<>();
+            for (CompositeResult result : compositeResults) {
+                if (Strings.isNullOrEmpty(result.getSuppNaccrMappingsResult())) {
+                    continue;
+                }
+                records.add(result.getSuppNaccrMappingsResult());
+            }
+            flatFileItemWriter.write(records);
+        }
+    }
+}

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppVitalStatusProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppVitalStatusProcessor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline;
+
+import org.mskcc.cmo.ks.ddp.pipeline.model.SuppVitalStatusRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
+
+import org.apache.log4j.Logger;
+import org.springframework.batch.item.ItemProcessor;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class SuppVitalStatusProcessor implements ItemProcessor<DDPCompositeRecord, String> {
+
+    private final Logger LOG = Logger.getLogger(SuppVitalStatusProcessor.class);
+
+    @Override
+    public String process(DDPCompositeRecord compositeRecord) throws Exception {
+        String record = null;
+        SuppVitalStatusRecord suppVitalStatusRecord = new SuppVitalStatusRecord(compositeRecord);
+        try {
+            record = DDPUtils.constructRecord(suppVitalStatusRecord);
+        }
+        catch (NullPointerException e) {
+            LOG.error("Error converting supplemental vital status record to string: " + suppVitalStatusRecord.toString());
+        }
+        return record;
+    }
+}

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppVitalStatusWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppVitalStatusWriter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline;
+
+import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
+import org.mskcc.cmo.ks.ddp.pipeline.model.SuppVitalStatusRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+
+import com.google.common.base.Strings;
+import java.io.*;
+import java.util.*;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.batch.item.file.transform.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class SuppVitalStatusWriter implements ItemStreamWriter<CompositeResult> {
+
+    @Value("#{jobParameters[outputDirectory]}")
+    private String outputDirectory;
+
+    @Value("${ddp.supp.dirname}")
+    private String ddpSuppDirname;
+
+    @Value("${ddp.supp.vital_status_filename}")
+    private String ddpSuppVitalStatusFilename;
+
+    @Value("#{jobParameters[cohortName]}")
+    private String cohortName;
+
+    private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
+
+    @Override
+    public void open(ExecutionContext ec) throws ItemStreamException {
+        if (DDPUtils.isMskimpactCohort(cohortName)) {
+            File stagingFile = new File(outputDirectory, ddpSuppDirname + File.separator + ddpSuppVitalStatusFilename);
+            LineAggregator<String> aggr = new PassThroughLineAggregator<>();
+            flatFileItemWriter.setLineAggregator(aggr);
+            flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
+                @Override
+                public void writeHeader(Writer writer) throws IOException {
+                    writer.write(StringUtils.join(SuppVitalStatusRecord.getFieldNames(), "\t"));
+                }
+            });
+            flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
+            flatFileItemWriter.open(ec);
+        }
+    }
+
+    @Override
+    public void update(ExecutionContext ec) throws ItemStreamException {}
+
+    @Override
+    public void close() throws ItemStreamException {
+        if (DDPUtils.isMskimpactCohort(cohortName)) {
+            flatFileItemWriter.close();
+        }
+    }
+
+    @Override
+    public void write(List<? extends CompositeResult> compositeResults) throws Exception {
+        if (DDPUtils.isMskimpactCohort(cohortName)) {
+            List<String> records = new ArrayList<>();
+            for (CompositeResult result : compositeResults) {
+                if (Strings.isNullOrEmpty(result.getSuppVitalStatusResult())) {
+                    continue;
+                }
+                records.add(result.getSuppVitalStatusResult());
+            }
+            flatFileItemWriter.write(records);
+        }
+    }
+}

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/CompositeResult.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/CompositeResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018-2019 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -43,6 +43,9 @@ public class CompositeResult {
     private List<String> timelineRadiationResults;
     private List<String> timelineChemoResults;
     private List<String> timelineSurgeryResults;
+    private String suppVitalStatusResult;
+    private String suppAgeResult;
+    private String suppNaccrMappingsResult;
 
     public CompositeResult(){}
 
@@ -100,5 +103,47 @@ public class CompositeResult {
      */
     public void setTimelineSurgeryResults(List<String> timelineSurgeryResults) {
         this.timelineSurgeryResults = timelineSurgeryResults;
+    }
+
+    /**
+     * @return the suppVitalStatusResult
+     */
+    public String getSuppVitalStatusResult() {
+        return suppVitalStatusResult;
+    }
+
+    /**
+     * @param suppVitalStatusResult the suppVitalStatusResult to set
+     */
+    public void setSuppVitalStatusResult(String suppVitalStatusResult) {
+        this.suppVitalStatusResult = suppVitalStatusResult;
+    }
+
+    /**
+     * @return the suppAgeResult
+     */
+    public String getSuppAgeResult() {
+        return suppAgeResult;
+    }
+
+    /**
+     * @param suppAgeResult the suppAgeResult to set
+     */
+    public void setSuppAgeResult(String suppAgeResult) {
+        this.suppAgeResult = suppAgeResult;
+    }
+
+    /**
+     * @return the suppNaccrMappingsResult
+     */
+    public String getSuppNaccrMappingsResult() {
+        return suppNaccrMappingsResult;
+    }
+
+    /**
+     * @param suppNaccrMappingsResult the suppNaccrMappingsResult to set
+     */
+    public void setSuppNaccrMappingsResult(String suppNaccrMappingsResult) {
+        this.suppNaccrMappingsResult = suppNaccrMappingsResult;
     }
 }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/SuppAgeRecord.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/SuppAgeRecord.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline.model;
+
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
+
+import java.text.ParseException;
+import java.util.*;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class SuppAgeRecord {
+
+    private String PATIENT_ID;
+    private String AGE;
+
+    public SuppAgeRecord(){}
+
+    public SuppAgeRecord(DDPCompositeRecord compositeRecord) throws ParseException {
+        this.PATIENT_ID = compositeRecord.getDmpPatientId();
+        this.AGE = DDPUtils.resolveYearsSinceBirth(compositeRecord.getPatientBirthDate());
+    }
+
+    /**
+     * @return the PATIENT_ID
+     */
+    public String getPATIENT_ID() {
+        return PATIENT_ID;
+    }
+
+    /**
+     * @param PATIENT_ID the PATIENT_ID to set
+     */
+    public void setPATIENT_ID(String PATIENT_ID) {
+        this.PATIENT_ID = PATIENT_ID;
+    }
+
+    /**
+     * @return the AGE
+     */
+    public String getAGE() {
+        return AGE;
+    }
+
+    /**
+     * @param AGE the AGE to set
+     */
+    public void setAGE(String AGE) {
+        this.AGE = AGE;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    /**
+     * Returns field names as list of strings.
+     *
+     * @return
+     */
+    public static List<String> getFieldNames() {
+        List<String> fieldNames = new ArrayList<>();
+        fieldNames.add("PATIENT_ID");
+        fieldNames.add("AGE"); // 'AGE' refers to the number of years since birth
+        return fieldNames;
+    }
+}

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/SuppNaaccrMappingsRecord.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/SuppNaaccrMappingsRecord.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline.model;
+
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
+
+import java.text.ParseException;
+import java.util.*;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class SuppNaaccrMappingsRecord {
+
+    private String PATIENT_ID;
+    private String NAACCR_SEX_CODE;
+    private String NAACCR_RACE_CODE_PRIMARY;
+    private String NAACCR_RACE_CODE_SECONDARY;
+    private String NAACCR_RACE_CODE_TERTIARY;
+    private String NAACCR_ETHNICITY_CODE;
+    private String BIRTH_YEAR;
+
+    public SuppNaaccrMappingsRecord(){}
+
+    public SuppNaaccrMappingsRecord(DDPCompositeRecord compositeRecord) throws ParseException {
+        this.PATIENT_ID = compositeRecord.getDmpPatientId();
+        this.NAACCR_SEX_CODE = DDPUtils.resolveNaaccrSexCode(compositeRecord.getPatientSex());
+        this.NAACCR_RACE_CODE_PRIMARY = DDPUtils.resolveNaaccrRaceCode(compositeRecord.getPatientRace());
+        this.NAACCR_RACE_CODE_SECONDARY = "NA";
+        this.NAACCR_RACE_CODE_TERTIARY = "NA";
+        this.NAACCR_ETHNICITY_CODE = DDPUtils.resolveNaaccrEthnicityCode(compositeRecord.getPatientEthnicity());
+        this.BIRTH_YEAR = DDPUtils.parseYearFromDateAsString(compositeRecord.getPatientBirthDate());
+    }
+
+    /**
+     * @return the PATIENT_ID
+     */
+    public String getPATIENT_ID() {
+        return PATIENT_ID;
+    }
+
+    /**
+     * @param PATIENT_ID the PATIENT_ID to set
+     */
+    public void setPATIENT_ID(String PATIENT_ID) {
+        this.PATIENT_ID = PATIENT_ID;
+    }
+
+    /**
+     * @return the NAACCR_SEX_CODE
+     */
+    public String getNAACCR_SEX_CODE() {
+        return NAACCR_SEX_CODE;
+    }
+
+    /**
+     * @param NAACCR_SEX_CODE the NAACCR_SEX_CODE to set
+     */
+    public void setNAACCR_SEX_CODE(String NAACCR_SEX_CODE) {
+        this.NAACCR_SEX_CODE = NAACCR_SEX_CODE;
+    }
+
+    /**
+     * @return the NAACCR_RACE_CODE_PRIMARY
+     */
+    public String getNAACCR_RACE_CODE_PRIMARY() {
+        return NAACCR_RACE_CODE_PRIMARY;
+    }
+
+    /**
+     * @param NAACCR_RACE_CODE_PRIMARY the NAACCR_RACE_CODE_PRIMARY to set
+     */
+    public void setNAACCR_RACE_CODE_PRIMARY(String NAACCR_RACE_CODE_PRIMARY) {
+        this.NAACCR_RACE_CODE_PRIMARY = NAACCR_RACE_CODE_PRIMARY;
+    }
+
+    /**
+     * @return the NAACCR_RACE_CODE_SECONDARY
+     */
+    public String getNAACCR_RACE_CODE_SECONDARY() {
+        return NAACCR_RACE_CODE_SECONDARY;
+    }
+
+    /**
+     * @param NAACCR_RACE_CODE_SECONDARY the NAACCR_RACE_CODE_SECONDARY to set
+     */
+    public void setNAACCR_RACE_CODE_SECONDARY(String NAACCR_RACE_CODE_SECONDARY) {
+        this.NAACCR_RACE_CODE_SECONDARY = NAACCR_RACE_CODE_SECONDARY;
+    }
+
+    /**
+     * @return the NAACCR_RACE_CODE_TERTIARY
+     */
+    public String getNAACCR_RACE_CODE_TERTIARY() {
+        return NAACCR_RACE_CODE_TERTIARY;
+    }
+
+    /**
+     * @param NAACCR_RACE_CODE_TERTIARY the NAACCR_RACE_CODE_TERTIARY to set
+     */
+    public void setNAACCR_RACE_CODE_TERTIARY(String NAACCR_RACE_CODE_TERTIARY) {
+        this.NAACCR_RACE_CODE_TERTIARY = NAACCR_RACE_CODE_TERTIARY;
+    }
+
+    /**
+     * @return the NAACCR_ETHNICITY_CODE
+     */
+    public String getNAACCR_ETHNICITY_CODE() {
+        return NAACCR_ETHNICITY_CODE;
+    }
+
+    /**
+     * @param NAACCR_ETHNICITY_CODE the NAACCR_ETHNICITY_CODE to set
+     */
+    public void setNAACCR_ETHNICITY_CODE(String NAACCR_ETHNICITY_CODE) {
+        this.NAACCR_ETHNICITY_CODE = NAACCR_ETHNICITY_CODE;
+    }
+
+    /**
+     * @return the BIRTH_YEAR
+     */
+    public String getBIRTH_YEAR() {
+        return BIRTH_YEAR;
+    }
+
+    /**
+     * @param BIRTH_YEAR the BIRTH_YEAR to set
+     */
+    public void setBIRTH_YEAR(String BIRTH_YEAR) {
+        this.BIRTH_YEAR = BIRTH_YEAR;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    /**
+     * Returns field names as list of strings.
+     *
+     * @return
+     */
+    public static List<String> getFieldNames() {
+        List<String> fieldNames = new ArrayList<>();
+        fieldNames.add("PATIENT_ID");
+        fieldNames.add("NAACCR_SEX_CODE");
+        fieldNames.add("NAACCR_RACE_CODE_PRIMARY");
+        fieldNames.add("NAACCR_RACE_CODE_SECONDARY");
+        fieldNames.add("NAACCR_RACE_CODE_TERTIARY");
+        fieldNames.add("NAACCR_ETHNICITY_CODE");
+        fieldNames.add("BIRTH_YEAR");
+        return fieldNames;
+    }
+}

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/SuppVitalStatusRecord.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/SuppVitalStatusRecord.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline.model;
+
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
+
+import com.google.common.base.Strings;
+import java.text.ParseException;
+import java.util.*;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class SuppVitalStatusRecord {
+
+    private String PATIENT_ID;
+    private String YEAR_CONTACT;
+    private String YEAR_DEATH;
+    private String INT_CONTACT;
+    private String INT_DOD;
+    private String DEAD;
+
+    public SuppVitalStatusRecord(){}
+
+    public SuppVitalStatusRecord(DDPCompositeRecord compositeRecord) throws ParseException {
+        this.PATIENT_ID = compositeRecord.getDmpPatientId();
+        this.YEAR_CONTACT = DDPUtils.parseYearFromDateAsString(compositeRecord.getLastContactDate());
+        this.YEAR_DEATH = DDPUtils.parseYearFromDateAsString(compositeRecord.getPatientDeathDate());
+        this.INT_CONTACT = DDPUtils.getDateInDaysAsString(compositeRecord.getLastContactDate());
+        this.INT_DOD = DDPUtils.getDateInDaysAsString(compositeRecord.getPatientDeathDate());
+        this.DEAD = (!Strings.isNullOrEmpty(compositeRecord.getPatientDeathDate())) ? "True" : "False";
+    }
+    /**
+     * @return the PATIENT_ID
+     */
+    public String getPATIENT_ID() {
+        return PATIENT_ID;
+    }
+
+    /**
+     * @param PATIENT_ID the PATIENT_ID to set
+     */
+    public void setPATIENT_ID(String PATIENT_ID) {
+        this.PATIENT_ID = PATIENT_ID;
+    }
+
+    /**
+     * @return the YEAR_CONTACT
+     */
+    public String getYEAR_CONTACT() {
+        return YEAR_CONTACT;
+    }
+
+    /**
+     * @param YEAR_CONTACT the YEAR_CONTACT to set
+     */
+    public void setYEAR_CONTACT(String YEAR_CONTACT) {
+        this.YEAR_CONTACT = YEAR_CONTACT;
+    }
+
+    /**
+     * @return the YEAR_DEATH
+     */
+    public String getYEAR_DEATH() {
+        return YEAR_DEATH;
+    }
+
+    /**
+     * @param YEAR_DEATH the YEAR_DEATH to set
+     */
+    public void setYEAR_DEATH(String YEAR_DEATH) {
+        this.YEAR_DEATH = YEAR_DEATH;
+    }
+
+    /**
+     * @return the INT_CONTACT
+     */
+    public String getINT_CONTACT() {
+        return INT_CONTACT;
+    }
+
+    /**
+     * @param INT_CONTACT the INT_CONTACT to set
+     */
+    public void setINT_CONTACT(String INT_CONTACT) {
+        this.INT_CONTACT = INT_CONTACT;
+    }
+
+    /**
+     * @return the INT_DOD
+     */
+    public String getINT_DOD() {
+        return INT_DOD;
+    }
+
+    /**
+     * @param INT_DOD the INT_DOD to set
+     */
+    public void setINT_DOD(String INT_DOD) {
+        this.INT_DOD = INT_DOD;
+    }
+
+    /**
+     * @return the DEAD
+     */
+    public String getDEAD() {
+        return DEAD;
+    }
+
+    /**
+     * @param DEAD the DEAD to set
+     */
+    public void setDEAD(String DEAD) {
+        this.DEAD = DEAD;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    /**
+     * Returns field names as list of strings.
+     *
+     * @return
+     */
+    public static List<String> getFieldNames() {
+        List<String> fieldNames = new ArrayList<>();
+        fieldNames.add("PATIENT_ID");
+        fieldNames.add("YEAR_CONTACT");
+        fieldNames.add("YEAR_DEATH");
+        fieldNames.add("INT_CONTACT");
+        fieldNames.add("INT_DOD");
+        fieldNames.add("DEAD");
+        return fieldNames;
+    }
+}

--- a/ddp/ddp_pipeline/src/main/resources/application.properties.EXAMPLE
+++ b/ddp/ddp_pipeline/src/main/resources/application.properties.EXAMPLE
@@ -30,3 +30,17 @@ async.DDP.thread.pool.size=50
 async.DDP.thread.pool.max=50
 processor.thread.pool.size=100
 processor.thread.pool.max=100
+
+# DDP cohort IDs
+ddp.cohort.map={"mskimpact":2033,"mskimpact_ped":1852}
+
+# NAACCR mappings resource filenames
+naaccr.ethnicity=naaccr_ethnicity.json
+naaccr.race=naaccr_race.json
+naaccr.sex=naaccr_sex.json
+
+# Supplemental data filenames (MSKIMPACT only)
+ddp.supp.dirname=ddp
+ddp.supp.vital_status_filename=ddp_vital_status.txt
+ddp.supp.age_filename=ddp_age.txt
+ddp.supp.naaccr_filename=ddp_naaccr.txt

--- a/ddp/ddp_source/src/main/java/org/mskcc/cmo/ks/ddp/source/composite/DDPCompositeRecord.java
+++ b/ddp/ddp_source/src/main/java/org/mskcc/cmo/ks/ddp/source/composite/DDPCompositeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018-2019 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -213,8 +213,19 @@ public class DDPCompositeRecord {
     }
 
     public String getPatientDeathDate() {
-        return (!Strings.isNullOrEmpty(patientDemographics.getPTDEATHDTE())) ? 
+        return (!Strings.isNullOrEmpty(patientDemographics.getPTDEATHDTE())) ?
                 patientDemographics.getPTDEATHDTE() : patientDemographics.getDeceasedDate();
+    }
+
+    public String getLastContactDate() {
+        // if patient is not deceased then return last contact date
+        // otherwise return date of death
+        String patientDeathDate = getPatientDeathDate();
+        if (!Strings.isNullOrEmpty(patientDeathDate)) {
+            return patientDeathDate;
+        }
+        return (!Strings.isNullOrEmpty(patientDemographics.getPLALASTCONTACTDTE()) ?
+                patientDemographics.getPLALASTCONTACTDTE() : patientDemographics.getLastContactDate());
     }
 
     public String getPatientRace() {

--- a/integration-tests/set_application_properties.sh
+++ b/integration-tests/set_application_properties.sh
@@ -13,4 +13,5 @@ rsync $JENKINS_PROPERTIES_DIRECTORY/fetch-cvr/$APPLICATION_PROPERTIES $CMO_PIPEL
 rsync $JENKINS_PROPERTIES_DIRECTORY/fetch-darwin/$APPLICATION_PROPERTIES $CMO_PIPELINES_DIRECTORY/darwin/src/main/resources
 rsync $JENKINS_PROPERTIES_DIRECTORY/fetch-crdb/$APPLICATION_PROPERTIES $CMO_PIPELINES_DIRECTORY/crdb/src/main/resources
 rsync $JENKINS_PROPERTIES_DIRECTORY/fetch-ddp/$APPLICATION_PROPERTIES $CMO_PIPELINES_DIRECTORY/ddp/ddp_pipeline/src/main/resources
+rsync $JENKINS_PROPERTIES_DIRECTORY/fetch-ddp/*.json $CMO_PIPELINES_DIRECTORY/ddp/ddp_pipeline/src/main/resources
 rsync $JENKINS_PIPELINES_CREDENTIALS/application-secure.properties $CMO_PIPELINES_DIRECTORY/ddp/ddp_pipeline/src/main/resources


### PR DESCRIPTION
DDP supplemental data files will now be generated only for mskimpact.

Note: These supplemental data files are used for MSK's GENIE data submissions.

Changes:
- Expanded `CompositeResult` with new supplemental data fields.
- NAACCR code mappings are loaded on application startup from JSON resource files to be stored under ddp/ddp_pipeline/src/main/resources
- Updated application.properties.EXAMPLE with supplemental DDP data filenames
- Added methods to `DDPUtils` to support new data values for supplemental DDP data files

Minor changes:
- some refactoring/cleanup/modularization

TODO
- [x] unit tests on year parsing / getting expected values for test cases (null, NA, valid year, invalid year, etc.)
- [x] unit tests on naaccr mappings / getting expected values, etc.

Darwin vs. DDP result comparisons:
- [x] Age
- [x] Race (1)
- [x] Ethnicity
- [x] Religion (2)


(1) DDP did not return race values for many patients. Spot checking these patients showed that the cbio pipelines DDP account does not have access to these patients. (401 unauthorized or 403 forbidden). We are receiving info for these patients from Darwin however so we are waiting for confirmation regarding whether we should actually have access to these patients or not.

(2) Some discrepancies with religion found:
```
P-0006914 protestant-ddp, christian-darwin
P-0040297 other-ddp, catholic/roman-darwin
P-0029384 no value entered-ddp, unknown-darwin
P-0030846 unknown-ddp, catholic/roman-darwin
P-0031434 no value entered-ddp, unknown-darwin
P-0031823 no value entered-ddp, unknown-darwin
P-0035133 not in darwin demographics file
P-0002845 not in darwin demographics file
P-0005393 not in darwin demographics file
P-0006874 not in darwin demographics file 
```





Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>