### PR TITLE
MSKACCESS seq date file fix

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -66,7 +66,7 @@ public class CVRUtilities {
     public static final String GML_FILE = "cvr_gml_data.json";
     public static final String GENE_PANEL = "gene_panels/impact468_gene_panel.txt";
     public static final String ZERO_VARIANT_WHITELIST_FILE = "cvr/zero_variant_whitelist.txt";
-    public static final List<String> SUPPORTED_SEQ_DATE_STUDY_IDS = Arrays.asList("mskimpact", "mskimpact_heme");
+    public static final List<String> SUPPORTED_SEQ_DATE_STUDY_IDS = Arrays.asList("mskimpact", "mskimpact_heme", "mskaccess");
 
     // pipeline globals
     public static final String CNA_HEADER_HUGO_SYMBOL = "Hugo_Symbol";

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -499,7 +499,7 @@ if [ $ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COU
     ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT
 fi
 
-$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskaccess -p $mskaccess_dmp_pids_file -f survival,diagnosis -o $MSK_ACCESS_DATA_HOME -r $ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskaccess -p $mskaccess_dmp_pids_file -s $MSK_ACCESS_DATA_HOME/cvr/seq_date.txt -f survival -o $MSK_ACCESS_DATA_HOME -r $ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT
 if [ $? -gt 0 ] ; then
     cd $MSK_ACCESS_DATA_HOME ; $HG_BINARY update -C ; find . -name "*.orig" -delete
     sendPreImportFailureMessageMskPipelineLogsSlack "ACCESS DDP Demographics Fetch"


### PR DESCRIPTION
Start supporting `cvr/seq_date.txt` processing for MSKACCESS. 

Call DDP fetcher with seq_date.txt file argument instead of fetching diagnosis. 

These changes are needed to resolve the `OS_MONTHS` issue for MSKACCESS data. If seq date is not available then the clinical data should default to `NA`

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>