### PR TITLE
Updated MSKACCESS CVR data types and consume samples after successful fetch/import

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -92,7 +92,7 @@ public class CVRUtilities {
         Map<String, List<String>> map = new HashMap<>();
         map.put("mskarcher", Arrays.asList(new String[]{"mutations", "cna", "seg"}));
         map.put("mskraindance", Arrays.asList(new String[]{"cna", "seg", "sv-fusions"}));
-        map.put("mskaccess", Arrays.asList(new String[]{"cna", "seg", "sv-fusions"}));
+        map.put("mskaccess", Arrays.asList(new String[]{"seg"}));
         return map;
     }
 

--- a/import-scripts/cvr_dmp_endpoint_utility.py
+++ b/import-scripts/cvr_dmp_endpoint_utility.py
@@ -33,6 +33,7 @@ RETRIEVE_VARIANTS_MSKIMPMACT = 'dmp.tokens.retrieve_variants.impact'
 RETRIEVE_VARIANTS_HEMEPACT = 'dmp.tokens.retrieve_variants.heme'
 RETRIEVE_VARIANTS_RAINDANCE = 'dmp.tokens.retrieve_variants.rdts'
 RETRIEVE_VARIANTS_ARCHER = 'dmp.tokens.retrieve_variants.archer'
+RETRIEVE_VARIANTS_ACCESS = 'dmp.tokens.retrieve_variants.access'
 
 REQUIRED_PROPERTIES = [
     DMP_USER,
@@ -49,7 +50,8 @@ REQUIRED_PROPERTIES = [
     RETRIEVE_VARIANTS_MSKIMPMACT,
     RETRIEVE_VARIANTS_HEMEPACT,
     RETRIEVE_VARIANTS_RAINDANCE,
-    RETRIEVE_VARIANTS_ARCHER
+    RETRIEVE_VARIANTS_ARCHER,
+    RETRIEVE_VARIANTS_ACCESS
 ]
 
 SESSION_DATA_FILENAME = 'cvr_session_data.json'
@@ -72,7 +74,7 @@ RETRIEVE_VARIANTS_DMP_SAMPLE_ID = 'dmp_sample_id'
 
 CONSUME_AFFECTED_ROWS = 'affectedRows'
 
-DMP_STUDY_IDS = ['mskimpact', 'mskimpact_heme', 'mskraindance', 'mskarcher']
+DMP_STUDY_IDS = ['mskimpact', 'mskimpact_heme', 'mskraindance', 'mskarcher', 'mskaccess']
 DMP_SAMPLE_ID_PATTERN = re.compile('P-\d*-T\d*-[IH|TB|TS|AH|AS|IM]+\d')
 
 MASTERLIST_CHECK_ARG_DESCRIPTION = '[optional] Fetches masterlist for study and reports samples from samples file that are missing from masterlist.'
@@ -99,6 +101,7 @@ class PortalProperties(object):
         self.retrieve_variants_hemepact = properties[RETRIEVE_VARIANTS_HEMEPACT]
         self.retrieve_variants_raindance = properties[RETRIEVE_VARIANTS_RAINDANCE]
         self.retrieve_variants_archer = properties[RETRIEVE_VARIANTS_ARCHER]
+        self.retrieve_variants_access = properties[RETRIEVE_VARIANTS_ACCESS]
 
     def parse_properties(self, properties_filename):
         properties = {}
@@ -148,6 +151,8 @@ class PortalProperties(object):
             return self.retrieve_variants_raindance
         if study_id == 'mskarcher':
             return self.retrieve_variants_archer
+        if study_id == 'mskacess':
+            return self.retrieve_variants_access
 
 # ------------------------------------------------------------------------------
 # functions
@@ -222,6 +227,9 @@ def get_dmp_masterlist(portal_properties, session_data, study_id):
     '''
         Returns the master list for a given study id.
     '''
+    if study_id == 'mskaccess':
+        print >> OUTPUT_FILE, 'The CVR master list is not yet supported in the CVR web service for study mskaccess'
+        return set()
     url = '%s%s/%s/%s' % (portal_properties.dmp_server, portal_properties.masterlist_route, session_data[CREATE_SESSION_SESSION_ID], portal_properties.get_study_masterlist_endpoint(study_id))
     print >> OUTPUT_FILE, 'Fetching masterlist for study \'%s\': %s' % (study_id, url)
     response = urllib.urlopen(url)

--- a/import-scripts/dmp-import-vars-functions.sh
+++ b/import-scripts/dmp-import-vars-functions.sh
@@ -356,4 +356,9 @@ function consumeSamplesAfterSolidHemeImport {
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -c $MSK_HEMEPACT_DATA_HOME/cvr_data.json
         rm -f $MSK_HEMEPACT_CONSUME_TRIGGER
     fi
+    if [ -f $MSK_ACCESS_CONSUME_TRIGGER ] ; then
+        echo "Consuming mskaccess samples from cvr"
+        $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -c $MSK_ACCESS_DATA_HOME/cvr_data.json
+        rm -f $MSK_ACCESS_CONSUME_TRIGGER
+    fi
 }


### PR DESCRIPTION
Consume MSKACCESS samples after successful fetch and import. 
Remove CNA and SV/fusions as skipped data types.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>