### PR TITLE
Add MSK GitHub enterprise SSH key to SSH agent

### DIFF
--- a/import-scripts/automation-environment.sh
+++ b/import-scripts/automation-environment.sh
@@ -115,3 +115,9 @@ export ACCESS_REDCAP_BACKUP=$REDCAP_BACKUP_DATA_HOME/mskaccess
 # environment variables used in the import-pdx-data script
 #######################
 export CRDB_FETCHER_PDX_HOME=$PDX_DATA_HOME/crdb_pdx_raw_data
+
+#######################
+# add github mskcc ssh key to ssh-agent
+#######################
+eval "$(ssh-agent -s)" > /dev/null 2>&1
+ssh-add ~/.ssh/id_rsa_shahcompbio 2> /dev/null


### PR DESCRIPTION
Run ssh-agent in background on source of `automation-environment.sh` and add ssh identity for MSK GitHub enterprise.

This change resolves permission denied error when attempting to update any MKS GitHub enterprise repositories without first adding the ssh identity key to the `pipelines` ssh-agent.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>