### PR TITLE
DDP Pipeline - add PED_IND column to clinical output

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
@@ -69,6 +69,9 @@ public class DDPCompositeProcessor implements ItemProcessor<DDPCompositeRecord, 
     @Value("#{jobParameters[cohortName]}")
     private String cohortName;
 
+    @Value("#{stepExecutionContext['pediatricCohortPatientIdsSet']}")
+    private Set<Integer> pediatricCohortPatientIdsSet;
+
     @Autowired
     private DDPDataSource ddpDataSource;
 
@@ -115,6 +118,9 @@ public class DDPCompositeProcessor implements ItemProcessor<DDPCompositeRecord, 
         // are null because an exception will be thrown in that case too (by the repository)
         try {
             compositeRecord.setPatientDemographics(futurePatientDemographics.get());
+            if (!pediatricCohortPatientIdsSet.isEmpty()) {
+                compositeRecord.setPediatricPatientStatus(pediatricCohortPatientIdsSet.contains(compositeRecord.getPatientDemographics().getDeidentPT()));
+            }
         } catch (InvalidAuthenticationException e) {
             throw new RuntimeException(e.getMessage());
         } catch (Exception e) {

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/ClinicalRecord.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/ClinicalRecord.java
@@ -51,6 +51,7 @@ public class ClinicalRecord {
     private String SEX;
     private String ETHNICITY;
     private String OS_STATUS;
+    private String PED_IND;
     private String OS_MONTHS;
     private String RADIATION_THERAPY;
     private String CHEMOTHERAPY;
@@ -66,6 +67,7 @@ public class ClinicalRecord {
         this.SEX = DDPUtils.resolvePatientSex(compositeRecord);
         this.ETHNICITY = compositeRecord.getPatientEthnicity() == null ? "NA" : compositeRecord.getPatientEthnicity();;
         this.OS_STATUS = DDPUtils.resolveOsStatus(compositeRecord);
+        this.PED_IND = DDPUtils.resolvePediatricCohortPatientStatus(compositeRecord.getPediatricPatientStatus());
         this.OS_MONTHS = DDPUtils.resolveOsMonths(OS_STATUS, compositeRecord);
         this.RADIATION_THERAPY = compositeRecord.hasReceivedRadiation() ? "Yes" : "No";
         this.CHEMOTHERAPY = compositeRecord.hasReceivedChemo() ? "Yes" : "No";
@@ -171,6 +173,20 @@ public class ClinicalRecord {
     }
 
     /**
+     * @return the PED_IND
+     */
+    public String getPED_IND() {
+        return PED_IND;
+    }
+
+    /**
+     * @param PED_IND the PED_IND to set
+     */
+    public void setPED_IND(String PED_IND) {
+        this.PED_IND = PED_IND;
+    }
+
+    /**
      * @return the OS_MONTHS
      */
     public String getOS_MONTHS() {
@@ -245,6 +261,7 @@ public class ClinicalRecord {
         fieldNames.add("SEX");
         fieldNames.add("ETHNICITY");
         fieldNames.add("OS_STATUS");
+        fieldNames.add("PED_IND");
         // OS_MONTHS depends on fields from the diagnosis query
         // so if querying diagnosis is turned off all fields will be NA
         if (includeDiagnosis) {

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -432,6 +432,13 @@ public class DDPUtils {
                 naaccrSexMap.getOrDefault(sex.toUpperCase(), "NA"));
     }
 
+    public static String resolvePediatricCohortPatientStatus(Boolean pediatricCohortPatientStatus) {
+        if (pediatricCohortPatientStatus == null) {
+            return "NA";
+        }
+        return (pediatricCohortPatientStatus ? "Yes" : "No");
+    }
+
     /**
      * Converts record as tab-delimited string of values.
      *

--- a/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtilsTest.java
+++ b/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtilsTest.java
@@ -406,11 +406,12 @@ public class DDPUtilsTest {
         clinicalRecord.setSEX("Female");
         clinicalRecord.setETHNICITY("MY_ETHNICITY");
         clinicalRecord.setOS_STATUS("LIVING");
+        clinicalRecord.setPED_IND("Yes");
         clinicalRecord.setOS_MONTHS("3.123");
         clinicalRecord.setRADIATION_THERAPY("MY_RADIATION_THERAPY");
         clinicalRecord.setCHEMOTHERAPY("  MY_CHEMOTHERAPY  "); // it does a trim too
         clinicalRecord.setSURGERY("MY_SURGERY");
-        String expectedValue = "MY_PT_ID\t20\tMY_RACE\tMY_RELIGION\tFemale\tMY_ETHNICITY\tLIVING\t3.123\tMY_RADIATION_THERAPY\tMY_CHEMOTHERAPY\tMY_SURGERY";
+        String expectedValue = "MY_PT_ID\t20\tMY_RACE\tMY_RELIGION\tFemale\tMY_ETHNICITY\tLIVING\tYes\t3.123\tMY_RADIATION_THERAPY\tMY_CHEMOTHERAPY\tMY_SURGERY";
         String returnedValue = DDPUtils.constructRecord(clinicalRecord, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE);
         Assert.assertEquals(expectedValue, returnedValue);
     }
@@ -425,11 +426,12 @@ public class DDPUtilsTest {
         clinicalRecord.setSEX("Female");
         clinicalRecord.setETHNICITY("MY_ETHNICITY");
         clinicalRecord.setOS_STATUS("LIVING");
+        clinicalRecord.setPED_IND("No");
         clinicalRecord.setOS_MONTHS("NA");
         clinicalRecord.setRADIATION_THERAPY("MY_RADIATION_THERAPY");
         clinicalRecord.setCHEMOTHERAPY("  MY_CHEMOTHERAPY  "); // it does a trim too
         clinicalRecord.setSURGERY("MY_SURGERY");
-        String expectedValue = "MY_PT_ID\t20\tMY_RACE\tMY_RELIGION\tFemale\tMY_ETHNICITY\tLIVING\tMY_RADIATION_THERAPY\tMY_CHEMOTHERAPY\tMY_SURGERY";
+        String expectedValue = "MY_PT_ID\t20\tMY_RACE\tMY_RELIGION\tFemale\tMY_ETHNICITY\tLIVING\tNo\tMY_RADIATION_THERAPY\tMY_CHEMOTHERAPY\tMY_SURGERY";
         String returnedValue = DDPUtils.constructRecord(clinicalRecord, Boolean.FALSE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE);
         Assert.assertEquals(expectedValue, returnedValue);
     }
@@ -444,11 +446,12 @@ public class DDPUtilsTest {
         clinicalRecord.setSEX("Female");
         clinicalRecord.setETHNICITY("MY_ETHNICITY");
         clinicalRecord.setOS_STATUS("LIVING");
+        clinicalRecord.setPED_IND("NA");
         clinicalRecord.setOS_MONTHS("3.123");
         clinicalRecord.setRADIATION_THERAPY("MY_RADIATION_THERAPY"); // doesn't matter if this was set
         clinicalRecord.setCHEMOTHERAPY("  MY_CHEMOTHERAPY  "); // it does a trim too
         clinicalRecord.setSURGERY("MY_SURGERY");
-        String expectedValue = "MY_PT_ID\t20\tMY_RACE\tMY_RELIGION\tFemale\tMY_ETHNICITY\tLIVING\t3.123\tMY_CHEMOTHERAPY\tMY_SURGERY";
+        String expectedValue = "MY_PT_ID\t20\tMY_RACE\tMY_RELIGION\tFemale\tMY_ETHNICITY\tLIVING\tNA\t3.123\tMY_CHEMOTHERAPY\tMY_SURGERY";
         String returnedValue = DDPUtils.constructRecord(clinicalRecord, Boolean.TRUE, Boolean.FALSE, Boolean.TRUE, Boolean.TRUE);
         Assert.assertEquals(expectedValue, returnedValue);
     }
@@ -463,11 +466,12 @@ public class DDPUtilsTest {
         clinicalRecord.setSEX("Female");
         clinicalRecord.setETHNICITY("MY_ETHNICITY");
         clinicalRecord.setOS_STATUS("LIVING");
+        clinicalRecord.setPED_IND("Yes");
         clinicalRecord.setOS_MONTHS("3.123");
         clinicalRecord.setRADIATION_THERAPY("MY_RADIATION_THERAPY");
         clinicalRecord.setCHEMOTHERAPY("  MY_CHEMOTHERAPY  "); // doesn't matter if this was set
         clinicalRecord.setSURGERY("MY_SURGERY");
-        String expectedValue = "MY_PT_ID\t20\tMY_RACE\tMY_RELIGION\tFemale\tMY_ETHNICITY\tLIVING\t3.123\tMY_RADIATION_THERAPY\tMY_SURGERY";
+        String expectedValue = "MY_PT_ID\t20\tMY_RACE\tMY_RELIGION\tFemale\tMY_ETHNICITY\tLIVING\tYes\t3.123\tMY_RADIATION_THERAPY\tMY_SURGERY";
         String returnedValue = DDPUtils.constructRecord(clinicalRecord, Boolean.TRUE, Boolean.TRUE, Boolean.FALSE, Boolean.TRUE);
         Assert.assertEquals(expectedValue, returnedValue);
     }
@@ -482,11 +486,12 @@ public class DDPUtilsTest {
         clinicalRecord.setSEX("Female");
         clinicalRecord.setETHNICITY("MY_ETHNICITY");
         clinicalRecord.setOS_STATUS("LIVING");
+        clinicalRecord.setPED_IND("No");
         clinicalRecord.setOS_MONTHS("3.123");
         clinicalRecord.setRADIATION_THERAPY("MY_RADIATION_THERAPY");
         clinicalRecord.setCHEMOTHERAPY("  MY_CHEMOTHERAPY  "); // it does a trim too
         clinicalRecord.setSURGERY("MY_SURGERY"); // doesn't matter if this was set
-        String expectedValue = "MY_PT_ID\t20\tMY_RACE\tMY_RELIGION\tFemale\tMY_ETHNICITY\tLIVING\t3.123\tMY_RADIATION_THERAPY\tMY_CHEMOTHERAPY";
+        String expectedValue = "MY_PT_ID\t20\tMY_RACE\tMY_RELIGION\tFemale\tMY_ETHNICITY\tLIVING\tNo\t3.123\tMY_RADIATION_THERAPY\tMY_CHEMOTHERAPY";
         String returnedValue = DDPUtils.constructRecord(clinicalRecord, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.FALSE);
         Assert.assertEquals(expectedValue, returnedValue);
     }

--- a/ddp/ddp_source/src/main/java/org/mskcc/cmo/ks/ddp/source/composite/DDPCompositeRecord.java
+++ b/ddp/ddp_source/src/main/java/org/mskcc/cmo/ks/ddp/source/composite/DDPCompositeRecord.java
@@ -51,6 +51,7 @@ public class DDPCompositeRecord {
     private List<Radiation> radiationProcedures;
     private List<Chemotherapy> chemoProcedures;
     private List<Surgery> surgicalProcedures;
+    private Boolean pediatricPatientStatus;
 
     public DDPCompositeRecord(){}
 
@@ -283,5 +284,19 @@ public class DDPCompositeRecord {
             }
         }
         return Boolean.FALSE;
+    }
+
+    /**
+     * @return the pediatricPatientStatus
+     */
+    public Boolean getPediatricPatientStatus() {
+        return pediatricPatientStatus;
+    }
+
+    /**
+     * @param pediatricPatientStatus the pediatricPatientStatus to set
+     */
+    public void setPediatricPatientStatus(Boolean pediatricPatientStatus) {
+        this.pediatricPatientStatus = pediatricPatientStatus;
     }
 }


### PR DESCRIPTION
Added `PED_IND` indicator to clinical output of DDP pipeline.

Flow:
1. `DDPReader` fetches set of pediatric cohort patients from DDP service, adds de-identified DDP IDs as set of integers to the step execution context for processor
2. `DDPCompositeProcessor` attempts to fetch DDP demographics for patient
3. If (1) and (2) are successful and set of IDs from (1) is not empty then `DDPCompositeProcessor` updates the pediatric patient status based on whether the DDP de-identified ID from the patient demographics results exists in the set of IDs from (1). If either (1) or (2) are unsuccessful then the pediatric patient status will be `null` and will be set to `NA` for the clinical output.


TO-DO:
- [x] update DDP REDCap projects with `PED_IND` column
- [ ] disable Darwin fetch / pull demographics from DDP
- [x] make a Darwin CAISIS only mode? (until we start fetching CAISIS from DDP) See PR #564 
- [ ] add sanity check on DDP demographics record count. Compare num of records from yesterday's fetch vs today's fetch.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>