### PR TITLE
Fix Split() in SeqDateTasklet

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTasklet.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTasklet.java
@@ -99,7 +99,7 @@ public class DDPSeqDateTasklet implements Tasklet {
         String line;
         List<String> warnings = new ArrayList<String>();
         while ((line = reader.readLine()) != null) {
-            String[] record = line.split("\t");
+            String[] record = line.split("\t", -1);
             String dmpPatientId = record[dmpPatientIdColumnIndex];
             String seqDateString = record[seqDateColumnIndex];
             if (!StringUtils.isEmpty(seqDateString)) {

--- a/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTaskletTest.java
+++ b/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTaskletTest.java
@@ -74,6 +74,7 @@ public class DDPSeqDateTaskletTest {
             .thenReturn("SAMPLE_8\tPATIENT_2\tMon, 01 Oct 2018 15:09:02 GMT")
             .thenReturn("SAMPLE_9\tPATIENT_4\tTes, 14 Feb 2014 17:21:03 GMT") // invalid date, this patient should not have a seq date in map
             .thenReturn("SAMPLE_9\tPATIENT_3\tFri, 14 Feb 2014 17:21:03 GMT")
+            .thenReturn("SAMPLE_10\tPATIENT_5\t") // no date provided, this patient should not have a seq date in map
             .thenReturn(null);
         DDPSeqDateTasklet tasklet = new DDPSeqDateTasklet();
         Map<String, Date> actualPatientFirstSeqDateMap = tasklet.getFirstSeqDatePerPatientFromFile("filename", mockBufferedReader);


### PR DESCRIPTION
records with no value in SEQ_DATE column were throwing `ArrayIndexOutOfBoundsException` because split() discarded trailing empty matches.  

Fix is to just add a negative limit to the split() call.
Also added a case to the unit tests for this case. Fails with `ArrayIndexOutOfBoundsException` without the code change. 