### PR TITLE
Use seq_date txt file to get OS_MONTHS

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/BatchConfiguration.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/BatchConfiguration.java
@@ -124,7 +124,8 @@ public class BatchConfiguration {
     @Bean
     public Job ddpCohortJob() {
         return jobBuilderFactory.get(DDP_COHORT_JOB)
-                .start(ddpStep())
+                .start(ddpSeqDateStep())
+                .next(ddpStep())
                 .next(ddpSortStep())
                 .next(ddpEmailStep())
                 .build();
@@ -234,6 +235,19 @@ public class BatchConfiguration {
         delegates.add(suppNaaccrMappingsWriter());
         writer.setDelegates(delegates);
         return writer;
+    }
+
+    @Bean
+    public Step ddpSeqDateStep() {
+        return stepBuilderFactory.get("ddpSeqDateStep")
+        .tasklet(ddpSeqDateTasklet())
+        .build();
+    }
+
+    @Bean
+    @StepScope
+    public Tasklet ddpSeqDateTasklet() {
+        return new DDPSeqDateTasklet();
     }
 
     @Bean

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/ClinicalProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/ClinicalProcessor.java
@@ -54,12 +54,14 @@ public class ClinicalProcessor implements ItemProcessor<DDPCompositeRecord, Stri
     private Boolean includeChemotherapy;
     @Value("#{jobParameters[includeSurgery]}")
     private Boolean includeSurgery;
+    @Value("#{jobParameters[includeSurvival]}")
+    private Boolean includeSurvival;
     private final Logger LOG = Logger.getLogger(ClinicalProcessor.class);
 
     @Override
     public String process(DDPCompositeRecord compositeRecord) throws Exception {
         String record = null;
-        ClinicalRecord clinicalRecord = new ClinicalRecord(compositeRecord);
+        ClinicalRecord clinicalRecord = new ClinicalRecord(compositeRecord, includeSurvival);
         try {
             record = DDPUtils.constructRecord(clinicalRecord, includeDiagnosis, includeRadiation, includeChemotherapy, includeSurgery);
         }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPEmailTasklet.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPEmailTasklet.java
@@ -33,6 +33,7 @@ package org.mskcc.cmo.ks.ddp.pipeline;
 
 import org.cbioportal.cmo.pipelines.common.util.EmailUtil;
 import org.mskcc.cmo.ks.ddp.pipeline.util.DDPPatientListUtil;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
 
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,6 +80,10 @@ public class DDPEmailTasklet implements Tasklet {
         Set<String> patientsMissingDiagnoses = ddpPatientListUtil.getPatientsMissingDiagnoses();
         if (patientsMissingDiagnoses.size() > 0) {
             body.append(constructMissingPatientsText(patientsMissingDiagnoses, "patients that were included are missing diagnoses"));
+        }
+        Set<String> patientsMissingSurvival = DDPUtils.getPatientsMissingSurvival();
+        if (patientsMissingSurvival.size() > 0) { // size will be zero if we either did not include survival information or if every patient has it
+            body.append(constructMissingPatientsText(patientsMissingSurvival, "patients that were included are missing survival information"));
         }
         if (!body.toString().isEmpty()) {
             emailUtil.sendEmailToDefaultRecipient(subject, body.toString());

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTasklet.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTasklet.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.mskcc.cmo.ks.ddp.pipeline;
+
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+/**
+ *
+ * @author Manda Wilson
+ */
+public class DDPSeqDateTasklet implements Tasklet {
+
+    @Value("#{jobParameters[seqDateFilename]}")
+    private String seqDateFilename;
+    @Value("#{jobParameters[includeSurvival]}")
+    private Boolean includeSurvival;
+
+    private final Logger LOG = Logger.getLogger(DDPSeqDateTasklet.class);
+
+    private static final String PATIENT_ID_COLUMN_LABEL = "PATIENT_ID";
+    private static final String SAMPLE_ID_COLUMN_LABEL = "SAMPLE_ID";
+    private static final String SEQ_DATE_COLUMN_LABEL = "SEQ_DATE";
+    private static final List<String> EXPECTED_SEQ_DATE_FILE_HEADER = Arrays.asList(SAMPLE_ID_COLUMN_LABEL, PATIENT_ID_COLUMN_LABEL, SEQ_DATE_COLUMN_LABEL);
+    private static final int MAX_ERRORS_TO_SHOW = 30;
+
+    @Override
+    public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext) throws Exception {
+        if (!StringUtils.isEmpty(seqDateFilename)) {
+            LOG.debug("Seq date file is: " + seqDateFilename);
+            BufferedReader reader = new BufferedReader(new FileReader(seqDateFilename));
+            // pass reader as parameter so we can mock it in tests
+            DDPUtils.setPatientFirstSeqDateMap(getFirstSeqDatePerPatientFromFile(seqDateFilename, reader));
+            DDPUtils.setUseSeqDateOsMonthsMethod(Boolean.TRUE);
+        } else {
+            LOG.debug("No seq date file given.");
+        }
+        return RepeatStatus.FINISHED;
+    }
+
+    public Map<String, Date> getFirstSeqDatePerPatientFromFile(String filename, BufferedReader reader) throws IOException {
+        // this method is public for unit testing
+        Map <String, Date> patientFirstSeqDateMap = new HashMap<String, Date>();
+        // skip first line (header)
+        List<String> header = Arrays.asList(reader.readLine().split("\t"));
+        int dmpPatientIdColumnIndex = header.indexOf(PATIENT_ID_COLUMN_LABEL);
+        int seqDateColumnIndex = header.indexOf(SEQ_DATE_COLUMN_LABEL);
+        Collections.sort(EXPECTED_SEQ_DATE_FILE_HEADER);
+        Collections.sort(header);
+        if (dmpPatientIdColumnIndex == -1 || seqDateColumnIndex == -1 || !EXPECTED_SEQ_DATE_FILE_HEADER.equals(header)) {
+            LOG.warn("Invalid header in '" + filename + "', expected '" + String.join(",", EXPECTED_SEQ_DATE_FILE_HEADER) + "', found '" + String.join(",", header)+ "'");
+            return patientFirstSeqDateMap; // empty map
+        } 
+        // e.g. Wed, 16 Mar 2016 18:09:02 GMT
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+        String line;
+        List<String> warnings = new ArrayList<String>();
+        while ((line = reader.readLine()) != null) {
+            String[] record = line.split("\t");
+            String dmpPatientId = record[dmpPatientIdColumnIndex];
+            String seqDateString = record[seqDateColumnIndex];
+            if (!StringUtils.isEmpty(seqDateString)) {
+                try {
+                    Date parsedRecordSeqDate = simpleDateFormat.parse(seqDateString);
+                    if (!patientFirstSeqDateMap.containsKey(dmpPatientId) || parsedRecordSeqDate.before(patientFirstSeqDateMap.get(dmpPatientId))) {
+                        patientFirstSeqDateMap.put(dmpPatientId, parsedRecordSeqDate);
+                    }
+                } catch (ParseException pe) {
+                    // do nothing, handle empty records later
+                    warnings.add("Invalid date format: '" + seqDateString + "' for sample '" + record[0] +"'");
+                }
+            } else {
+                warnings.add("Empty date: '" + seqDateString + "' for sample '" + record[0] +"'");
+            }
+        }
+        reader.close();
+        if (warnings.size() > 0) {
+            LOG.warn(warnings.size() + " sample(s) found with invalid records.  The first " + MAX_ERRORS_TO_SHOW + " are listed below:");
+            for (int w = 0; w < warnings.size() && w < MAX_ERRORS_TO_SHOW; w++) {
+                LOG.warn(warnings.get(w)); 
+            }
+        }
+        return patientFirstSeqDateMap;
+    }
+}

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/ClinicalRecord.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/ClinicalRecord.java
@@ -56,10 +56,11 @@ public class ClinicalRecord {
     private String RADIATION_THERAPY;
     private String CHEMOTHERAPY;
     private String SURGERY;
+    private Boolean includeSurvival;
 
     public ClinicalRecord(){}
 
-    public ClinicalRecord(DDPCompositeRecord compositeRecord) throws ParseException {
+    public ClinicalRecord(DDPCompositeRecord compositeRecord, Boolean includeSurvival) throws ParseException {
         this.PATIENT_ID = compositeRecord.getDmpPatientId();
         this.AGE_CURRENT = DDPUtils.resolvePatientCurrentAge(compositeRecord);
         this.RACE = compositeRecord.getPatientRace() == null ? "NA" : compositeRecord.getPatientRace();
@@ -68,7 +69,7 @@ public class ClinicalRecord {
         this.ETHNICITY = compositeRecord.getPatientEthnicity() == null ? "NA" : compositeRecord.getPatientEthnicity();;
         this.OS_STATUS = DDPUtils.resolveOsStatus(compositeRecord);
         this.PED_IND = DDPUtils.resolvePediatricCohortPatientStatus(compositeRecord.getPediatricPatientStatus());
-        this.OS_MONTHS = DDPUtils.resolveOsMonths(OS_STATUS, compositeRecord);
+        this.OS_MONTHS = includeSurvival != null && includeSurvival ? DDPUtils.resolveOsMonths(OS_STATUS, compositeRecord) : "NA";
         this.RADIATION_THERAPY = compositeRecord.hasReceivedRadiation() ? "Yes" : "No";
         this.CHEMOTHERAPY = compositeRecord.hasReceivedChemo() ? "Yes" : "No";
         this.SURGERY = compositeRecord.hasReceivedSurgery() ? "Yes" : "No";
@@ -262,11 +263,10 @@ public class ClinicalRecord {
         fieldNames.add("ETHNICITY");
         fieldNames.add("OS_STATUS");
         fieldNames.add("PED_IND");
-        // OS_MONTHS depends on fields from the diagnosis query
-        // so if querying diagnosis is turned off all fields will be NA
-        if (includeDiagnosis) {
-            fieldNames.add("OS_MONTHS");
-        }
+        // OS_MONTHS depends on fields from the diagnosis query OR seq_date.txt
+        // so if querying diagnosis is turned off and we do not get a seq_date.txt file
+        // then all fields will be NA
+        fieldNames.add("OS_MONTHS");
         if (includeRadiation) {
             fieldNames.add("RADIATION_THERAPY");
         }

--- a/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTaskletTest.java
+++ b/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTaskletTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline;
+
+import java.io.BufferedReader;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.Test;
+import org.mockito.*;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ *
+ * @author Manda Wilson
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes={DDPSeqDateTaskletTestConfiguration.class})
+public class DDPSeqDateTaskletTest {
+
+    @Test
+    public void testGetFirstSeqDatePerPatientFromFileInvalidHeader() throws Exception {
+        BufferedReader mockBufferedReader = Mockito.mock(BufferedReader.class);
+        Mockito.when(mockBufferedReader.readLine()).thenReturn("BLAH").thenReturn("SAMPLE_1\tPATIENT_1\tMon, 01 Oct 2018 15:09:02 GMT").thenReturn(null);
+        DDPSeqDateTasklet tasklet = new DDPSeqDateTasklet();
+        Map<String, Date> actualPatientFirstSeqDateMap = tasklet.getFirstSeqDatePerPatientFromFile("filename", mockBufferedReader);
+        Assert.assertTrue("Expected an empty map because of an invalid header", actualPatientFirstSeqDateMap.size() == 0);
+    }
+
+    @Test
+    public void testGetFirstSeqDatePerPatientFromFile() throws Exception {
+        BufferedReader mockBufferedReader = Mockito.mock(BufferedReader.class);
+        Mockito.when(mockBufferedReader.readLine())
+            .thenReturn("SAMPLE_ID\tPATIENT_ID\tSEQ_DATE")
+            .thenReturn("SAMPLE_1\tPATIENT_1\tMon, 01 Oct 2018 15:09:02 GMT")
+            .thenReturn("SAMPLE_2\tPATIENT_2\tMon, 11 Jun 2018 15:20:33 GMT")
+            .thenReturn("SAMPLE_3\tPATIENT_3\tFri, 23 Nov 2018 15:01:19 GMT")
+            .thenReturn("SAMPLE_4\tPATIENT_1\tSat, 20 Apr 2019 22:01:22 GMT")
+            .thenReturn("SAMPLE_5\tPATIENT_2\tMon, 30 Mar 2015 17:21:08 GMT")
+            .thenReturn("SAMPLE_6\tPATIENT_3\tMon, 22 Oct 2018 15:33:15 GMT")
+            .thenReturn("SAMPLE_7\tPATIENT_1\tFri, 23 Nov 2018 15:01:19 GMT")
+            .thenReturn("SAMPLE_8\tPATIENT_2\tMon, 01 Oct 2018 15:09:02 GMT")
+            .thenReturn("SAMPLE_9\tPATIENT_4\tTes, 14 Feb 2014 17:21:03 GMT") // invalid date, this patient should not have a seq date in map
+            .thenReturn("SAMPLE_9\tPATIENT_3\tFri, 14 Feb 2014 17:21:03 GMT")
+            .thenReturn(null);
+        DDPSeqDateTasklet tasklet = new DDPSeqDateTasklet();
+        Map<String, Date> actualPatientFirstSeqDateMap = tasklet.getFirstSeqDatePerPatientFromFile("filename", mockBufferedReader);
+        Map<String, Date> expectedPatientFirstSeqDateMap = new HashMap<String, Date>();
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+        expectedPatientFirstSeqDateMap.put("PATIENT_1", simpleDateFormat.parse("Mon, 01 Oct 2018 15:09:02 GMT")); 
+        expectedPatientFirstSeqDateMap.put("PATIENT_2", simpleDateFormat.parse("Mon, 30 Mar 2015 17:21:08 GMT"));
+        expectedPatientFirstSeqDateMap.put("PATIENT_3", simpleDateFormat.parse("Fri, 14 Feb 2014 17:21:03 GMT"));
+        Assert.assertEquals(expectedPatientFirstSeqDateMap, actualPatientFirstSeqDateMap);
+    }
+}

--- a/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTaskletTestConfiguration.java
+++ b/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTaskletTestConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cmo.ks.ddp.pipeline;
+
+import org.springframework.context.annotation.*;
+
+@Configuration
+public class DDPSeqDateTaskletTestConfiguration {
+    // TO-DO: Get rid of DDPSeqDateTaskletTestConfiguration if not going to be expanded
+}

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -254,7 +254,7 @@ echo $(date)
 mskimpact_dmp_pids_file=$MSK_DMP_TMPDIR/mskimpact_patient_list.txt
 awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt | sort | uniq > $mskimpact_dmp_pids_file
 ##TO-DO: ADD ARG TO PASS IN "YESTERDAY'S" DEMOGRAHICS RECORD COUNT TO DDP TO ENSURE WE AREN'T OVERWRITING WITH INVALID DATA
-$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact -s $mskimpact_dmp_pids_file -o $MSK_IMPACT_DATA_HOME
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact -p $mskimpact_dmp_pids_file -s $MSK_IMPACT_DATA_HOME/cvr/seq_date.txt -f survival -o $MSK_IMPACT_DATA_HOME
 if [ $? -gt 0 ] ; then
     cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
     sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT DDP Demographics Fetch"
@@ -269,7 +269,7 @@ if [ $FETCH_DDP_IMPACT_FAIL -eq 0 ] ; then
     awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PED_IND"] == "Yes") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_ddp.txt | sort | uniq > $MSK_DMP_TMPDIR/mskimpact_ped_patient_list.txt
     # override default ddp clinical filename so that pediatric demographics file does not conflict with mskimpact demographics file
     DDP_PEDIATRIC_PROP_OVERRIDES="-Dddp.clinical_filename=data_clinical_ddp_pediatrics.txt"
-    $JAVA_BINARY $DDP_PEDIATRIC_PROP_OVERRIDES $JAVA_DDP_FETCHER_ARGS -o $MSK_IMPACT_DATA_HOME -s $MSK_DMP_TMPDIR/mskimpact_ped_patient_list.txt -f diagnosis,radiation,chemotherapy,surgery
+    $JAVA_BINARY $DDP_PEDIATRIC_PROP_OVERRIDES $JAVA_DDP_FETCHER_ARGS -o $MSK_IMPACT_DATA_HOME -p $MSK_DMP_TMPDIR/mskimpact_ped_patient_list.txt -s $MSK_IMPACT_DATA_HOME/cvr/seq_date.txt -f diagnosis,radiation,chemotherapy,surgery,survival
     if [ $? -gt 0 ] ; then
         cd $MSK_IMPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
         sendPreImportFailureMessageMskPipelineLogsSlack "MSKIMPACT Pediatric DDP Fetch"
@@ -332,7 +332,7 @@ echo $(date)
 mskimpact_heme_dmp_pids_file=$MSK_DMP_TMPDIR/mskimpact_heme_patient_list.txt
 awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt | sort | uniq > $mskimpact_heme_dmp_pids_file
 ##TO-DO: ADD ARG TO PASS IN "YESTERDAY'S" DEMOGRAHICS RECORD COUNT TO DDP TO ENSURE WE AREN'T OVERWRITING WITH INVALID DATA
-$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact_heme -s $mskimpact_heme_dmp_pids_file -o $MSK_HEMEPACT_DATA_HOME
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact_heme -p $mskimpact_heme_dmp_pids_file -s $MSK_HEMEPACT_DATA_HOME/cvr/seq_date.txt -f survival -o $MSK_HEMEPACT_DATA_HOME
 if [ $? -gt 0 ] ; then
     cd $MSK_HEMEPACT_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
     sendPreImportFailureMessageMskPipelineLogsSlack "HEMEPACT DDP Demographics Fetch"
@@ -378,7 +378,7 @@ echo $(date)
 mskraindance_dmp_pids_file=$MSK_DMP_TMPDIR/mskraindance_patient_list.txt
 awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_RAINDANCE_DATA_HOME/data_clinical_mskraindance_data_clinical.txt | sort | uniq > $mskraindance_dmp_pids_file
 ##TO-DO: ADD ARG TO PASS IN "YESTERDAY'S" DEMOGRAHICS RECORD COUNT TO DDP TO ENSURE WE AREN'T OVERWRITING WITH INVALID DATA
-$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskraindance -s $mskraindance_dmp_pids_file -o $MSK_RAINDANCE_DATA_HOME
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskraindance -p $mskraindance_dmp_pids_file -s $MSK_RAINDANCE_DATA_HOME/cvr/seq_date.txt -f survival -o $MSK_RAINDANCE_DATA_HOME
 if [ $? -gt 0 ] ; then
     cd $MSK_RAINDANCE_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
     sendPreImportFailureMessageMskPipelineLogsSlack "RAINDANCE DDP Demographics Fetch"
@@ -425,7 +425,7 @@ echo $(date)
 mskarcher_dmp_pids_file=$MSK_DMP_TMPDIR/mskarcher_patient_list.txt
 awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_ARCHER_UNFILTERED_DATA_HOME/data_clinical_mskarcher_data_clinical.txt | sort | uniq > $mskarcher_dmp_pids_file
 ##TO-DO: ADD ARG TO PASS IN "YESTERDAY'S" DEMOGRAHICS RECORD COUNT TO DDP TO ENSURE WE AREN'T OVERWRITING WITH INVALID DATA
-$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskarcher -s $mskarcher_dmp_pids_file -o $MSK_ARCHER_UNFILTERED_DATA_HOME
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskarcher -p $mskarcher_dmp_pids_file -s $MSK_ARCHER_UNFILTERED_DATA_HOME/cvr/seq_date.txt -f survival -o $MSK_ARCHER_UNFILTERED_DATA_HOME
 if [ $? -gt 0 ] ; then
     cd $MSK_ARCHER_UNFILTERED_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
     sendPreImportFailureMessageMskPipelineLogsSlack "ARCHER_UNFILTERED DDP Demographics Fetch"


### PR DESCRIPTION
If we query DDP for diagnosis, then OS_MONTHS still uses the first tumor diagnosis date as the OS_MONTHS, otherwise if we have provided seq_date.txt as a parameter to the job then we use the first sequence date for OS_MONTHS.

This also includes a fix for the `-t` test flag, which was fetching patient identifiers for more than 500 patients.

The `-s` `--subset_file` parameter was renamed to `-p` `--patient_subset_file`, so that we can use the `-s` for the seq_date.txt file.

