### PR TITLE
fix bug when multiple restart fails occur

### DIFF
--- a/import-scripts/restart-portal-pods.sh
+++ b/import-scripts/restart-portal-pods.sh
@@ -29,7 +29,7 @@ if [ -z $portal_id ] ; then
     exit 1
 fi
 deployment_id=${portal_to_deployment_map[$portal_id]}
-if [ -z $deployment_id ] ; then
+if [ -z "$deployment_id" ] ; then
     echo "invalid portal_id : $portal_id"
     print_portal_id_values
 fi


### PR DESCRIPTION
we were getting emails from the cron daemon such as this:
/data/portal-cron/scripts/import-portal-users.sh: line 37: [: cgds_gdac: binary operator expected
when both kubernetes deployments failed to restart. This fixes this bug by wrapping the list of failed redeployments in quotes to form a string before doing the empty-string test.