### PR TITLE
Disable Darwin fetch, enable DDP demographics fetch

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -54,7 +54,7 @@ public class CVRUtilities {
     public static final String UNFILTERED_MUTATION_FILE = "data_mutations_unfiltered.txt";
     public static final String DEFAULT_CLINICAL_FILE = "data_clinical.txt";
     public static final String SEQ_DATE_CLINICAL_FILE = "cvr/seq_date.txt";
-    public static final String DARWIN_AGE_FILE = "darwin/darwin_age.txt";
+    public static final String DDP_AGE_FILE = "ddp/ddp_age.txt";
     public static final String CORRESPONDING_ID_FILE = "cvr/linked_cases.txt";
     public static final String CNA_FILE = "data_CNA.txt";
     public static final String SEG_FILE = "_data_cna_hg19.seg";

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
@@ -181,7 +181,7 @@ public class CVRClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
     }
 
     private void processAgeFile(ExecutionContext ec) {
-        File mskimpactAgeFile = new File(stagingDirectory, cvrUtilities.DARWIN_AGE_FILE);
+        File mskimpactAgeFile = new File(stagingDirectory, cvrUtilities.DDP_AGE_FILE);
         if (!mskimpactAgeFile.exists()) {
             log.error("File does not exist - skipping data loading from age file: " + mskimpactAgeFile.getName());
             return;

--- a/import-scripts/dmp-import-vars-functions.sh
+++ b/import-scripts/dmp-import-vars-functions.sh
@@ -19,8 +19,7 @@ JAVA_REDCAP_PIPELINE_ARGS="-jar $REDCAP_PIPELINE_JAR_FILENAME"
 JAVA_DEBUG_ARGS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182"
 JAVA_IMPORTER_ARGS="$JAVA_PROXY_ARGS $JAVA_DEBUG_ARGS -Dspring.profiles.active=dbcp -Djava.io.tmpdir=$MSK_DMP_TMPDIR -ea -cp $IMPORTER_JAR_FILENAME org.mskcc.cbio.importer.Admin"
 
-#default darwin demographics row count is 2 to allow minimum records written to be 1 in fetched Darwin Demographics result (allow 10% drop)
-DEFAULT_DARWIN_DEMOGRAPHICS_ROW_COUNT=2
+##TO-DO: ADD DEFAULT DDP DEMOGRAPHICS ROW COUNT
 
 # Clinical attribute fields which should never be filtered because of empty content
 FILTER_EMPTY_COLUMNS_KEEP_COLUMN_LIST="PATIENT_ID,SAMPLE_ID,ONCOTREE_CODE,PARTA_CONSENTED_12_245,PARTC_CONSENTED_12_245"
@@ -127,10 +126,9 @@ function import_crdb_to_redcap {
 }
 
 # Function for importing mskimpact darwin files to redcap
-function import_mskimpact_darwin_to_redcap {
+function import_mskimpact_darwin_caisis_to_redcap {
     return_value=0
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_clinical_supp_caisis_gbm.txt mskimpact_clinical_caisis ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_clinical_supp_darwin_demographics.txt mskimpact_data_clinical_darwin_demographics ; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_timeline_imaging_caisis_gbm.txt mskimpact_timeline_imaging_caisis ; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_timeline_specimen_caisis_gbm.txt mskimpact_timeline_specimen_caisis ; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_timeline_status_caisis_gbm.txt mskimpact_timeline_status_caisis ; then return_value=1 ; fi
@@ -157,16 +155,10 @@ function import_mskimpact_supp_date_to_redcap {
 function import_mskimpact_ddp_to_redcap {
     return_value=0
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_clinical_ddp.txt mskimpact_data_clinical_ddp_demographics ; then return_value=1 ; fi
+    if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_clinical_ddp_pediatrics.txt mskimpact_data_clinical_ddp_demographics_pediatrics ; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskimpact_timeline_chemotherapy_ddp; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_timeline_ddp_radiation.txt mskimpact_timeline_radiation_ddp ; then return_value=1 ; fi
     if ! import_project_to_redcap $MSK_IMPACT_DATA_HOME/data_timeline_ddp_surgery.txt mskimpact_timeline_surgery_ddp ; then return_value=1 ; fi
-    return $return_value
-}
-
-# Function for importing hemepact darwin files to redcap
-function import_hemepact_darwin_to_redcap {
-    return_value=0
-    if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_clinical_supp_darwin_demographics.txt hemepact_data_clinical_supp_darwin_demographics ; then return_value=1 ; fi
     return $return_value
 }
 
@@ -188,16 +180,9 @@ function import_hemepact_supp_date_to_redcap {
 function import_hemepact_ddp_to_redcap {
     return_value=0
     if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_clinical_ddp.txt hemepact_data_clinical_ddp_demographics ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_timeline_ddp_chemotherapy.txt hemepact_timeline_chemotherapy_ddp; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_timeline_ddp_radiation.txt hemepact_timeline_radiation_ddp ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_timeline_ddp_surgery.txt hemepact_data_timeline_surgery_ddp ; then return_value=1 ; fi
-    return $return_value
-}
-
-# Function for importing raindance darwin files to redcap
-function import_raindance_darwin_to_redcap {
-    return_value=0
-    if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_clinical_supp_darwin_demographics.txt mskraindance_data_clinical_supp_darwin_demographics ; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_timeline_ddp_chemotherapy.txt hemepact_timeline_chemotherapy_ddp; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_timeline_ddp_radiation.txt hemepact_timeline_radiation_ddp ; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_HEMEPACT_DATA_HOME/data_timeline_ddp_surgery.txt hemepact_data_timeline_surgery_ddp ; then return_value=1 ; fi
     return $return_value
 }
 
@@ -219,16 +204,9 @@ function import_raindance_supp_date_to_redcap {
 function import_raindance_ddp_to_redcap {
     return_value=0
     if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_clinical_ddp.txt mskraindance_data_clinical_ddp_demographics ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskraindance_timeline_chemotherapy_ddp; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_radiation.txt mskraindance_timeline_radiation_ddp ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_surgery.txt mskraindance_data_timeline_surgery_ddp ; then return_value=1 ; fi
-    return $return_value
-}
-
-# Function for importing archer darwin files to redcap
-function import_archer_darwin_to_redcap {
-    return_value=0
-    if ! import_project_to_redcap $MSK_ARCHER_UNFILTERED_DATA_HOME/data_clinical_supp_darwin_demographics.txt mskarcher_data_clinical_supp_darwin_demographics ; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskraindance_timeline_chemotherapy_ddp; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_radiation.txt mskraindance_timeline_radiation_ddp ; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_surgery.txt mskraindance_data_timeline_surgery_ddp ; then return_value=1 ; fi
     return $return_value
 }
 
@@ -250,9 +228,9 @@ function import_archer_supp_date_to_redcap {
 function import_archer_ddp_to_redcap {
     return_value=0
     if ! import_project_to_redcap $MSK_ARCHER_UNFILTERED_DATA_HOME/data_clinical_ddp.txt mskarcher_data_clinical_ddp_demographics ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_ARCHER_UNFILTERED_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskarcher_timeline_chemotherapy_ddp; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_ARCHER_UNFILTERED_DATA_HOME/data_timeline_ddp_radiation.txt mskarcher_timeline_radiation_ddp ; then return_value=1 ; fi
-    if ! import_project_to_redcap $MSK_ARCHER_UNFILTERED_DATA_HOME/data_timeline_ddp_surgery.txt mskarcher_data_timeline_surgery_ddp ; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_ARCHER_UNFILTERED_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskarcher_timeline_chemotherapy_ddp; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_ARCHER_UNFILTERED_DATA_HOME/data_timeline_ddp_radiation.txt mskarcher_timeline_radiation_ddp ; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_ARCHER_UNFILTERED_DATA_HOME/data_timeline_ddp_surgery.txt mskarcher_data_timeline_surgery_ddp ; then return_value=1 ; fi
     return $return_value
 }
 

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -23,10 +23,7 @@ EXPORT_SUPP_DATE_ARCHER_FAIL=0
 
 # Assume fetchers have failed until they complete successfully
 FETCH_CRDB_IMPACT_FAIL=1
-FETCH_DARWIN_IMPACT_FAIL=1
-FETCH_DARWIN_HEME_FAIL=1
-FETCH_DARWIN_RAINDANCE_FAIL=1
-FETCH_DARWIN_ARCHER_FAIL=1
+FETCH_DARWIN_CASISIS_FAIL=1
 FETCH_DDP_IMPACT_FAIL=1
 FETCH_DDP_HEME_FAIL=1
 FETCH_DDP_RAINDANCE_FAIL=1
@@ -176,23 +173,33 @@ fi
 # MSKIMPACT DATA FETCHES
 # TODO: move other pre-import/data-fetch steps here (i.e exporting raw files from redcap)
 
-# fetch Darwin data
-echo "fetching Darwin impact data"
+# fetch ddp demographics data
+echo "fetching DDP demographics data for mskimpact..."
 echo $(date)
-# if darwin demographics row count less than or equal to default row count then set it to default value
-MSKIMPACT_DARWIN_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSKIMPACT_REDCAP_BACKUP/data_clinical_mskimpact_data_clinical_darwin_demographics.txt)
-if [ $MSKIMPACT_DARWIN_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DARWIN_DEMOGRAPHICS_ROW_COUNT ] ; then
-    MSKIMPACT_DARWIN_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DARWIN_DEMOGRAPHICS_ROW_COUNT
-fi
-$JAVA_BINARY $JAVA_DARWIN_FETCHER_ARGS -d $MSK_IMPACT_DATA_HOME -s mskimpact -r $MSKIMPACT_DARWIN_DEMOGRAPHICS_RECORD_COUNT
-##TODO - RUN DARWIN FETCHER IN CASISIS ONLY MODE [-c] ONCE DDP DEMOGRAPHICS FETCHING IS DEPLOYED 
+mskimpact_dmp_pids_file=$MSK_DMP_TMPDIR/mskimpact_patient_list.txt
+awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt | sort | uniq > $mskimpact_dmp_pids_file
+##TO-DO: ADD ARG TO PASS IN "YESTERDAY'S" DEMOGRAHICS RECORD COUNT TO DDP TO ENSURE WE AREN'T OVERWRITING WITH INVALID DATA
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact -s $mskimpact_dmp_pids_file -o $MSK_IMPACT_DATA_HOME
 if [ $? -gt 0 ] ; then
     cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
-    sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT DARWIN Fetch"
+    sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT DDP Demographics Fetch"
 else
-    FETCH_DARWIN_IMPACT_FAIL=0
-    echo "committing darwin data"
-    cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY commit -m "Latest MSKIMPACT Dataset: Darwin"
+    FETCH_DDP_IMPACT_FAIL=0
+    echo "committing ddp data"
+    cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY commit -m "Latest MSKIMPACT Dataset: DDP Demographics"
+fi
+
+# fetch darwin caisis data
+echo "fetching Darwin CAISIS data for mskimpact..."
+echo $(date)
+$JAVA_BINARY $JAVA_DARWIN_FETCHER_ARGS -s mskimpact -d $MSK_IMPACT_DATA_HOME -c
+if [ $? -gt 0 ] ; then
+    cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
+    sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT Darwin CAISIS Fetch"
+else
+    FETCH_DARWIN_CASISIS_FAIL=0
+    echo "committing darwin caisis data"
+    cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY commit -m "Latest MSKIMPACT Dataset: Darwin CAISIS"
 fi
 
 if [ $IMPORT_STATUS_IMPACT -eq 0 ] ; then
@@ -257,18 +264,19 @@ if [ $IMPORT_STATUS_IMPACT -eq 0 ] ; then
     fi
 fi
 
-if [ $FETCH_DARWIN_IMPACT_FAIL -eq 0 ] ; then
-    awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PED_IND"] == "Yes") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_supp_darwin_demographics.txt | sort | uniq > $MSK_DMP_TMPDIR/mskimpact_ped_patient_list.txt
-    # For future use: when we want to replace darwin demographics attributes with ddp-fetched attributes instead of just for ped-cohort
-    #awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt | sort | uniq > $MSK_DMP_TMPDIR/mskimpact_patient_list.txt
-    $JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -o $MSK_IMPACT_DATA_HOME -s $MSK_DMP_TMPDIR/mskimpact_ped_patient_list.txt -f diagnosis,radiation,chemotherapy,surgery
+# fetch ddp data for pediatric cohort
+if [ $FETCH_DDP_IMPACT_FAIL -eq 0 ] ; then
+    awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PED_IND"] == "Yes") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_ddp.txt | sort | uniq > $MSK_DMP_TMPDIR/mskimpact_ped_patient_list.txt
+    # override default ddp clinical filename so that pediatric demographics file does not conflict with mskimpact demographics file
+    DDP_PEDIATRIC_PROP_OVERRIDES="-Dddp.clinical_filename=data_clinical_ddp_pediatrics.txt"
+    $JAVA_BINARY $DDP_PEDIATRIC_PROP_OVERRIDES $JAVA_DDP_FETCHER_ARGS -o $MSK_IMPACT_DATA_HOME -s $MSK_DMP_TMPDIR/mskimpact_ped_patient_list.txt -f diagnosis,radiation,chemotherapy,surgery
     if [ $? -gt 0 ] ; then
         cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
-        sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT DDP Fetch"
+        sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT Pediatric DDP Fetch"
     else
         FETCH_DDP_IMPACT_FAIL=0
-        echo "committing DDP data"
-        cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY commit -m "Latest MSKIMPACT Dataset: DDP demographics/timeline"
+        echo "committing Pediatric DDP data"
+        cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY commit -m "Latest MSKIMPACT Dataset: Pediatric DDP demographics/timeline"
     fi
 fi
 
@@ -290,21 +298,21 @@ fi
 # -----------------------------------------------------------------------------------------------------------
 # HEMEPACT DATA FETCHES
 
-echo "fetching Darwin heme data"
+# fetch ddp demographics data
+echo "fetching DDP demographics data for heme..."
 echo $(date)
-# if darwin demographics row count less than or equal to default row count then set it to default value
-HEMEPACT_DARWIN_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $HEMEPACT_REDCAP_BACKUP/data_clinical_hemepact_data_clinical_supp_darwin_demographics.txt)
-if [ $HEMEPACT_DARWIN_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DARWIN_DEMOGRAPHICS_ROW_COUNT ] ; then
-    HEMEPACT_DARWIN_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DARWIN_DEMOGRAPHICS_ROW_COUNT
-fi
-$JAVA_BINARY $JAVA_DARWIN_FETCHER_ARGS -d $MSK_HEMEPACT_DATA_HOME -s mskimpact_heme -r $HEMEPACT_DARWIN_DEMOGRAPHICS_RECORD_COUNT
+
+mskimpact_heme_dmp_pids_file=$MSK_DMP_TMPDIR/mskimpact_heme_patient_list.txt
+awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt | sort | uniq > $mskimpact_heme_dmp_pids_file
+##TO-DO: ADD ARG TO PASS IN "YESTERDAY'S" DEMOGRAHICS RECORD COUNT TO DDP TO ENSURE WE AREN'T OVERWRITING WITH INVALID DATA
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact_heme -s $mskimpact_heme_dmp_pids_file -o $MSK_HEMEPACT_DATA_HOME
 if [ $? -gt 0 ] ; then
-    cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
-    sendPreImportFailureMessageMskPipelineLogsSlack "HEMEPACT DARWIN Fetch"
+    cd $MSK_HEMEPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
+    sendPreImportFailureMessageMskPipelineLogsSlack "HEMEPACT DDP Demographics Fetch"
 else
-    FETCH_DARWIN_HEME_FAIL=0
-    echo "committing darwin data for heme"
-    cd $MSK_HEMEPACT_DATA_HOME ; $HG_BINARY commit -m "Latest HEMEPACT Dataset: Darwin"
+    FETCH_DDP_HEME_FAIL=0
+    echo "committing ddp data"
+    cd $MSK_HEMEPACT_DATA_HOME ; $HG_BINARY commit -m "Latest HEMEPACT Dataset: DDP Demographics"
 fi
 
 if [ $IMPORT_STATUS_HEME -eq 0 ] ; then
@@ -334,38 +342,24 @@ if [ $IMPORT_STATUS_HEME -eq 0 ] ; then
     fi
 fi
 
-# For future use: when we want to replace darwin demographics attributes with ddp-fetched attributes
-#if [ $FETCH_CVR_HEME_FAIL -eq 0 ] ; then
-#    awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt | sort | uniq > $MSK_DMP_TMPDIR/hemepact_patient_list.txt
-#    $JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -o $MSK_HEMEPACT_DATA_HOME -s $MSK_DMP_TMPDIR/hemepact_patient_list.txt
-#    if [ $? -gt 0 ] ; then
-#        cd $MSK_HEMEPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
-#        sendPreImportFailureMessageMskPipelineLogsSlack "HEMEPACT DDP Fetch"
-#    else
-#        FETCH_DDP_HEME_FAIL=0
-#        echo "committing DDP data for heme"
-#        cd $MSK_HEMEPACT_DATA_HOME ; $HG_BINARY commit -m "Latest HEMEPACT Dataset: DDP demographics/timeline"
-#    fi
-#fi
-
 # -----------------------------------------------------------------------------------------------------------
 # RAINDANCE DATA FETCHES
 
-echo "fetching Darwin raindance data"
+# fetch ddp demographics data
+echo "fetching DDP demographics data for mskraindance..."
 echo $(date)
-# if darwin demographics row count less than or equal to default row count then set it to default value
-RAINDANCE_DARWIN_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $RAINDANCE_REDCAP_BACKUP/data_clinical_mskraindance_data_clinical_supp_darwin_demographics.txt)
-if [ $RAINDANCE_DARWIN_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DARWIN_DEMOGRAPHICS_ROW_COUNT ] ; then
-    RAINDANCE_DARWIN_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DARWIN_DEMOGRAPHICS_ROW_COUNT
-fi
-$JAVA_BINARY $JAVA_DARWIN_FETCHER_ARGS -d $MSK_RAINDANCE_DATA_HOME -s mskraindance -r $RAINDANCE_DARWIN_DEMOGRAPHICS_RECORD_COUNT
+
+mskraindance_dmp_pids_file=$MSK_DMP_TMPDIR/mskraindance_patient_list.txt
+awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_RAINDANCE_DATA_HOME/data_clinical_mskraindance_data_clinical.txt | sort | uniq > $mskraindance_dmp_pids_file
+##TO-DO: ADD ARG TO PASS IN "YESTERDAY'S" DEMOGRAHICS RECORD COUNT TO DDP TO ENSURE WE AREN'T OVERWRITING WITH INVALID DATA
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskraindance -s $mskraindance_dmp_pids_file -o $MSK_RAINDANCE_DATA_HOME
 if [ $? -gt 0 ] ; then
     cd $MSK_RAINDANCE_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
-    sendPreImportFailureMessageMskPipelineLogsSlack "RAINDANCE DARWIN Fetch"
+    sendPreImportFailureMessageMskPipelineLogsSlack "RAINDANCE DDP Demographics Fetch"
 else
-    FETCH_DARWIN_RAINDANCE_FAIL=0
-    echo "commting darwin data for raindance"
-    cd $MSK_RAINDANCE_DATA_HOME ; $HG_BINARY commit -m "Latest RAINDANCE Dataset: Darwin"
+    FETCH_DDP_RAINDANCE_FAIL=0
+    echo "committing ddp data"
+    cd $MSK_RAINDANCE_DATA_HOME ; $HG_BINARY commit -m "Latest RAINDANCE Dataset: DDP Demographics"
 fi
 
 if [ $IMPORT_STATUS_RAINDANCE -eq 0 ] ; then
@@ -394,38 +388,24 @@ if [ $IMPORT_STATUS_RAINDANCE -eq 0 ] ; then
     fi
 fi
 
-# For future use: when we want to replace darwin demographics attributes with ddp-fetched attributes
-#if [ $FETCH_CVR_RAINDANCE_FAIL -eq 0 ] ; then
-#    awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_RAINDANCE_DATA_HOME/data_clinical_mskraindance_data_clinical.txt | sort | uniq > $MSK_DMP_TMPDIR/mskraindance_patient_list.txt
-#    $JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -o $MSK_RAINDANCE_DATA_HOME -s $MSK_DMP_TMPDIR/mskraindance_patient_list.txt
-#    if [ $? -gt 0 ] ; then
-#        cd $MSK_RAINDANCE_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
-#        sendPreImportFailureMessageMskPipelineLogsSlack "RAINDANCE DDP Fetch"
-#    else
-#        FETCH_DDP_RAINDANCE_FAIL=0
-#        echo "committing DDP data for raindance"
-#        cd $MSK_RAINDANCE_DATA_HOME ; $HG_BINARY commit -m "Latest RAINDANCE Dataset: DDP demographics/timeline"
-#    fi
-#fi
-
 # -----------------------------------------------------------------------------------------------------------
 # ARCHER DATA FETCHES
 
-echo "fetching Darwin archer data"
+# fetch ddp demographics data
+echo "fetching DDP demographics data for mskarcher..."
 echo $(date)
-# if darwin demographics row count less than or equal to default row count then set it to default value
-ARCHER_DARWIN_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $ARCHER_REDCAP_BACKUP/data_clinical_mskarcher_data_clinical_supp_darwin_demographics.txt)
-if [ $ARCHER_DARWIN_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DARWIN_DEMOGRAPHICS_ROW_COUNT ] ; then
-    ARCHER_DARWIN_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DARWIN_DEMOGRAPHICS_ROW_COUNT
-fi
-$JAVA_BINARY $JAVA_DARWIN_FETCHER_ARGS -d $MSK_ARCHER_UNFILTERED_DATA_HOME -s mskarcher -r $ARCHER_DARWIN_DEMOGRAPHICS_RECORD_COUNT
+
+mskarcher_dmp_pids_file=$MSK_DMP_TMPDIR/mskarcher_patient_list.txt
+awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_ARCHER_UNFILTERED_DATA_HOME/data_clinical_mskarcher_data_clinical.txt | sort | uniq > $mskarcher_dmp_pids_file
+##TO-DO: ADD ARG TO PASS IN "YESTERDAY'S" DEMOGRAHICS RECORD COUNT TO DDP TO ENSURE WE AREN'T OVERWRITING WITH INVALID DATA
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskarcher -s $mskarcher_dmp_pids_file -o $MSK_ARCHER_UNFILTERED_DATA_HOME
 if [ $? -gt 0 ] ; then
     cd $MSK_ARCHER_UNFILTERED_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
-    sendPreImportFailureMessageMskPipelineLogsSlack "ARCHER_UNFILTERED DARWIN Fetch"
+    sendPreImportFailureMessageMskPipelineLogsSlack "ARCHER_UNFILTERED DDP Demographics Fetch"
 else
-    FETCH_DARWIN_ARCHER_FAIL=0
-    echo " committing darwin data for archer"
-    cd $MSK_ARCHER_UNFILTERED_DATA_HOME ; $HG_BINARY commit -m "Latest ARCHER_UNFILTERED Dataset: Darwin"
+    FETCH_DDP_ARCHER_FAIL=0
+    echo "committing ddp data"
+    cd $MSK_ARCHER_UNFILTERED_DATA_HOME ; $HG_BINARY commit -m "Latest ARCHER_UNFILTERED Dataset: DDP Demographics"
 fi
 
 if [ $IMPORT_STATUS_ARCHER -eq 0 ] ; then
@@ -454,20 +434,6 @@ if [ $IMPORT_STATUS_ARCHER -eq 0 ] ; then
         fi
     fi
 fi
-
-# For future use: when we want to replace darwin demographics attributes with ddp-fetched attributes
-#if [ $FETCH_CVR_ARCHER_FAIL -eq 0 ] ; then
-#    awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_ARCHER_UNFILTERED_DATA_HOME/data_clinical_mskarcher_data_clinical.txt | sort | uniq > $MSK_DMP_TMPDIR/mskarcher_patient_list.txt
-#    $JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -o $MSK_ARCHER_UNFILTERED_DATA_HOME -s $MSK_DMP_TMPDIR/mskarcher_patient_list.txt
-#    if [ $? -gt 0 ] ; then
-#        cd $MSK_ARCHER_UNFILTERED_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
-#        sendPreImportFailureMessageMskPipelineLogsSlack "ARCHER_UNFILTERED DDP Fetch"
-#    else
-#        FETCH_DDP_ARCHER_FAIL=0
-#        echo "committing DDP data for archer"
-#        cd $MSK_ARCHER_UNFILTERED_DATA_HOME ; $HG_BINARY commit -m "Latest ARCHER_UNFILTERED Dataset: DDP demographics/timeline"
-#    fi
-#fi
 
 # -----------------------------------------------------------------------------------------------------------
 # GENERATE CANCER TYPE CASE LISTS AND SUPP DATE ADDED FILES
@@ -557,6 +523,7 @@ fi
 
 # import newly fetched files into redcap
 echo "Starting import into redcap"
+echo $(date)
 
 ## MSKIMPACT imports
 
@@ -565,16 +532,16 @@ if [ $PERFORM_CRDB_FETCH -gt 0 ] && [ $FETCH_CRDB_IMPACT_FAIL -eq 0 ] ; then
     import_crdb_to_redcap
     if [ $? -gt 0 ] ; then
         #NOTE: we have decided to allow import of mskimpact project to proceed even when CRDB data has been lost from redcap (not setting IMPORT_STATUS_IMPACT)
-        sendPreImportFailureMessageMskPipelineLogsSlack "Mskimpact CRDB Redcap Import - Recovery Of Redcap Project Needed!"
+        sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT CRDB Redcap Import - Recovery Of Redcap Project Needed!"
     fi
 fi
 
 # imports mskimpact darwin data into redcap
-if [ $FETCH_DARWIN_IMPACT_FAIL -eq 0 ] ; then
-    import_mskimpact_darwin_to_redcap
+if [ $FETCH_DARWIN_CASISIS_FAIL -eq 0 ] ; then
+    import_mskimpact_darwin_caisis_to_redcap
     if [ $? -gt 0 ] ; then
         IMPORT_STATUS_IMPACT=1
-        sendPreImportFailureMessageMskPipelineLogsSlack "Mskimpact Darwin Redcap Import"
+        sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT Darwin CAISIS Redcap Import"
     fi
 fi
 
@@ -583,7 +550,7 @@ if [ $FETCH_DDP_IMPACT_FAIL -eq 0 ] ; then
     import_mskimpact_ddp_to_redcap
     if [ $? -gt 0 ] ; then
         IMPORT_STATUS_IMPACT=1
-        sendPreImportFailureMessageMskPipelineLogsSlack "Mskimpact DDP Redcap Import"
+        sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT DDP Redcap Import"
     fi
 fi
 
@@ -592,70 +559,50 @@ if [ $FETCH_CVR_IMPACT_FAIL -eq 0 ] ; then
     import_mskimpact_cvr_to_redcap
     if [ $? -gt 0 ] ; then
         IMPORT_STATUS_IMPACT=1
-        sendPreImportFailureMessageMskPipelineLogsSlack "Mskimpact CVR Redcap Import"
+        sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT CVR Redcap Import"
     fi
     if [ $EXPORT_SUPP_DATE_IMPACT_FAIL -eq 0 ] ; then
         import_mskimpact_supp_date_to_redcap
         if [ $? -gt 0 ] ; then
-            sendPreImportFailureMessageMskPipelineLogsSlack "Mskimpact Supp Date Redcap Import. Project is now empty, data restoration required"
+            sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT Supp Date Redcap Import. Project is now empty, data restoration required"
         fi
     fi
 fi
 
 ## HEMEPACT imports
 
-# imports hemepact darwin data into redcap
-if [ $FETCH_DARWIN_HEME_FAIL -eq 0 ] ; then
-    import_hemepact_darwin_to_redcap
-    if [ $? -gt 0 ] ; then
-        IMPORT_STATUS_HEME=1
-        sendPreImportFailureMessageMskPipelineLogsSlack "Hemepact Darwin Redcap Import"
-    fi
+if [ $FETCH_DDP_HEME_FAIL -eq 0 ] ; then
+   import_hemepact_ddp_to_redcap
+   if [$? -gt 0 ] ; then
+       IMPORT_STATUS_HEME=1
+       sendPreImportFailureMessageMskPipelineLogsSlack "HEMEPACT DDP Redcap Import"
+   fi
 fi
-
-# For future use: imports hemepact ddp data into redcap
-#if [ $FETCH_DDP_HEME_FAIL -eq 0 ] ; then
-#    import_hemepact_ddp_to_redcap
-#    if [$? -gt 0 ] ; then
-#        IMPORT_STATUS_HEME=1
-#        sendPreImportFailureMessageMskPipelineLogsSlack "Hemepact DDP Redcap Import"
-#    fi
-#fi
 
 # imports hemepact cvr data into redcap
 if [ $FETCH_CVR_HEME_FAIL -eq 0 ] ; then
     import_hemepact_cvr_to_redcap
     if [ $? -gt 0 ] ; then
         IMPORT_STATUS_HEME=1
-        sendPreImportFailureMessageMskPipelineLogsSlack "Hemepact CVR Redcap Import"
+        sendPreImportFailureMessageMskPipelineLogsSlack "HEMEPACT CVR Redcap Import"
     fi
     if [ $EXPORT_SUPP_DATE_HEME_FAIL -eq 0 ] ; then
         import_hemepact_supp_date_to_redcap
         if [ $? -gt 0 ] ; then
-            sendPreImportFailureMessageMskPipelineLogsSlack "Mskimpact Supp Date Redcap Import. Project is now empty, data restoration required"
+            sendPreImportFailureMessageMskPipelineLogsSlack "HEMEPACT Supp Date Redcap Import. Project is now empty, data restoration required"
         fi
     fi
 fi
 
 ## ARCHER imports
 
-# imports archer darwin data into redcap
-if [ $FETCH_DARWIN_ARCHER_FAIL -eq 0 ] ; then
-    import_archer_darwin_to_redcap
-    if [ $? -gt 0 ] ; then
-        IMPORT_STATUS_ARCHER=1
-        sendPreImportFailureMessageMskPipelineLogsSlack "ARCHER_UNFILTERED Darwin Redcap Import"
-    fi
+if [ $FETCH_DDP_ARCHER_FAIL -eq 0 ] ; then
+   import_archer_ddp_to_redcap
+   if [$? -gt 0 ] ; then
+       IMPORT_STATUS_ARCHER=1
+       sendPreImportFailureMessageMskPipelineLogsSlack "ARCHER_UNFILTERED DDP Redcap Import"
+   fi
 fi
-
-# For future use: imports archer ddp data into redcap
-#if [ $FETCH_DDP_ARCHER_FAIL -eq 0 ] ; then
-#    import_archer_ddp_to_redcap
-#    if [$? -gt 0 ] ; then
-#        IMPORT_STATUS_ARCHER=1
-#        sendPreImportFailureMessageMskPipelineLogsSlack "ARCHER_UNFILTERED DDP Redcap Import"
-#    fi
-#fi
 
 # imports archer cvr data into redcap
 if [ $FETCH_CVR_ARCHER_FAIL -eq 0 ] ; then
@@ -674,35 +621,25 @@ fi
 
 ## RAINDANCE imports
 
-# imports raindance darwin data into redcap
-if [ $FETCH_DARWIN_RAINDANCE_FAIL -eq 0 ] ; then
-    import_raindance_darwin_to_redcap
-    if [ $? -gt 0 ] ; then
-        IMPORT_STATUS_RAINDANCE=1
-        sendPreImportFailureMessageMskPipelineLogsSlack "Raindance Darwin Redcap Import"
-    fi
+if [ $FETCH_DDP_RAINDANCE_FAIL -eq 0 ] ; then
+   import_raindance_ddp_to_redcap
+   if [$? -gt 0 ] ; then
+       IMPORT_STATUS_RAINDANCE=1
+       sendPreImportFailureMessageMskPipelineLogsSlack "RAINDANCE DDP Redcap Import"
+   fi
 fi
-
-# For future use: imports raindance ddp data into redcap
-#if [ $FETCH_DDP_RAINDANCE_FAIL -eq 0 ] ; then
-#    import_raindance_ddp_to_redcap
-#    if [$? -gt 0 ] ; then
-#        IMPORT_STATUS_RAINDANCE=1
-#        sendPreImportFailureMessageMskPipelineLogsSlack "RAINDANCE DDP Redcap Import"
-#    fi
-#fi
 
 # imports raindance cvr data into redcap
 if [ $FETCH_CVR_RAINDANCE_FAIL -eq 0 ] ; then
     import_raindance_cvr_to_redcap
     if [ $? -gt 0 ] ; then
         IMPORT_STATUS_RAINDANCE=1
-        sendPreImportFailureMessageMskPipelineLogsSlack "Raindance CVR Redcap Import"
+        sendPreImportFailureMessageMskPipelineLogsSlack "RAINDANCE CVR Redcap Import"
     fi
     if [ $EXPORT_SUPP_DATE_RAINDANCE_FAIL -eq 0 ] ; then
         import_raindance_supp_date_to_redcap
         if [ $? -gt 0 ] ; then
-            sendPreImportFailureMessageMskPipelineLogsSlack "Raindance Supp Date Redcap Import. Project is now empty, data restoration required"
+            sendPreImportFailureMessageMskPipelineLogsSlack "RAINDANCE Supp Date Redcap Import. Project is now empty, data restoration required"
         fi
     fi
 fi
@@ -734,7 +671,7 @@ $HG_BINARY commit -m "Raw clinical and timeline file cleanup: MSKIMPACT, HEMEPAC
 
 echo "exporting impact data from redcap"
 if [ $IMPORT_STATUS_IMPACT -eq 0 ] ; then
-    export_stable_id_from_redcap mskimpact $MSK_IMPACT_DATA_HOME mskimpact_data_clinical_ddp_demographics,mskimpact_timeline_radiation_ddp,mskimpact_timeline_chemotherapy_ddp,mskimpact_timeline_surgery_ddp
+    export_stable_id_from_redcap mskimpact $MSK_IMPACT_DATA_HOME mskimpact_data_clinical_ddp_demographics_pediatrics,mskimpact_timeline_radiation_ddp,mskimpact_timeline_chemotherapy_ddp,mskimpact_timeline_surgery_ddp
     if [ $? -gt 0 ] ; then
         IMPORT_STATUS_IMPACT=1
         cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
@@ -1124,7 +1061,7 @@ fi
 # tmp directory for subsetting purposes to prevent any conflicts and allow easier debugging of any issues that arise
 MSKIMPACT_PED_TMP_DIR=$MSK_DMP_TMPDIR/mskimpact_ped_tmp
 rsync -a $MSK_IMPACT_DATA_HOME/* $MSKIMPACT_PED_TMP_DIR
-export_stable_id_from_redcap mskimpact $MSKIMPACT_PED_TMP_DIR mskimpact_clinical_caisis,mskimpact_timeline_surgery_caisis,mskimpact_timeline_status_caisis,mskimpact_timeline_treatment_caisis,mskimpact_timeline_imaging_caisis,mskimpact_timeline_specimen_caisis,mskimpact_timeline_chemotherapy_ddp,mskimpact_timeline_surgery_ddp
+export_stable_id_from_redcap mskimpact $MSKIMPACT_PED_TMP_DIR mskimpact_clinical_caisis,mskimpact_timeline_surgery_caisis,mskimpact_timeline_status_caisis,mskimpact_timeline_treatment_caisis,mskimpact_timeline_imaging_caisis,mskimpact_timeline_specimen_caisis,mskimpact_data_clinical_ddp_demographics,mskimpact_timeline_chemotherapy_ddp,mskimpact_timeline_surgery_ddp
 if [ $? -gt 0 ] ; then
     echo "MSKIMPACT redcap export for MSKIMPACT_PED failed! Study will not be updated in the portal"
     sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT_PED redcap export"

--- a/import-scripts/subset-impact-data.sh
+++ b/import-scripts/subset-impact-data.sh
@@ -61,9 +61,9 @@ MERGE_SCRIPT_FAILURE=0
 ADD_METADATA_HEADERS_FAILURE=0
 
 if [ $STUDY_ID == "genie" ]; then
-    # in the case of genie data, the input data directory must be the mskimpact data home, where we expect to see darwin_naaccr.txt
-    # copy the darwin genie files to the output directory with different filenames
-    cp $INPUT_DIRECTORY/darwin/darwin_naaccr.txt $OUTPUT_DIRECTORY/data_clinical_supp_patient.txt
+    # in the case of genie data, the input data directory must be the mskimpact data home, where we expect to see ddp_naaccr.txt
+    # copy the ddp genie files to the output directory with different filenames
+    cp $INPUT_DIRECTORY/ddp/ddp_naaccr.txt $OUTPUT_DIRECTORY/data_clinical_supp_patient.txt
     cut -f1,2 $CLINICAL_FILENAME | grep -v "^#" > $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt
 
     # run the generate clinical subset script to generate list of sample ids to subset from impact data - subset of sample ids will be written to given $SUBSET_FILENAME
@@ -76,9 +76,9 @@ if [ $STUDY_ID == "genie" ]; then
         # starting in Nov 2018 releases, all vital status information will be removed from patient file and placed in a separate file:
         # get the patients from the filtered set of patients from the generate-clinical-subset.py call and expand file with the vital status columns
         cut -f1 $OUTPUT_DIRECTORY/data_clinical_supp_patient.txt > $OUTPUT_DIRECTORY/vital_status.txt
-        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/vital_status.txt" --clinical-supp-file="$INPUT_DIRECTORY/darwin/darwin_vital_status.txt" --fields="YEAR_CONTACT,YEAR_DEATH,INT_CONTACT,INT_DOD,DEAD" --identifier-column-name="PATIENT_ID"
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/expand-clinical-data.py --study-id="genie" --clinical-file="$OUTPUT_DIRECTORY/vital_status.txt" --clinical-supp-file="$INPUT_DIRECTORY/ddp/ddp_vital_status.txt" --fields="YEAR_CONTACT,YEAR_DEATH,INT_CONTACT,INT_DOD,DEAD" --identifier-column-name="PATIENT_ID"
         if [ $? -gt 0 ] ; then
-            echo "Failed to expand $OUTPUT_DIRECTORY/vital_status.txt with YEAR_CONTACT, YEAR_DEATH, INT_CONTACT, INT_DOD, DEAD from $INPUT_DIRECTORY/darwin/darwin_vital_status.txt. Exiting..."
+            echo "Failed to expand $OUTPUT_DIRECTORY/vital_status.txt with YEAR_CONTACT, YEAR_DEATH, INT_CONTACT, INT_DOD, DEAD from $INPUT_DIRECTORY/ddp/ddp_vital_status.txt. Exiting..."
             exit 2
         fi
         # expand data_clinical_supp_sample.txt with ONCOTREE_CODE, SAMPLE_TYPE, GENE_PANEL from data_clinical.txt
@@ -91,7 +91,7 @@ if [ $STUDY_ID == "genie" ]; then
 
         # add age at seq report using cvr/seq_date.txt
         echo "Adding AGE_AT_SEQ_REPORT to $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt"
-        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/add-age-at-seq-report.py --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --seq-date-file="$INPUT_DIRECTORY/cvr/seq_date.txt" --age-file="$INPUT_DIRECTORY/darwin/darwin_age.txt" --convert-to-days="true"
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/add-age-at-seq-report.py --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --seq-date-file="$INPUT_DIRECTORY/cvr/seq_date.txt" --age-file="$INPUT_DIRECTORY/ddp/ddp_age.txt" --convert-to-days="true"
         if [ $? -gt 0 ] ; then
             echo "Failed to add AGE_AT_SEQ_REPORT to $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt using $INPUT_DIRECTORY/cvr/seq_date.txt. Exiting..."
             exit 2l


### PR DESCRIPTION
~**NOTE: Dependent on CASIS mode PR #564**~ this PR was merged to the dev branch

**NOTE: Second commit is going to be kept separate since it has fixes to the PDX subset and merge test data for unit testing/integration tests and is not related to the DDP/Darwin changes  in this PR**

Script updates to start fetching demographics data from DDP.

In total there are 5 calls to DDP fetcher: once for each primary cohort (impact, heme, etc.) to get demographics data only and once call for pediatric cohort to fetch all clinical and timeline data from DDP

TO-DO list documented in issue #565 


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>