### PR TITLE
Annotate PDX MAFs

### DIFF
--- a/import-scripts/automation-environment.sh
+++ b/import-scripts/automation-environment.sh
@@ -28,6 +28,7 @@ export CMO_PIPELINES_HOME=$PORTAL_GIT_HOME/cmo-pipelines
 export PIPELINES_HOME=$PORTAL_GIT_HOME/pipelines
 export CBIOPORTAL_HOME=$PORTAL_GIT_HOME/cbioportal
 export GENOME_NEXUS_ANNOTATOR_HOME=$PORTAL_GIT_HOME/genome-nexus-annotation-pipeline
+export ANNOTATOR_JAR=$GENOME_NEXUS_ANNOTATOR_HOME/annotationPipeline/target/annotationPipeline*.jar
 export ONCO_HOME=$PORTAL_GIT_HOME/oncotree
 export CDD_HOME=$PORTAL_GIT_HOME/clinical-data-dictionary
 export DDP_CREDENTIALS_FILE=$PORTAL_HOME/pipelines-credentials/application-secure.properties

--- a/import-scripts/import-pdx-data.sh
+++ b/import-scripts/import-pdx-data.sh
@@ -148,8 +148,8 @@ fi
 
 . $PATH_TO_AUTOMATION_SCRIPT
 
-if [ -z $BIC_DATA_HOME ] | [ -z $PRIVATE_DATA_HOME ] | [ -z $PDX_DATA_HOME ] | [ -z $HG_BINARY ] | [ -z $PYTHON_BINARY ] | [ -z $DATAHUB_DATA_HOME ] ; then
-    message="could not run import-pdx-data.sh: automation-environment.sh script must be run in order to set needed environment variables (like BIC_DATA_HOME, PDX_DATA_HOME, ...)"
+if [ -z $BIC_DATA_HOME ] | [ -z $PRIVATE_DATA_HOME ] | [ -z $PDX_DATA_HOME ] | [ -z $HG_BINARY ] | [ -z $PYTHON_BINARY ] | [ -z $DATAHUB_DATA_HOME ] | [ -z $ANNOTATOR_JAR ] ; then
+    message="could not run import-pdx-data.sh: automation-environment.sh script must be run in order to set needed environment variables (like BIC_DATA_HOME, PDX_DATA_HOME, ANNOTATOR_JAR...)"
     echo ${message}
     echo -e "${message}" |  mail -s "import-pdx-data failed to run." $pipelines_email_list
     sendFailureMessageMskPipelineLogsSlack "CRDB PDX Pipeline Failure"
@@ -270,7 +270,7 @@ if [ $CRDB_PDX_FETCH_SUCCESS -ne 0 ] ; then
     mapping_filename="source_to_destination_mappings.txt"
     clinical_annotation_mapping_filename="clinical_annotations_mappings.txt"
     scripts_directory="$PORTAL_HOME/scripts"
-    $PYTHON_BINARY $PORTAL_HOME/scripts/subset_and_merge_crdb_pdx_studies.py --mapping-file $mapping_filename --root-directory $PDX_DATA_HOME --lib $scripts_directory --data-source-directories $DATAHUB_DATA_HOME,$BIC_DATA_HOME,$PRIVATE_DATA_HOME,$DMP_DATA_HOME --fetch-directory $CRDB_FETCHER_PDX_HOME --temp-directory $CRDB_PDX_TMPDIR --warning-file $SUBSET_AND_MERGE_WARNINGS_FILENAME --clinical-annotation-mapping-file $clinical_annotation_mapping_filename
+    $PYTHON_BINARY $PORTAL_HOME/scripts/subset_and_merge_crdb_pdx_studies.py --mapping-file $mapping_filename --root-directory $PDX_DATA_HOME --lib $scripts_directory --data-source-directories $DATAHUB_DATA_HOME,$BIC_DATA_HOME,$PRIVATE_DATA_HOME,$DMP_DATA_HOME --fetch-directory $CRDB_FETCHER_PDX_HOME --temp-directory $CRDB_PDX_TMPDIR --warning-file $SUBSET_AND_MERGE_WARNINGS_FILENAME --clinical-annotation-mapping-file $clinical_annotation_mapping_filename --annotator $ANNOTATOR_JAR
     if [ $? -ne 0 ] ; then
         echo "error: subset_and_merge_crdb_pdx_studies.py exited with non zero status"
         sendFailureMessageMskPipelineLogsSlack "CRDB PDX Subset-And-Merge Script Failure"

--- a/import-scripts/pom.xml
+++ b/import-scripts/pom.xml
@@ -46,6 +46,7 @@
           </arguments>
           <environmentVariables>
             <PYTHONPATH>$PYTHONPATH</PYTHONPATH>
+            <ANNOTATOR_JAR>${ANNOTATOR_JAR}</ANNOTATOR_JAR>
           </environmentVariables>
         </configuration>
       </plugin>

--- a/integration-tests/set_application_properties.sh
+++ b/integration-tests/set_application_properties.sh
@@ -15,3 +15,6 @@ rsync $JENKINS_PROPERTIES_DIRECTORY/fetch-crdb/$APPLICATION_PROPERTIES $CMO_PIPE
 rsync $JENKINS_PROPERTIES_DIRECTORY/fetch-ddp/$APPLICATION_PROPERTIES $CMO_PIPELINES_DIRECTORY/ddp/ddp_pipeline/src/main/resources
 rsync $JENKINS_PROPERTIES_DIRECTORY/fetch-ddp/*.json $CMO_PIPELINES_DIRECTORY/ddp/ddp_pipeline/src/main/resources
 rsync $JENKINS_PIPELINES_CREDENTIALS/application-secure.properties $CMO_PIPELINES_DIRECTORY/ddp/ddp_pipeline/src/main/resources
+
+cp $JENKINS_USER_HOME_DIRECTORY/jobs/genome-nexus-annotation-pipeline/workspace/annotationPipeline/target/annotationPipeline*.jar $CMO_PIPELINES_DIRECTORY/annotator.jar
+


### PR DESCRIPTION
1. Run annotator as post-processing step in PDX pipeline
- MAFs in each destination directory are annotated and written to <destination_directory>/data_mutations_annotated.txt
- If the annotation is successful then the annotated MAF replaces the original MAF
- If annotation fails then the annotated MAF file is removed if it exists and the original MAF is kept in place and the warning file is updated stating that the detination study failed during the annotation step

2. Added integration tests for annotating MAFs
- HGVSp_Short column is dropped from the original MAF and the MAF is copied to <destination_directory>/orig_data_mutations_extended.txt since the annotation step will replace the original MAF with the annotated MAF contents
- MAF is annotated and the test checks that HGVSp_Short exists in the annotated MAF header but not the original MAF header
- Test also checks that there exists valid values in the HGVSp_Short column of the annotated MAF (meaning there are non-empty, non-NA values in that column)

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>