### PR TITLE
authenticate when querying oncokb

### DIFF
--- a/import-scripts/automation-environment.sh
+++ b/import-scripts/automation-environment.sh
@@ -126,4 +126,5 @@ export CRDB_FETCHER_PDX_HOME=$PDX_DATA_HOME/crdb_pdx_raw_data
 # environment variables used for oncokb annotator script
 #######################
 export ONCOKB_URL="http://oncokb.org"
+export ONCOKB_TOKEN_FILE=$PORTAL_HOME/pipelines-credentials/oncokb.token
 export CANCER_HOTSPOTS_URL="http://www.cancerhotspots.org"


### PR DESCRIPTION
* Uses `-b` option when calling `MafAnnotator.py`, `FusionAnnotator.py`, and `CnaAnnotator.py`
* Calls `GenerateReadMe.py` to generate `dmp/msk_solid_heme/oncokb/README`

TODO:
* Switch to `with-auth` branch in production.