### PR TITLE
Handle special cases for OS_MONTHS calculation

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/DDPPipeline.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/DDPPipeline.java
@@ -137,7 +137,7 @@ public class DDPPipeline {
         CommandLineParser parser = new DefaultParser();
         CommandLine commandLine = parser.parse(options, args);
         if (commandLine.hasOption("h") || !commandLine.hasOption("o") ||
-                (!commandLine.hasOption("c") && !commandLine.hasOption("s"))) {
+                (!commandLine.hasOption("c") && !commandLine.hasOption("p"))) {
             help(options, 1);
         }
         // parse input arguments

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPEmailTasklet.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPEmailTasklet.java
@@ -46,6 +46,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import org.apache.commons.lang.StringUtils;
 
 /**
  *
@@ -84,6 +85,13 @@ public class DDPEmailTasklet implements Tasklet {
         Set<String> patientsMissingSurvival = DDPUtils.getPatientsMissingSurvival();
         if (patientsMissingSurvival.size() > 0) { // size will be zero if we either did not include survival information or if every patient has it
             body.append(constructMissingPatientsText(patientsMissingSurvival, "patients that were included are missing survival information"));
+        }
+        Set<String> patientsWithNegativeOsMOnths = DDPUtils.getPatientsWithNegativeOsMonths();
+        if (patientsWithNegativeOsMOnths.size() > 0) { // size will be zero if we either did not include survival information or if every patient has it
+            body.append("Found ")
+                    .append(patientsWithNegativeOsMOnths.size())
+                    .append(" patients with negative OS_MONTHS - see DDP fetcher log for further details:\n")
+                    .append(StringUtils.join(patientsWithNegativeOsMOnths, "\n\t"));
         }
         if (!body.toString().isEmpty()) {
             emailUtil.sendEmailToDefaultRecipient(subject, body.toString());

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/ClinicalRecord.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/ClinicalRecord.java
@@ -56,7 +56,6 @@ public class ClinicalRecord {
     private String RADIATION_THERAPY;
     private String CHEMOTHERAPY;
     private String SURGERY;
-    private Boolean includeSurvival;
 
     public ClinicalRecord(){}
 
@@ -69,7 +68,7 @@ public class ClinicalRecord {
         this.ETHNICITY = compositeRecord.getPatientEthnicity() == null ? "NA" : compositeRecord.getPatientEthnicity();;
         this.OS_STATUS = DDPUtils.resolveOsStatus(compositeRecord);
         this.PED_IND = DDPUtils.resolvePediatricCohortPatientStatus(compositeRecord.getPediatricPatientStatus());
-        this.OS_MONTHS = includeSurvival != null && includeSurvival ? DDPUtils.resolveOsMonths(OS_STATUS, compositeRecord) : "NA";
+        this.OS_MONTHS = includeSurvival ? DDPUtils.resolveOsMonths(OS_STATUS, compositeRecord) : "NA";
         this.RADIATION_THERAPY = compositeRecord.hasReceivedRadiation() ? "Yes" : "No";
         this.CHEMOTHERAPY = compositeRecord.hasReceivedChemo() ? "Yes" : "No";
         this.SURGERY = compositeRecord.hasReceivedSurgery() ? "Yes" : "No";

--- a/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtilsTest.java
+++ b/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtilsTest.java
@@ -262,6 +262,10 @@ public class DDPUtilsTest {
         // the following has both diagnosis and seq date, seq date wins
         resolveOsMonthsAndAssert("LIVING", "2019-04-12", "ignore", "2018-02-19", "Fri, 13 Oct 2017 15:33:32 GMT",
             String.format("%.3f", 17.9506));
+        // deceased patient date of death is before first tumor sequencing date
+        resolveOsMonthsAndAssert("DECEASED", "ignore", "2015-05-10", "2014-01-20", "Fri, 20 Jan 2017 16:52:02 GMT", "0");
+        // living patient last follow up date is before first tumor sequencing date
+        resolveOsMonthsAndAssert("LIVING", "2013-07-19", "ignore", "2016-06-08", "Fri, 20 Jan 2017 16:52:02 GMT", "NA");
     }
 
     /**
@@ -525,7 +529,7 @@ public class DDPUtilsTest {
         patientFirstSeqDateMap.put(dmpPatientId, seqDate);
         DDPUtils.setPatientFirstSeqDateMap(patientFirstSeqDateMap);
         compositeRecord.setPatientDemographics(patientDemographics);
-        compositeRecord.setCohortPatient(cohortPatient); 
+        compositeRecord.setCohortPatient(cohortPatient);
         ClinicalRecord clinicalRecord = new ClinicalRecord(compositeRecord, Boolean.TRUE);
         String expectedValue = "MY_PT_ID\t75\tNA\tNA\tNA\tNA\tLIVING\tNA\t17.951";
         String returnedValue = DDPUtils.constructRecord(clinicalRecord, Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE);


### PR DESCRIPTION
There are some special cases to handle if we are calculating OS_MONTHS from the first date of sequencing:
1. If a patient dies before the sequencing date, return 0
2. If a living patient has a last follow up date occurring before the date of sequencing, return NA

If the calculated OS_MONTHS is negative after handling these special cases then log the operands and resulting OS_MONTHS for reference.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>