### PR TITLE
NPE thrown during OS Months calculation

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -306,7 +306,7 @@ public class DDPUtils {
      * @return
      */
     public static Boolean patientDiedBeforeFirstTumorSequencingDate(String osStatus, Long deceasedDate, Long firstTumorSequencingDate) {
-        return (!osStatus.equals("LIVING") && deceasedDate != null && deceasedDate < firstTumorSequencingDate);
+        return (!osStatus.equals("LIVING") && deceasedDate != null  && firstTumorSequencingDate != null && deceasedDate < firstTumorSequencingDate);
     }
 
     /**
@@ -318,7 +318,7 @@ public class DDPUtils {
      * @return
      */
     public static Boolean lastFollowUpBeforeFirstTumorSequencingDate(String osStatus, Long dateLastActive, Long firstTumorSequencingDate) {
-        return (osStatus.equals("LIVING") && dateLastActive != null && dateLastActive < firstTumorSequencingDate);
+        return (osStatus.equals("LIVING") && dateLastActive != null && firstTumorSequencingDate != null && dateLastActive < firstTumorSequencingDate);
     }
 
     /**


### PR DESCRIPTION
caused the following: `org.mskcc.cmo.ks.ddp.pipeline.DDPCompositeProcessor - Error converting composite record into clinical record`