### PR TITLE
Drop references to google sheets for pulling clinical attributes

### DIFF
--- a/import-scripts/monitor-cdd.sh
+++ b/import-scripts/monitor-cdd.sh
@@ -10,6 +10,6 @@ then
     (>&2 echo "GET '$URL' returned '$http_code' status code, expected '$OK'")
     if [ "$http_code" -eq $SERVICE_UNAVAILABLE ]
     then
-        (>&2 echo "The CDD cache is empty, attempts to refresh the cache from Google must have failed")
+        (>&2 echo "The CDD cache is empty, attempts to refresh the cache from TopBraid must have failed")
     fi
 fi


### PR DESCRIPTION
some scripts were making references to google sheets as a source of clinical attribute definitions.
this removes those references

There were also unused (I believe) references to 'import httplib2' and 'import time' which I have dropped.