### PR TITLE
Fetch and update timeline data for MSKSPECTRUM

### DIFF
--- a/ddp/ddp_pipeline/src/main/resources/application.properties.EXAMPLE
+++ b/ddp/ddp_pipeline/src/main/resources/application.properties.EXAMPLE
@@ -32,7 +32,7 @@ processor.thread.pool.size=100
 processor.thread.pool.max=100
 
 # DDP cohort IDs
-ddp.cohort.map={"mskimpact":2033,"mskimpact_ped":1852, "mskimpact_heme":2033, "mskraindance":2033, "mskarcher":2033, "mskaccess":2033, "mskextract":2033}
+ddp.cohort.map={"mskimpact":2033,"mskimpact_ped":1852, "mskimpact_heme":2033, "mskraindance":2033, "mskarcher":2033, "mskaccess":2033, "mskextract":2033, "mskspectrum":2033}
 
 # NAACCR mappings resource filenames
 naaccr.ethnicity=naaccr_ethnicity.json

--- a/import-scripts/automation-environment.sh
+++ b/import-scripts/automation-environment.sh
@@ -53,6 +53,7 @@ export FOUNDATION_DATA_HOME=$PORTAL_DATA_HOME/foundation
 export IMPACT_DATA_HOME=$PORTAL_DATA_HOME/impact
 export DATAHUB_DATA_HOME=$PORTAL_DATA_HOME/datahub/public
 export MSK_EXTRACT_DATA_HOME=$PORTAL_DATA_HOME/msk-extract
+export MSK_SHAHLAB_DATA_HOME=$PORTAL_DATA_HOME/datahub_shahlab
 
 #######################
 # environment variables used across import scripts
@@ -101,6 +102,7 @@ export MSK_SCLC_DATA_HOME=$DMP_DATA_HOME/sclc_mskimpact_2017
 export MSKIMPACT_PED_DATA_HOME=$DMP_DATA_HOME/mskimpact_ped
 export LYMPHOMA_SUPER_COHORT_DATA_HOME=$DMP_DATA_HOME/lymphoma_super_cohort_fmi_msk
 export MSK_EXTRACT_COHORT_DATA_HOME=$MSK_EXTRACT_DATA_HOME/datahub/msk_extract_cohort2_2019
+export MSK_SPECTRUM_COHORT_DATA_HOME=$MSK_SHAHLAB_DATA_HOME/msk_spectrum
 # read-only data directories
 export FMI_BATLEVI_DATA_HOME=$FOUNDATION_DATA_HOME/mixed/lymphoma/mskcc/foundation/lymph_landscape_fmi_201611
 

--- a/import-scripts/fetch-and-import-dmp-data-wrapper.sh
+++ b/import-scripts/fetch-and-import-dmp-data-wrapper.sh
@@ -16,4 +16,7 @@ date
 echo executing update-msk-extract-cohort.sh
 /data/portal-cron/scripts/update-msk-extract-cohort.sh
 date
+echo executing update-msk-spectrum-cohort.sh
+/data/portal-cron/scripts/update-msk-spectrum-cohort.sh
+date
 echo wrapper complete

--- a/import-scripts/update-msk-spectrum-cohort.sh
+++ b/import-scripts/update-msk-spectrum-cohort.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+source $PORTAL_HOME/scripts/dmp-import-vars-functions.sh
+source $PORTAL_HOME/scripts/set-data-source-environment-vars.sh
+
+echo $(date)
+
+if [[ -d "$MSK_DMP_TMPDIR" && "$MSK_DMP_TMPDIR" != "/" ]] ; then
+    rm -rf "$MSK_DMP_TMPDIR"/*
+fi
+
+if [ -z $JAVA_BINARY ] | [ -z $GIT_BINARY ] | [ -z $PORTAL_HOME ] | [ -z $MSK_SHAHLAB_DATA_HOME ] | [ -z $MSK_SPECTRUM_COHORT_DATA_HOME ] ; then
+    message="test could not run update-msk-spectrum-cohort.sh: automation-environment.sh script must be run in order to set needed environment variables (like MSK_SHAHLAB_DATA_HOME, ...)"
+    echo $message
+    echo -e "$message" |  mail -s "update-msk-spectrum-cohort failed to run." $PIPELINES_EMAIL_LIST
+    sendPreImportFailureMessageMskPipelineLogsSlack "$message"
+    exit 2
+fi
+
+IMPORT_FAIL=0
+mskspectrum_notification_file=$(mktemp $MSK_DMP_TMPDIR/mskspectrum-portal-update-notification.$now.XXXXXX)
+# update msk-spectrum github repo
+fetch_updates_in_data_sources "datahub_shahlab"
+
+# fetch ddp timeline data
+printTimeStampedDataProcessingStepMessage "DDP demographics fetch for MSKSPECTRUM"
+mskspectrum_dmp_pids_file=$MSK_DMP_TMPDIR/mskspectrum_patient_list.txt
+grep -v "^#" $MSK_SPECTRUM_COHORT_DATA_HOME/data_clinical_patient.txt | cut -f1 | grep -v "PATIENT_ID" | sort | uniq > $mskspectrum_dmp_pids_file
+MSKSPECTRUM_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $mskspectrum_dmp_pids_file)
+if [ $MSKSPECTRUM_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT ] ; then
+    MSKSPECTRUM_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT
+fi
+
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskspectrum -p $mskspectrum_dmp_pids_file -f diagnosis,radiation,chemotherapy,surgery,survival -o $MSK_SPECTRUM_COHORT_DATA_HOME -r $MSKSPECTRUM_DDP_DEMOGRAPHICS_RECORD_COUNT
+if [ $? -gt 0 ] ; then
+    bash $PORTAL_HOME/scripts/datasource-repo-cleanup.sh $PORTAL_DATA_HOME/datahub_shahlab
+    sendPreImportFailureMessageMskPipelineLogsSlack "MSKSPECTRUM DDP Timeline Fetch"
+else
+    echo "commit ddp timeline data for MSKSPECTRUM"
+    cd $MSK_SHAHLAB_DATA_HOME ; rm -f $MSK_SPECTRUM_COHORT_DATA_HOME/data_clinical_ddp.txt ; $GIT_BINARY add $MSK_SPECTRUM_COHORT_DATA_HOME/data_timeline* ; $GIT_BINARY commit -m "Latest MSKSPECTRUM DDP timeline data" ; $GIT_BINARY push origin
+fi
+
+# update mskspectrum cohort in portal
+$JAVA_BINARY -Xmx64g $JAVA_IMPORTER_ARGS --update-study-data --portal msk-spectrum-portal --notification-file $mskspectrum_notification_file --oncotree-version $ONCOTREE_VERSION_TO_USE --transcript-overrides-source mskcc --disable-redcap-export
+if [ $? -gt 0 ]; then
+    echo "MSKSPECTRUM update failed!"
+    IMPORT_FAIL=1
+    EMAIL_BODY="MSKSPECTRUM update failed"
+    echo -e "Sending email $EMAIL_BODY"
+    echo -e "$EMAIL_BODY" | mail -s "Update failure: MSKSPECTRUM" $CMO_EMAIL_LIST
+fi
+
+# get num studies updated
+if [[ $? -eq 0 && -f "$TMP_DIRECTORY/num_studies_updated.txt" ]]; then
+    num_studies_updated=`cat $TMP_DIRECTORY/num_studies_updated.txt`
+else
+    num_studies_updated=0
+fi
+
+# redeploy war
+if [[ $IMPORT_FAIL -eq 0 && $num_studies_updated -gt 0 ]]; then
+    echo "'$num_studies_updated' studies have been updated, requesting redeployment of msk portal war..."
+    restartMSKTomcats
+    echo "'$num_studies_updated' studies have been updated (no longer need to restart $TOMCAT_SERVER_DISPLAY_NAME server...)"
+else
+    echo "No studies have been updated, skipping redeploy of msk portal war..."
+fi
+
+# clean up msk-spectrum repo and send notification file
+bash $PORTAL_HOME/scripts/datasource-repo-cleanup.sh $PORTAL_DATA_HOME/datahub_shahlab
+$JAVA_BINARY $JAVA_IMPORTER_ARGS --send-update-notification --portal msk-spectrum-portal --notification-file "$mskspectrum_notification_file"


### PR DESCRIPTION
Changes in this PR:
- added mskspectrum to set of valid cohort ids for DDP fetcher
- updated automation environment script with vars for SHAHLAB and MSKSPECTRUM file paths
- updated fetch/import DMP data wrapper with call to script to update mskspectrum timeline data


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>