### PR TITLE
modularize fetch calls in import scripts

### DIFF
--- a/import-scripts/backup-redcap-data.sh
+++ b/import-scripts/backup-redcap-data.sh
@@ -2,7 +2,7 @@
 
 # take snapshot of REDCap projects for MSKIMPACT, RAINDANCE, HEMEPACT, ARCHER
 echo $(date)
-email_list="cbioportal-pipelines@cbio.mskcc.org"
+PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
 
 # flags for REDCap export status
 MSKIMPACT_REDCAP_EXPORT_FAIL=0
@@ -199,25 +199,25 @@ fi
 EMAIL_BODY="Failed to backup MSKIMPACT REDCap data"
 if [ $MSKIMPACT_REDCAP_EXPORT_FAIL -gt 0 ]; then
     echo "Sending email $EMAIL_BODY"
-    echo $EMAIL_BODY | mail -s "[URGENT]: MSKIMPACT REDCap Backup Failure" $email_list
+    echo $EMAIL_BODY | mail -s "[URGENT]: MSKIMPACT REDCap Backup Failure" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to backup RAINDANCE REDCap data"
 if [ $RAINDANCE_REDCAP_EXPORT_FAIL -gt 0 ]; then
     echo "Sending email $EMAIL_BODY"
-    echo $EMAIL_BODY | mail -s "[URGENT]: RAINDANCE REDCap Backup Failure" $email_list
+    echo $EMAIL_BODY | mail -s "[URGENT]: RAINDANCE REDCap Backup Failure" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to backup HEMEPACT REDCap data"
 if [ $HEMEPACT_REDCAP_EXPORT_FAIL -gt 0 ]; then
     echo "Sending email $EMAIL_BODY"
-    echo $EMAIL_BODY | mail -s "[URGENT]: HEMEPACT REDCap Backup Failure" $email_list
+    echo $EMAIL_BODY | mail -s "[URGENT]: HEMEPACT REDCap Backup Failure" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to backup ARCHER REDCap data"
 if [ $ARCHER_REDCAP_EXPORT_FAIL -gt 0 ]; then
     echo "Sending email $EMAIL_BODY"
-    echo $EMAIL_BODY | mail -s "[URGENT]: ARCHER REDCap Backup Failure" $email_list
+    echo $EMAIL_BODY | mail -s "[URGENT]: ARCHER REDCap Backup Failure" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to backup ACCESS REDCap data"
@@ -230,25 +230,25 @@ fi
 EMAIL_BODY="Validation of MSKIMPACT REDCap data failed"
 if [ $MSKIMPACT_VALIDATION_FAIL -gt 0 ]; then
     echo "Sending email $EMAIL_BODY"
-    echo $EMAIL_BODY | mail -s "[URGENT]: MSKIMPACT REDCap Data Validation Failure" $email_list
+    echo $EMAIL_BODY | mail -s "[URGENT]: MSKIMPACT REDCap Data Validation Failure" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Validation of RAINDANCE REDCap data failed"
 if [ $RAINDANCE_VALIDATION_FAIL -gt 0 ]; then
     echo "Sending email $EMAIL_BODY"
-    echo $EMAIL_BODY | mail -s "[URGENT]: RAINDANCE REDCap Data Validation Failure" $email_list
+    echo $EMAIL_BODY | mail -s "[URGENT]: RAINDANCE REDCap Data Validation Failure" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Validation of HEMEPACT REDCap data failed"
 if [ $HEMEPACT_VALIDATION_FAIL -gt 0 ]; then
     echo "Sending email $EMAIL_BODY"
-    echo $EMAIL_BODY | mail -s "[URGENT]: HEMEPACT REDCap Data Validation Failure" $email_list
+    echo $EMAIL_BODY | mail -s "[URGENT]: HEMEPACT REDCap Data Validation Failure" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Validation of ARCHER REDCap data failed"
 if [ $ARCHER_VALIDATION_FAIL -gt 0 ]; then
     echo "Sending email $EMAIL_BODY"
-    echo $EMAIL_BODY | mail -s "[URGENT]: ARCHER REDCap Data Validation Failure" $email_list
+    echo $EMAIL_BODY | mail -s "[URGENT]: ARCHER REDCap Data Validation Failure" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Validation of ACCESS REDCap data failed"

--- a/import-scripts/dmp-import-vars-functions.sh
+++ b/import-scripts/dmp-import-vars-functions.sh
@@ -18,6 +18,7 @@ JAVA_DDP_FETCHER_ARGS="-jar $DDP_FETCHER_JAR_FILENAME"
 JAVA_REDCAP_PIPELINE_ARGS="-jar $REDCAP_PIPELINE_JAR_FILENAME"
 JAVA_DEBUG_ARGS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182"
 JAVA_IMPORTER_ARGS="$JAVA_PROXY_ARGS $JAVA_DEBUG_ARGS -Dspring.profiles.active=dbcp -Djava.io.tmpdir=$MSK_DMP_TMPDIR -ea -cp $IMPORTER_JAR_FILENAME org.mskcc.cbio.importer.Admin"
+PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
 
 DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT=2
 
@@ -313,7 +314,7 @@ function restartMSKTomcats {
     if [ ${#failed_restart_server_list[*]} -ne 0 ] ; then
         EMAIL_BODY="Attempt to trigger a restart of the $TOMCAT_SERVER_DISPLAY_NAME server on the following hosts failed: ${failed_restart_server_list[*]}"
         echo -e "Sending email $EMAIL_BODY"
-        echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $email_list
+        echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $PIPELINES_EMAIL_LIST
     fi
 }
 
@@ -339,7 +340,7 @@ function restartSchultzTomcats {
     if [ ${#failed_restart_server_list[*]} -ne 0 ] ; then
         EMAIL_BODY="Attempt to trigger a restart of the $TOMCAT_SERVER_DISPLAY_NAME server on the following hosts failed: ${failed_restart_server_list[*]}"
         echo -e "Sending email $EMAIL_BODY"
-        echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $email_list
+        echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $PIPELINES_EMAIL_LIST
     fi
 }
 

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -53,7 +53,7 @@ LYMPHOMA_SUPER_COHORT_SUBSET_FAIL=0
 
 GENERATE_MASTERLIST_FAIL=0
 
-email_list="cbioportal-pipelines@cbio.mskcc.org"
+PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
 
 # -----------------------------------------------------------------------------------------------------------
 # START DMP DATA FETCHING
@@ -66,7 +66,7 @@ fi
 if [ -z $JAVA_BINARY ] | [ -z $HG_BINARY ] | [ -z $PORTAL_HOME ] | [ -z $MSK_IMPACT_DATA_HOME ] ; then
     message="test could not run import-dmp-impact.sh: automation-environment.sh script must be run in order to set needed environment variables (like MSK_IMPACT_DATA_HOME, ...)"
     echo $message
-    echo -e "$message" |  mail -s "fetch-dmp-data-for-import failed to run." $email_list
+    echo -e "$message" |  mail -s "fetch-dmp-data-for-import failed to run." $PIPELINES_EMAIL_LIST
     sendPreImportFailureMessageMskPipelineLogsSlack "$message"
     exit 2
 fi
@@ -81,7 +81,7 @@ if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
     if [ $? -gt 0 ]; then
         message="Failed to refresh CDD cache!"
         echo $message
-        echo -e "$message" | mail -s "CDD cache failed to refresh" $email_list
+        echo -e "$message" | mail -s "CDD cache failed to refresh" $PIPELINES_EMAIL_LIST
         sendPreImportFailureMessageMskPipelineLogsSlack "$message"
         CDD_RECACHE_FAIL=1
     fi
@@ -89,7 +89,7 @@ if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
     if [ $? -gt 0 ]; then
         message="Failed to refresh ONCOTREE cache!"
         echo $message
-        echo -e "$message" | mail -s "ONCOTREE cache failed to refresh" $email_list
+        echo -e "$message" | mail -s "ONCOTREE cache failed to refresh" $PIPELINES_EMAIL_LIST
         sendPreImportFailureMessageMskPipelineLogsSlack "$message"
         ONCOTREE_RECACHE_FAIL=1
     fi
@@ -1360,28 +1360,28 @@ EMAIL_BODY="Failed to push outgoing changes to Mercurial - address ASAP!"
 # send email if failed to push outgoing changes to mercurial
 if [ $MERCURIAL_PUSH_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "[URGENT] HG PUSH FAILURE" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "[URGENT] HG PUSH FAILURE" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="The MSKIMPACT study failed fetch. The original study will remain on the portal."
 # send email if fetch fails
 if [ $IMPORT_STATUS_IMPACT -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Fetch Failure: Import" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Fetch Failure: Import" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="The HEMEPACT study failed fetch. The original study will remain on the portal."
 # send email if fetch fails
 if [ $IMPORT_STATUS_HEME -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "HEMEPACT Fetch Failure: Import" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "HEMEPACT Fetch Failure: Import" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="The RAINDANCE study failed fetch. The original study will remain on the portal."
 # send email if fetch fails
 if [ $IMPORT_STATUS_RAINDANCE -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "RAINDANCE Fetch Failure: Import" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "RAINDANCE Fetch Failure: Import" $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="The ARCHER study failed fetch. The original study will remain on the portal."
@@ -1401,89 +1401,89 @@ fi
 EMAIL_BODY="Failed to merge ARCHER fusion events into MSKIMPACT"
 if [ $ARCHER_MERGE_IMPACT_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "MSKIMPACT-ARCHER Merge Failure: Study will be updated without new ARCHER fusion events." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "MSKIMPACT-ARCHER Merge Failure: Study will be updated without new ARCHER fusion events." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to merge ARCHER fusion events into HEMEPACT"
 if [ $ARCHER_MERGE_HEME_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "HEMEPACT-ARCHER Merge Failure: Study will be updated without new ARCHER fusion events." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "HEMEPACT-ARCHER Merge Failure: Study will be updated without new ARCHER fusion events." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset UNLINKED_ARCHER data from ARCHER_UNFILTERED"
 if [ $UNLINKED_ARCHER_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "UNLINKED_ARCHER Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "UNLINKED_ARCHER Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to merge MSK-IMPACT, HEMEPACT, ARCHER, and RAINDANCE data. Merged study will not be updated."
 if [ $MIXEDPACT_MERGE_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "MIXEDPACT Merge Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "MIXEDPACT Merge Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to merge MSK-IMPACT, HEMEPACT, and ARCHER data. Merged study will not be updated."
 if [ $MSK_SOLID_HEME_MERGE_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "MSKSOLIDHEME Merge Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "MSKSOLIDHEME Merge Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset Kings County Cancer Center data. Subset study will not be updated."
 if [ $MSK_KINGS_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "KINGSCOUNTY Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "KINGSCOUNTY Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset Lehigh Valley data. Subset study will not be updated."
 if [ $MSK_LEHIGH_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "LEHIGHVALLEY Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "LEHIGHVALLEY Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset Queens Cancer Center data. Subset study will not be updated."
 if [ $MSK_QUEENS_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "QUEENSCANCERCENTER Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "QUEENSCANCERCENTER Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset Miami Cancer Institute data. Subset study will not be updated."
 if [ $MSK_MCI_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "MIAMICANCERINSTITUTE Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "MIAMICANCERINSTITUTE Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset Hartford Healthcare data. Subset study will not be updated."
 if [ $MSK_HARTFORD_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "HARTFORDHEALTHCARE Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "HARTFORDHEALTHCARE Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset Ralph Lauren Center data. Subset study will not be updated."
 if [ $MSK_RALPHLAUREN_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "RALPHLAUREN Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "RALPHLAUREN Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset MSK Tailor Med Japan data. Subset study will not be updated."
 if [ $MSK_RIKENGENESISJAPAN_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" |  mail -s "RIKENGENESISJAPAN Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" |  mail -s "RIKENGENESISJAPAN Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset MSKIMPACT_PED data. Subset study will not be updated."
 if [ $MSKIMPACT_PED_SUBSET_FAIL -gt 0 ]; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT_PED Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT_PED Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset MSKIMPACT SCLC data. Subset study will not be updated."
 if [ $SCLC_MSKIMPACT_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "SCLCMSKIMPACT Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" | mail -s "SCLCMSKIMPACT Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi
 
 EMAIL_BODY="Failed to subset LYMPHOMASUPERCOHORT data. Subset study will not be updated."
 if [ $LYMPHOMA_SUPER_COHORT_SUBSET_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "LYMPHOMASUPERCOHORT Subset Failure: Study will not be updated." $email_list
+    echo -e "$EMAIL_BODY" | mail -s "LYMPHOMASUPERCOHORT Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
 fi

--- a/import-scripts/import-dmp-impact-data.sh
+++ b/import-scripts/import-dmp-impact-data.sh
@@ -9,12 +9,12 @@ source $PORTAL_HOME/scripts/dmp-import-vars-functions.sh
 
 echo $(date)
 
-email_list="cbioportal-pipelines@cbio.mskcc.org"
+PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
 
 if [ -z $JAVA_BINARY ] | [ -z $PORTAL_HOME ] | [ -z $MSK_IMPACT_DATA_HOME ] ; then
     message="test could not run import-dmp-impact.sh: automation-environment.sh script must be run in order to set needed environment variables (like MSK_IMPACT_DATA_HOME, ...)"
     echo ${message}
-    echo -e "${message}" |  mail -s "import-dmp-impact-data failed to run." $email_list
+    echo -e "${message}" |  mail -s "import-dmp-impact-data failed to run." $PIPELINES_EMAIL_LIST
     sendImportFailureMessageMskPipelineLogsSlack "${message}"
     exit 2
 fi
@@ -29,7 +29,7 @@ if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
     if [ $? -gt 0 ]; then
         message="Failed to refresh CDD cache!"
         echo $message
-        echo -e "$message" | mail -s "CDD cache failed to refresh" $email_list
+        echo -e "$message" | mail -s "CDD cache failed to refresh" $PIPELINES_EMAIL_LIST
         sendImportFailureMessageMskPipelineLogsSlack "$message"
         CDD_RECACHE_FAIL=1
     fi
@@ -37,7 +37,7 @@ if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
     if [ $? -gt 0 ]; then
         message="Failed to refresh ONCOTREE cache!"
         echo $message
-        echo -e "$message" | mail -s "ONCOTREE cache failed to refresh" $email_list
+        echo -e "$message" | mail -s "ONCOTREE cache failed to refresh" $PIPELINES_EMAIL_LIST
         sendImportFailureMessageMskPipelineLogsSlack "$message"
         ONCOTREE_RECACHE_FAIL=1
     fi
@@ -120,7 +120,7 @@ RESTART_AFTER_IMPACT_IMPORT=0
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_SOLID_HEME_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import of MSKSOLIDHEME (will be renamed MSKIMPACT) study"
     # this usage is a little different -- we are comparing the backup-study-id "yesterday_mskimpact" because we will be renaming this imported study to mskimpact after a successful import
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskimpact" --temp-study-id="temporary_mskimpact" --backup-study-id="yesterday_mskimpact" --portal-name="msk-solid-heme-portal" --study-path="$MSK_SOLID_HEME_DATA_HOME" --notification-file="$msk_solid_heme_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskimpact" --temp-study-id="temporary_mskimpact" --backup-study-id="yesterday_mskimpact" --portal-name="msk-solid-heme-portal" --study-path="$MSK_SOLID_HEME_DATA_HOME" --notification-file="$msk_solid_heme_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         consumeSamplesAfterSolidHemeImport
         RESTART_AFTER_IMPACT_IMPORT=1
@@ -156,7 +156,7 @@ RESTART_AFTER_DMP_PIPELINES_IMPORT=0
 ## TEMP STUDY IMPORT: MSKRAINDANCE
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_RAINDANCE_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for mskraindance"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskraindance" --temp-study-id="temporary_mskraindance" --backup-study-id="yesterday_mskraindance" --portal-name="mskraindance-portal" --study-path="$MSK_RAINDANCE_DATA_HOME" --notification-file="$mskraindance_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskraindance" --temp-study-id="temporary_mskraindance" --backup-study-id="yesterday_mskraindance" --portal-name="mskraindance-portal" --study-path="$MSK_RAINDANCE_DATA_HOME" --notification-file="$mskraindance_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_DMP_PIPELINES_IMPORT=1
         IMPORT_FAIL_RAINDANCE=0
@@ -178,7 +178,7 @@ fi
 # TEMP STUDY IMPORT: MSKARCHER
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_ARCHER_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for mskarcher"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskarcher" --temp-study-id="temporary_mskarcher" --backup-study-id="yesterday_mskarcher" --portal-name="mskarcher-portal" --study-path="$MSK_ARCHER_DATA_HOME" --notification-file="$mskarcher_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskarcher" --temp-study-id="temporary_mskarcher" --backup-study-id="yesterday_mskarcher" --portal-name="mskarcher-portal" --study-path="$MSK_ARCHER_DATA_HOME" --notification-file="$mskarcher_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_DMP_PIPELINES_IMPORT=1
         IMPORT_FAIL_ARCHER=0
@@ -217,7 +217,7 @@ RESTART_AFTER_MSK_AFFILIATE_IMPORT=0
 # TEMP STUDY IMPORT: KINGSCOUNTY
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_KINGS_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for msk_kingscounty"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_kingscounty" --temp-study-id="temporary_msk_kingscounty" --backup-study-id="yesterday_msk_kingscounty" --portal-name="msk-kingscounty-portal" --study-path="$MSK_KINGS_DATA_HOME" --notification-file="$kingscounty_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_kingscounty" --temp-study-id="temporary_msk_kingscounty" --backup-study-id="yesterday_msk_kingscounty" --portal-name="msk-kingscounty-portal" --study-path="$MSK_KINGS_DATA_HOME" --notification-file="$kingscounty_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_MSK_AFFILIATE_IMPORT=1
         IMPORT_FAIL_KINGS=0
@@ -239,7 +239,7 @@ fi
 # TEMP STUDY IMPORT: LEHIGHVALLEY
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_LEHIGH_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for msk_lehighvalley"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_lehighvalley" --temp-study-id="temporary_msk_lehighvalley" --backup-study-id="yesterday_msk_lehighvalley" --portal-name="msk-lehighvalley-portal" --study-path="$MSK_LEHIGH_DATA_HOME" --notification-file="$lehighvalley_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_lehighvalley" --temp-study-id="temporary_msk_lehighvalley" --backup-study-id="yesterday_msk_lehighvalley" --portal-name="msk-lehighvalley-portal" --study-path="$MSK_LEHIGH_DATA_HOME" --notification-file="$lehighvalley_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_MSK_AFFILIATE_IMPORT=1
         IMPORT_FAIL_LEHIGH=0
@@ -261,7 +261,7 @@ fi
 # TEMP STUDY IMPORT: QUEENSCANCERCENTER
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_QUEENS_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for msk_queenscancercenter"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_queenscancercenter" --temp-study-id="temporary_msk_queenscancercenter" --backup-study-id="yesterday_msk_queenscancercenter" --portal-name="msk-queenscancercenter-portal" --study-path="$MSK_QUEENS_DATA_HOME" --notification-file="$queenscancercenter_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_queenscancercenter" --temp-study-id="temporary_msk_queenscancercenter" --backup-study-id="yesterday_msk_queenscancercenter" --portal-name="msk-queenscancercenter-portal" --study-path="$MSK_QUEENS_DATA_HOME" --notification-file="$queenscancercenter_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_MSK_AFFILIATE_IMPORT=1
         IMPORT_FAIL_QUEENS=0
@@ -283,7 +283,7 @@ fi
 # TEMP STUDY IMPORT: MIAMICANCERINSTITUTE
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_MCI_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for msk_miamicancerinstitute"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_miamicancerinstitute" --temp-study-id="temporary_msk_miamicancerinstitute" --backup-study-id="yesterday_msk_miamicancerinstitute" --portal-name="msk-mci-portal" --study-path="$MSK_MCI_DATA_HOME" --notification-file="$miamicancerinstitute_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_miamicancerinstitute" --temp-study-id="temporary_msk_miamicancerinstitute" --backup-study-id="yesterday_msk_miamicancerinstitute" --portal-name="msk-mci-portal" --study-path="$MSK_MCI_DATA_HOME" --notification-file="$miamicancerinstitute_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_MSK_AFFILIATE_IMPORT=1
         IMPORT_FAIL_MCI=0
@@ -305,7 +305,7 @@ fi
 # TEMP STUDY IMPORT: HARTFORDHEALTHCARE
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_HARTFORD_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for msk_hartfordhealthcare"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_hartfordhealthcare" --temp-study-id="temporary_msk_hartfordhealthcare" --backup-study-id="yesterday_msk_hartfordhealthcare" --portal-name="msk-hartford-portal" --study-path="$MSK_HARTFORD_DATA_HOME" --notification-file="$hartfordhealthcare_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_hartfordhealthcare" --temp-study-id="temporary_msk_hartfordhealthcare" --backup-study-id="yesterday_msk_hartfordhealthcare" --portal-name="msk-hartford-portal" --study-path="$MSK_HARTFORD_DATA_HOME" --notification-file="$hartfordhealthcare_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_MSK_AFFILIATE_IMPORT=1
         IMPORT_FAIL_HARTFORD=0
@@ -327,7 +327,7 @@ fi
 # TEMP STUDY IMPORT: RALPHLAUREN
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_RALPHLAUREN_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for msk_ralphlauren"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_ralphlauren" --temp-study-id="temporary_msk_ralphlauren" --backup-study-id="yesterday_msk_ralphlauren" --portal-name="msk-ralphlauren-portal" --study-path="$MSK_RALPHLAUREN_DATA_HOME" --notification-file="$ralphlauren_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_ralphlauren" --temp-study-id="temporary_msk_ralphlauren" --backup-study-id="yesterday_msk_ralphlauren" --portal-name="msk-ralphlauren-portal" --study-path="$MSK_RALPHLAUREN_DATA_HOME" --notification-file="$ralphlauren_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_MSK_AFFILIATE_IMPORT=1
         IMPORT_FAIL_RALPHLAUREN=0
@@ -349,7 +349,7 @@ fi
 # TEMP STUDY IMPORT: RIKENGENESISJAPAN
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_RIKENGENESISJAPAN_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for msk_rikengenesisjapan"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_rikengenesisjapan" --temp-study-id="temporary_msk_rikengenesisjapan" --backup-study-id="yesterday_msk_rikengenesisjapan" --portal-name="msk-tailormedjapan-portal" --study-path="$MSK_RIKENGENESISJAPAN_DATA_HOME" --notification-file="$rikengenesisjapan_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="msk_rikengenesisjapan" --temp-study-id="temporary_msk_rikengenesisjapan" --backup-study-id="yesterday_msk_rikengenesisjapan" --portal-name="msk-tailormedjapan-portal" --study-path="$MSK_RIKENGENESISJAPAN_DATA_HOME" --notification-file="$rikengenesisjapan_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_MSK_AFFILIATE_IMPORT=1
         IMPORT_FAIL_RIKENGENESISJAPAN=0
@@ -374,7 +374,7 @@ fi
 # TEMP STUDY IMPORT: MSKIMPACT_PED
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSKIMPACT_PED_IMPORT_TRIGGER ]; then
     printTimeStampedDataProcessingStepMessage "import for mskimpact_ped study"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskimpact_ped" --temp-study-id="temporary_mskimpact_ped" --backup-study-id="yesterday_mskimpact_ped" --portal-name="msk-ped-portal" --study-path="$MSKIMPACT_PED_DATA_HOME" --notification-file="$mskimpact_ped_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskimpact_ped" --temp-study-id="temporary_mskimpact_ped" --backup-study-id="yesterday_mskimpact_ped" --portal-name="msk-ped-portal" --study-path="$MSKIMPACT_PED_DATA_HOME" --notification-file="$mskimpact_ped_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ]; then
         RESTART_AFTER_MSK_AFFILIATE_IMPORT=1
         IMPORT_FAIL_MSKIMPACT_PED=0
@@ -400,7 +400,7 @@ RESTART_AFTER_SCLC_IMPORT=0
 # TEMP STUDY IMPORT: SCLCMSKIMPACT
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_SCLC_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for sclc_mskimpact_2017 study"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="sclc_mskimpact_2017" --temp-study-id="temporary_sclc_mskimpact_2017" --backup-study-id="yesterday_sclc_mskimpact_2017" --portal-name="msk-sclc-portal" --study-path="$MSK_SCLC_DATA_HOME" --notification-file="$sclc_mskimpact_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="sclc_mskimpact_2017" --temp-study-id="temporary_sclc_mskimpact_2017" --backup-study-id="yesterday_sclc_mskimpact_2017" --portal-name="msk-sclc-portal" --study-path="$MSK_SCLC_DATA_HOME" --notification-file="$sclc_mskimpact_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_SCLC_IMPORT=1
         IMPORT_FAIL_SCLC_MSKIMPACT=0
@@ -425,7 +425,7 @@ fi
 # TEMP STUDY IMPORT: LYMPHOMASUPERCOHORT
 if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $LYMPHOMA_SUPER_COHORT_IMPORT_TRIGGER ] ; then
     printTimeStampedDataProcessingStepMessage "import for lymphoma_super_cohort_fmi_msk study"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="lymphoma_super_cohort_fmi_msk" --temp-study-id="temporary_lymphoma_super_cohort_fmi_msk" --backup-study-id="yesterday_lymphoma_super_cohort_fmi_msk" --portal-name="msk-fmi-lymphoma-portal" --study-path="$LYMPHOMA_SUPER_COHORT_DATA_HOME" --notification-file="$lymphoma_super_cohort_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$email_list" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="lymphoma_super_cohort_fmi_msk" --temp-study-id="temporary_lymphoma_super_cohort_fmi_msk" --backup-study-id="yesterday_lymphoma_super_cohort_fmi_msk" --portal-name="msk-fmi-lymphoma-portal" --study-path="$LYMPHOMA_SUPER_COHORT_DATA_HOME" --notification-file="$lymphoma_super_cohort_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
     if [ $? -eq 0 ] ; then
         RESTART_AFTER_MSK_AFFILIATE_IMPORT=1
         IMPORT_FAIL_LYMPHOMA=0
@@ -475,7 +475,7 @@ EMAIL_BODY="The MSKIMPACT database version is incompatible. Imports will be skip
 # send email if db version isn't compatible
 if [ $DB_VERSION_FAIL -gt 0 ] ; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Update Failure: DB version is incompatible" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "MSKIMPACT Update Failure: DB version is incompatible" $PIPELINES_EMAIL_LIST
 fi
 
 echo "Fetching and importing of clinical datasets complete!"

--- a/import-scripts/import-gdac-aws-data.sh
+++ b/import-scripts/import-gdac-aws-data.sh
@@ -15,7 +15,7 @@ tmp=$PORTAL_HOME/tmp/import-cron-aws-gdac
 if [[ -d "$tmp" && "$tmp" != "/" ]]; then
     rm -rf "$tmp"/*
 fi
-email_list="cbioportal-pipelines@cbio.mskcc.org"
+PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
 now=$(date "+%Y-%m-%d-%H-%M-%S")
 TRUSTSTORE_PASSWORD=`cat $AWS_GDAC_SSL_TRUSTSTORE_PASSWORD_FILE`
 ENABLE_DEBUGGING=0
@@ -55,7 +55,7 @@ if [[ $DB_VERSION_FAIL -eq 0 ]]; then
         GDAC_IMPORT_FAIL=1
         EMAIL_BODY="Import of gdac studes (cmo) into aws gdac failed"
         echo -e "Sending email $EMAIL_BODY"
-        echo -e "$EMAIL_BODY" | mail -s "Import failure: aws gdac" $email_list
+        echo -e "$EMAIL_BODY" | mail -s "Import failure: aws gdac" $PIPELINES_EMAIL_LIST
     fi
     num_studies_updated=`cat $tmp/num_studes_updated.txt`
     echo "`$num_studies_updated` studies have been updated"
@@ -69,7 +69,7 @@ if [[ $DB_VERSION_FAIL -eq 0 ]]; then
         STATIC_GDAC_IMPORT_FAIL=1
         EMAIL_BODY="Import of daily studies (dmp/pdx) into aws gdac failed"
         echo -e "Sending email $EMAIL_BODY"
-        echo -e "$EMAIL_BODY" | mail -s "Import failure: aws gdac" $email_list
+        echo -e "$EMAIL_BODY" | mail -s "Import failure: aws gdac" $PIPELINES_EMAIL_LIST
     fi
     num_studies_updated=`cat $tmp/num_studies_updated.txt`
     echo "'$num_studies_updated' studies have been updated"
@@ -81,7 +81,7 @@ EMAIL_BODY="The aws gdac database version is incompatible. Imports will be skipp
 # send email if db version isn't compatible
 if [ $DB_VERSION_FAIL -gt 0 ]; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "AWS GDAC Update Failure: DB version is incompatible" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "AWS GDAC Update Failure: DB version is incompatible" $PIPELINES_EMAIL_LIST
 fi
 
 if [ $GDAC_IMPORT_FAIL -eq 0 ] ; then

--- a/import-scripts/import-genie-data.sh
+++ b/import-scripts/import-genie-data.sh
@@ -6,7 +6,7 @@ tmp=$PORTAL_HOME/tmp/import-cron-genie
 if [[ -d "$tmp" && "$tmp" != "/" ]]; then
     rm -rf "$tmp"/*
 fi
-email_list="cbioportal-pipelines@cbio.mskcc.org"
+PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
 now=$(date "+%Y-%m-%d-%H-%M-%S")
 IMPORTER_JAR_FILENAME="$PORTAL_HOME/lib/genie-importer.jar"
 JAVA_DEBUG_ARGS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27186"
@@ -22,7 +22,7 @@ if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
         CDD_ONCOTREE_RECACHE_FAIL=1
         message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
         echo $message
-        echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $email_list
+        echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $PIPELINES_EMAIL_LIST
     fi
 fi
 
@@ -44,7 +44,7 @@ if [ $? -gt 0 ]; then
     GENIE_FETCH_FAIL=1
     EMAIL_BODY="The genie data fetch failed."
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: genie" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: genie" $PIPELINES_EMAIL_LIST
 fi
 
 if [[ $DB_VERSION_FAIL -eq 0 && $GENIE_FETCH_FAIL -eq 0 && $CDD_ONCOTREE_RECACHE_FAIL -eq 0 ]]; then
@@ -59,7 +59,7 @@ if [[ $DB_VERSION_FAIL -eq 0 && $GENIE_FETCH_FAIL -eq 0 && $CDD_ONCOTREE_RECACHE
         IMPORT_FAIL=1
         EMAIL_BODY="Genie import failed"
         echo -e "Sending email $EMAIL_BODY"
-        echo -e "$EMAIL_BODY" | mail -s "Import failure: Genie" $email_list
+        echo -e "$EMAIL_BODY" | mail -s "Import failure: Genie" $PIPELINES_EMAIL_LIST
     fi
     num_studies_updated=`cat $tmp/num_studies_updated.txt`
 
@@ -82,7 +82,7 @@ if [[ $DB_VERSION_FAIL -eq 0 && $GENIE_FETCH_FAIL -eq 0 && $CDD_ONCOTREE_RECACHE
         if [ ${#failed_restart_server_list[*]} -ne 0 ] ; then
             EMAIL_BODY="Attempt to trigger a restart of the $TOMCAT_SERVER_DISPLAY_NAME server on the following hosts failed: ${failed_restart_server_list[*]}"
             echo -e "Sending email $EMAIL_BODY"
-            echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $email_list
+            echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $PIPELINES_EMAIL_LIST
         fi
         echo "'$num_studies_updated' studies have been updated (no longer need to restart $TOMCAT_SERVER_DISPLAY_NAME server...)"
     else
@@ -94,7 +94,7 @@ EMAIL_BODY="The genie database version is incompatible. Imports will be skipped 
 # send email if db version isn't compatible
 if [ $DB_VERSION_FAIL -gt 0 ]; then
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "GENIE Update Failure: DB version is incompatible" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "GENIE Update Failure: DB version is incompatible" $PIPELINES_EMAIL_LIST
 fi
 
 $JAVA_BINARY $JAVA_IMPORTER_ARGS --send-update-notification --portal genie-portal --notification-file "$genie_portal_notification_file"

--- a/import-scripts/import-public-data.sh
+++ b/import-scripts/import-public-data.sh
@@ -50,7 +50,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-public-data.lock"
     ONCOTREE_VERSION_TO_USE=oncotree_latest_stable
     TOMCAT_SERVER_SHOULD_BE_RESTARTED=0 # 0 = skip the restart, non-0 = do the restart
 
-    email_list="cbioportal-pipelines@cbio.mskcc.org"
+    PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
     CDD_ONCOTREE_RECACHE_FAIL=0
     if ! [ -z $INHIBIT_RECACHING_FROM_TOPBRAID ] ; then
         # refresh cdd and oncotree cache
@@ -59,7 +59,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-public-data.lock"
             CDD_ONCOTREE_RECACHE_FAIL=1
             message="Failed to refresh CDD and/or ONCOTREE cache during TRIAGE import!"
             echo $message
-            echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $email_list
+            echo -e "$message" | mail -s "CDD and/or ONCOTREE cache failed to refresh" $PIPELINES_EMAIL_LIST
         fi
     fi
 
@@ -81,7 +81,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-public-data.lock"
         CBIO_PORTAL_DATA_FETCH_FAIL=1
         EMAIL_BODY="The cbio-portal-data data fetch failed."
         echo -e "Sending email $EMAIL_BODY"
-        echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: cbio-portal-data" $email_list
+        echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: cbio-portal-data" $PIPELINES_EMAIL_LIST
     fi
 
     # fetch updates in CMO impact
@@ -93,7 +93,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-public-data.lock"
         CMO_IMPACT_FETCH_FAIL=1
         EMAIL_BODY="The impact data fetch failed."
         echo -e "Sending email $EMAIL_BODY"
-        echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: impact" $email_list
+        echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: impact" $PIPELINES_EMAIL_LIST
     fi
 
     # fetch updates in private repository
@@ -105,7 +105,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-public-data.lock"
         PRIVATE_FETCH_FAIL=1
         EMAIL_BODY="The private data fetch failed."
         echo -e "Sending email $EMAIL_BODY"
-        echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: private" $email_list
+        echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: private" $PIPELINES_EMAIL_LIST
     fi
 
     echo "fetching updates from datahub..."
@@ -116,7 +116,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-public-data.lock"
         DATAHUB_FETCH_FAIL=1
         EMAIL_BODY="The datahub data fetch failed."
         echo -e "Sending email $EMAIL_BODY"
-        echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: datahub" $pipeline_email_list
+        echo -e "$EMAIL_BODY" | mail -s "Data fetch failure: datahub" $PIPELINES_EMAIL_LIST
     fi
 
     if [[ $DB_VERSION_FAIL -eq 0 && $PRIVATE_FETCH_FAIL -eq 0 && $CMO_IMPACT_FETCH_FAIL -eq 0 && $CBIO_PORTAL_DATA_FETCH_FAIL -eq 0 && $DATAHUB_FETCH_FAIL -eq 0 && $CDD_ONCOTREE_RECACHE_FAIL -eq 0 ]]; then
@@ -130,7 +130,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-public-data.lock"
             echo "Public import failed!"
             EMAIL_BODY="Public import failed"
             echo -e "Sending email $EMAIL_BODY"
-            echo -e "$EMAIL_BODY" | mail -s "Import failure: public" $email_list
+            echo -e "$EMAIL_BODY" | mail -s "Import failure: public" $PIPELINES_EMAIL_LIST
         fi
         num_studies_updated=''
         num_studies_updated_filename="$tmp/num_studies_updated.txt"
@@ -157,7 +157,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-public-data.lock"
         if [ $RESTART_EXIT_STATUS -ne 0 ] ; then
             EMAIL_BODY="Attempt to trigger a redeployment of the public portal tomcat pods failed"
             echo -e "Sending email $EMAIL_BODY"
-            echo -e "$EMAIL_BODY" | mail -s "Public Portal Tomcat Pod Redeployment Error : unable to trigger redeployment" $email_list
+            echo -e "$EMAIL_BODY" | mail -s "Public Portal Tomcat Pod Redeployment Error : unable to trigger redeployment" $PIPELINES_EMAIL_LIST
         fi
     fi
 
@@ -165,7 +165,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-public-data.lock"
     # send email if db version isn't compatible
     if [ $DB_VERSION_FAIL -gt 0 ]; then
         echo -e "Sending email $EMAIL_BODY"
-        echo -e "$EMAIL_BODY" | mail -s "Public Update Failure: DB version is incompatible" $email_list
+        echo -e "$EMAIL_BODY" | mail -s "Public Update Failure: DB version is incompatible" $PIPELINES_EMAIL_LIST
     fi
 
     $JAVA_BINARY $JAVA_IMPORTER_ARGS --send-update-notification --portal public-portal --notification-file "$public_portal_notification_file"

--- a/import-scripts/set-data-source-environment-vars.sh
+++ b/import-scripts/set-data-source-environment-vars.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+export CMO_EMAIL_LIST="cbioportal-cmo-importer@cbio.mskcc.org"
+export PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
+export ALL_DATA_SOURCES="bic-mskcc private genie impact impact-MERGED knowledge-systems-curated-studies immunotherapy datahub datahub_shahlab msk-extract-datahub"
+
+unset DATA_SOURCE_NAME_TO_START_LOG_MESSAGE
+declare -Ax DATA_SOURCE_NAME_TO_START_LOG_MESSAGE
+unset DATA_SOURCE_NAME_TO_EXTRA_IMPORTER_ARGS
+declare -Ax DATA_SOURCE_NAME_TO_EXTRA_IMPORTER_ARGS
+unset DATA_SOURCE_NAME_TO_FAILURE_LOG_MESSAGE
+declare -Ax DATA_SOURCE_NAME_TO_FAILURE_LOG_MESSAGE
+unset DATA_SOURCE_NAME_TO_EMAIL_BODY
+declare -Ax DATA_SOURCE_NAME_TO_EMAIL_BODY
+unset DATA_SOURCE_NAME_TO_EMAIL_SUBJECT
+declare -Ax DATA_SOURCE_NAME_TO_EMAIL_SUBJECT
+unset DATA_SOURCE_NAME_TO_EMAIL_RECIPIENT
+declare -Ax DATA_SOURCE_NAME_TO_EMAIL_RECIPIENT
+#set default strings for fetches
+for data_source in ${ALL_DATA_SOURCES[*]} ; do
+    DATA_SOURCE_NAME_TO_START_LOG_MESSAGE[$data_source]="fetching updates from ${data_source}..."
+    DATA_SOURCE_NAME_TO_EXTRA_IMPORTER_ARGS[$data_source]=""
+    DATA_SOURCE_NAME_TO_FAILURE_LOG_MESSAGE[$data_source]="$data_source fetch failed!"
+    DATA_SOURCE_NAME_TO_EMAIL_BODY[$data_source]="The $data_source data fetch failed."
+    DATA_SOURCE_NAME_TO_EMAIL_SUBJECT[$data_source]="Data fetch failure: $data_source"
+    DATA_SOURCE_NAME_TO_EMAIL_RECIPIENT[$data_source]="$PIPELINES_EMAIL_LIST"
+done
+#set exceptions for fetches
+for data_source in "bic-mskcc" ; do
+    DATA_SOURCE_NAME_TO_FAILURE_LOG_MESSAGE[$data_source]="CMO ($data_source) fetch failed!"
+    DATA_SOURCE_NAME_TO_EMAIL_RECIPIENT[$data_source]="$CMO_EMAIL_LIST"
+    DATA_SOURCE_NAME_TO_EMAIL_BODY[$data_source]="The CMO ($data_source) data fetch failed. Imports into Triage and production WILL NOT HAVE UP-TO-DATE DATA until this is resolved.\n\n*** DO NOT MARK STUDIES FOR IMPORT INTO msk-automation-portal. ***\n\n*** DO NOT MERGE ANY STUDIES until this has been resolved. Please uncheck any merged studies in the cBio Portal Google document. ***\n\nYou may keep projects marked for import into Triage in the cBio Portal Google document. Triage studies will be reimported once there has been a successful data fetch.\n\nPlease don't hesitate to ask if you have any questions."
+    DATA_SOURCE_NAME_TO_EMAIL_SUBJECT[$data_source]="Data fetch failure: CMO ($data_source)"
+done
+DATA_SOURCE_NAME_TO_START_LOG_MESSAGE[knowledge-systems-curated-studies]="fetching updates from cbio-portal-data..."
+DATA_SOURCE_NAME_TO_EXTRA_IMPORTER_ARGS[bic-mskcc]="--update-worksheet"
+DATA_SOURCE_NAME_TO_FAILURE_LOG_MESSAGE[knowledge-systems-curated-studies]="cbio-portal-data fetch failed!"
+DATA_SOURCE_NAME_TO_EMAIL_BODY[knowledge-systems-curated-studies]="The cbio-portal-data data fetch failed."
+DATA_SOURCE_NAME_TO_EMAIL_SUBJECT[knowledge-systems-curated-studies]="Data fetch failure: cbio-portal-data"
+
+function fetch_updates_in_data_source {
+    data_source=$1
+    start_log_msg=$2
+    extra_importer_args=$3
+    failure_log_msg=$4
+    email_body=$5
+    email_subject=$6
+    email_recipient=$7
+
+    echo $start_log_msg
+    $JAVA_BINARY $JAVA_IMPORTER_ARGS --fetch-data --data-source $data_source --run-date latest $extra_importer_args
+    if [ $? -ne 0 ]; then
+        echo $failure_log_msg
+        echo -e "Sending email $email_body"
+        echo -e "$email_body" | mail -s "$email_subject" $email_recipient
+        return 1
+    fi
+    return 0
+}
+
+# failed_data_source_fetches will contain a list of all data source fetches which failed after calling fetch_updates_in_data_sources()
+unset failed_data_source_fetches
+declare -ax failed_data_source_fetches
+
+function fetch_updates_in_data_sources {
+    failed_data_source_fetches=()
+    data_source_list=$*
+    # fetch updates in data sources
+    for data_source in $data_source_list ; do
+        #check if there is a typo in the data source name, and log / skip
+        if [ -z ${DATA_SOURCE_NAME_TO_EMAIL_RECIPIENT[$data_source]} ] ; then
+            echo "error: asked to fetch unrecognized data source : $data_source"
+            failed_data_source_fetches+=("$data_source")
+            continue
+        fi
+        fetch_updates_in_data_source \
+                $data_source \
+                "${DATA_SOURCE_NAME_TO_START_LOG_MESSAGE[$data_source]}" \
+                "${DATA_SOURCE_NAME_TO_EXTRA_IMPORTER_ARGS[$data_source]}" \
+                "${DATA_SOURCE_NAME_TO_FAILURE_LOG_MESSAGE[$data_source]}" \
+                "${DATA_SOURCE_NAME_TO_EMAIL_BODY[$data_source]}" \
+                "${DATA_SOURCE_NAME_TO_EMAIL_SUBJECT[$data_source]}" \
+                "${DATA_SOURCE_NAME_TO_EMAIL_RECIPIENT[$data_source]}"
+        if [ $? -ne 0 ] ; then
+            failed_data_source_fetches+=("$data_source")
+        fi
+    done
+}
+
+export -f fetch_updates_in_data_source
+export -f fetch_updates_in_data_sources

--- a/import-scripts/test_for_multi_hg_heads.sh
+++ b/import-scripts/test_for_multi_hg_heads.sh
@@ -5,12 +5,12 @@ HG_SUB_REPO_LIST=". bic-mouse bic-mskcc brlo_tcga gdac_provisional_tcga genie gr
 HG_ERROR_CODE=1
 NO_HEAD_FOUND_CODE=255
 
-email_list="cbioportal-pipelines@cbio.mskcc.org"
+PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
 
 if [ -z ${PORTAL_DATA_HOME} ] || [ -z ${HG_BINARY} ] ; then
 	message="test could not run: automation-environment.sh script must be run in order to set PORTAL_DATA_HOME and HG_BINARY environment variables"
 	echo ${message}
-	echo ${message} | mail -s "Mercurial Repository Problem Report" $email_list
+	echo ${message} | mail -s "Mercurial Repository Problem Report" $PIPELINES_EMAIL_LIST
 	exit 250
 fi
 function repository_has_single_head () {
@@ -37,7 +37,7 @@ tempfilename=$(mktemp /tmp/test_for_multi_hg_heads_email.XXXXXX)
 if [ -z ${tempfilename} ] || ! [ -w ${tempfilename} ] ; then
 	message="test could not run: tempfile \"${tempfilename}\" could not be created/written"
 	echo ${message}
-	echo ${message} | mail -s "Mercurial Repository Problem Report" $email_list
+	echo ${message} | mail -s "Mercurial Repository Problem Report" $PIPELINES_EMAIL_LIST
 	exit 249
 fi
 
@@ -81,7 +81,7 @@ for subdir in ${HG_SUB_REPO_LIST} ; do
 done
 if [ ${sendemailflag} -ne 0 ] ; then
 	cat ${tempfilename}
-	cat ${tempfilename} | mail -s "Mercurial Repository Problem Report" $email_list
+	cat ${tempfilename} | mail -s "Mercurial Repository Problem Report" $PIPELINES_EMAIL_LIST
 fi
 rm -f ${tempfilename}
 exit ${sendemailflag}

--- a/import-scripts/test_if_impact_has_lost_allele_count.sh
+++ b/import-scripts/test_if_impact_has_lost_allele_count.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-email_list="cbioportal-pipelines@cbio.mskcc.org"
+PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
 export tab=$'\t'
 tmp=$PORTAL_HOME/tmp/import-cron-dmp-msk
 sourcefilename=$MSK_IMPACT_DATA_HOME/data_mutations_extended.txt
@@ -16,7 +16,7 @@ headerlinecount=$(cat ${tempfilename} | wc -l)
 if [ ${headerlinecount} -ne 1 ] ; then
 	message="failed to complete mskimpact missing tumor/normal-ref/alt counts test because no header was found"
 	echo ${message}
-	echo -e "${message}" | mail -s "MSKIMPACT scan for missing tumor/normal-ref/alt counts failure" $email_list
+	echo -e "${message}" | mail -s "MSKIMPACT scan for missing tumor/normal-ref/alt counts failure" $PIPELINES_EMAIL_LIST
 	rm -f ${tempfilename}
 	exit 1
 fi
@@ -31,7 +31,7 @@ rm -f ${tempfilename}.fields
 if [ -z ${mut_stat_index} ] || [ -z ${t_ref_index} ] || [ -z ${t_alt_index} ] || [ -z ${n_ref_index} ] || [ -z ${n_alt_index} ] ; then
 	message="failed to complete mskimpact missing tumor/normal-ref/alt counts test because header was missing a necessary field"
 	echo ${message}
-	echo -e "${message}" | mail -s "MSKIMPACT scan for missing tumor/normal-ref/alt counts failure" $email_list
+	echo -e "${message}" | mail -s "MSKIMPACT scan for missing tumor/normal-ref/alt counts failure" $PIPELINES_EMAIL_LIST
 	rm ${tempfilename}
 	exit 2
 fi
@@ -46,7 +46,7 @@ rm -f ${tempfilename} ${tempfilename}.blanks
 if [ ${recordswithblanks} -gt 0 ] ; then
 	message="mskimpact missing tumor/normal-ref/alt counts test failed : ${recordswithblanks} (somatic/unknown) records with blanks found in field t_ref_count, t_alt_count, n_ref_count, or n_alt_count"
 	echo ${message}
-	echo -e "${message}" | mail -s "MSKIMPACT scan for missing tumor/normal-ref/alt counts failure" $email_list
+	echo -e "${message}" | mail -s "MSKIMPACT scan for missing tumor/normal-ref/alt counts failure" $PIPELINES_EMAIL_LIST
 	exit 3
 fi
 #test passed - no blanks found in somatic/unknown records

--- a/import-scripts/update-gene-data.sh
+++ b/import-scripts/update-gene-data.sh
@@ -4,7 +4,7 @@ tmp=$PORTAL_HOME/tmp/update-gene-data
 if [[ -d "$tmp" && "$tmp" != "/" ]]; then
     rm -rf "$tmp"/*
 fi
-email_list="cbioportal-pipelines@cbio.mskcc.org"
+PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
 GENE_DATA_UPDATER_JAR_FILENAME="$PORTAL_HOME/lib/gene_data_updater.jar"
 JAVA_GENE_DATA_UPDATER_ARGS="$JAVA_PROXY_ARGS -jar $GENE_DATA_UPDATER_JAR_FILENAME"
 JAVA_SSL_TRUSTORE_ARGS="-Djavax.net.ssl.trustStore=$AWS_GDAC_SSL_TRUSTSTORE -Djavax.net.ssl.turstStorePassword=$TRUSTSTORE_PASSWORD"
@@ -77,15 +77,15 @@ function runGeneUpdatePipeline {
     $JAVA_BINARY $JAVA_EXTRA_ARGS $JAVA_GENE_DATA_UPDATER_ARGS -d $tmp/Homo_sapiens.gene_info -l $tmp/ref_GRCh38.p12_top_level.gff3 -n $tmp/gene-update-notification.txt
     if [ $? -ne 0 ]; then
         echo "Error updating gene data"
-        echo -e "Error updating gene data." | mail -s "Gene Data Update Failure: $DATABASE_NAME" $email_list
+        echo -e "Error updating gene data." | mail -s "Gene Data Update Failure: $DATABASE_NAME" $PIPELINES_EMAIL_LIST
     else
         echo "Success!"
         echo "Emailing results to email list..."
         if [[ -f $tmp/gene-update-notification.txt && $(wc -l < $tmp/gene-update-notification.txt) -gt 0 ]]; then
-            cat $tmp/gene-update-notification.txt | mail -s "Gene Data Update Results: $DATABASE_NAME" $email_list
+            cat $tmp/gene-update-notification.txt | mail -s "Gene Data Update Results: $DATABASE_NAME" $PIPELINES_EMAIL_LIST
         else
             EMAIL_BODY="Error loading $tmp/gene-update-notification.txt"
-            echo -e $EMAIL_BODY | mail -s "Gene Data Update Results: $DATABASE_NAME" $email_list
+            echo -e $EMAIL_BODY | mail -s "Gene Data Update Results: $DATABASE_NAME" $PIPELINES_EMAIL_LIST
         fi
     fi
 }
@@ -111,7 +111,7 @@ TOMCAT_SERVER_DISPLAY_NAME="triage-tomcat7"
 if ! /usr/bin/sudo /etc/init.d/triage-tomcat7 restart ; then
     EMAIL_BODY="Attempt to trigger a restart of the $TOMCAT_SERVER_DISPLAY_NAME server failed"
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $pipeline_email_list
+    echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $PIPELINES_EMAIL_LIST
 fi
 
 echo "Restarting msk-tomcat servers..."
@@ -131,7 +131,7 @@ done
 if [ ${#failed_restart_server_list[*]} -ne 0 ] ; then
     EMAIL_BODY="Attempt to trigger a restart of the $TOMCAT_SERVER_DISPLAY_NAME server on the following hosts failed: ${failed_restart_server_list[*]}"
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $PIPELINES_EMAIL_LIST
 fi
 
 echo "Restarting public-tomcat servers..."
@@ -151,7 +151,7 @@ done
 if [ ${#failed_restart_server_list[*]} -ne 0 ] ; then
     EMAIL_BODY="Attempt to trigger a restart of the $TOMCAT_SERVER_DISPLAY_NAME server on the following hosts failed: ${failed_restart_server_list[*]}"
     echo -e "Sending email $EMAIL_BODY"
-    echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $email_list
+    echo -e "$EMAIL_BODY" | mail -s "$TOMCAT_SERVER_PRETTY_DISPLAY_NAME Restart Error : unable to trigger restart" $PIPELINES_EMAIL_LIST
 fi
 
 echo "Removing gene data files downloaded..."


### PR DESCRIPTION
The core files to examine are:
import-scripts/import-cmo-data-msk.sh
import-scripts/import-cmo-data-triage.sh
import-scripts/set-data-source-environment-vars.sh (new functions an variables placed here)

All other file changes are simply standardizations of the script variable names for email lists.