### PR TITLE
fix lock acquisition bug

### DIFF
--- a/import-scripts/purge_deactivated_ldap_users.sh
+++ b/import-scripts/purge_deactivated_ldap_users.sh
@@ -4,14 +4,14 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/purge_deactivated_ldap_users.lock
 IMPORT_PORTAL_USERS_FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-portal-users.lock"
 
 (
+    # wait for import_portal_users to complete and release lock if it is running
+    flock --exclusive $import_portal_users_flock_fd
+
     # check lock so that script executions do not overlap
     if ! flock --nonblock --exclusive $my_flock_fd ; then
         echo "Failure : could not acquire lock for $MY_FLOCK_FILEPATH another instance of this process seems to still be running."
         exit 1
     fi
-
-    # wait for import_portal_users to complete and release lock if it is running
-    flock --exclusive $import_portal_users_flock_fd
 
     LDAPLOGFILENAME="$PORTAL_HOME/logs/purge-deactivated-ldap-users.log"
     LDAPTMPDIRECTORY="$PORTAL_HOME/tmp/ldap"


### PR DESCRIPTION
- purge_deactivated_ldap_users script was sometimes blocked by import-portal-users because its own lock could be held by import-portal-users at time of execution.
- now the purge script will wait for import-portal-users to exit and release both locks before it attempts to acquire its own lock.