### PR TITLE
Update slack webhook for msk-pipeline-logs

### DIFF
--- a/import-scripts/automation-environment.sh
+++ b/import-scripts/automation-environment.sh
@@ -36,6 +36,7 @@ export CDD_HOME=$PORTAL_GIT_HOME/clinical-data-dictionary
 export DDP_CREDENTIALS_FILE=$PORTAL_HOME/pipelines-credentials/application-secure.properties
 export AWS_SSL_TRUSTSTORE=$PORTAL_HOME/pipelines-credentials/AwsSsl.truststore
 export AWS_SSL_TRUSTSTORE_PASSWORD_FILE=$PORTAL_HOME/pipelines-credentials/AwsSsl.truststore.password
+export SLACK_URL_FILE=$PORTAL_HOME/pipelines-credentials/slack.url
 
 #######################
 # environment variables for configuration / properties files

--- a/import-scripts/backup-redcap-data.sh
+++ b/import-scripts/backup-redcap-data.sh
@@ -3,6 +3,7 @@
 # take snapshot of REDCap projects for MSKIMPACT, RAINDANCE, HEMEPACT, ARCHER
 echo $(date)
 PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
+SLACK_PIPELINES_MONITOR_URL=`cat $SLACK_URL_FILE`
 
 # flags for REDCap export status
 MSKIMPACT_REDCAP_EXPORT_FAIL=0
@@ -23,13 +24,13 @@ ACCESS_VALIDATION_FAIL=0
 # Function for alerting slack channel of any failures
 function sendFailureMessageMskPipelineLogsSlack {
     MESSAGE=$1
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"REDCap backup failed: $MESSAGE\", \"icon_emoji\": \":fire:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"REDCap backup failed: $MESSAGE\", \"icon_emoji\": \":fire:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 
 # Function for alerting slack channel of successful imports
 function sendSuccessMessageMskPipelineLogsSlack {
     MESSAGE=$1
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"REDCap data backup succeeded! $MESSAGE\", \"icon_emoji\": \":tada:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"REDCap data backup succeeded! $MESSAGE\", \"icon_emoji\": \":tada:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 
 # Validate exported REDCap data

--- a/import-scripts/dmp-import-vars-functions.sh
+++ b/import-scripts/dmp-import-vars-functions.sh
@@ -20,6 +20,7 @@ JAVA_REDCAP_PIPELINE_ARGS="-jar $REDCAP_PIPELINE_JAR_FILENAME"
 JAVA_DEBUG_ARGS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182"
 JAVA_IMPORTER_ARGS="$JAVA_PROXY_ARGS $JAVA_DEBUG_ARGS -Dspring.profiles.active=dbcp -Djava.io.tmpdir=$MSK_DMP_TMPDIR -ea -cp $IMPORTER_JAR_FILENAME org.mskcc.cbio.importer.Admin"
 PIPELINES_EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
+SLACK_PIPELINES_MONITOR_URL=`cat $SLACK_URL_FILE`
 
 DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT=2
 
@@ -70,19 +71,19 @@ function extractPropertiesFromFile() {
 # Function for alerting slack channel of any failures
 function sendPreImportFailureMessageMskPipelineLogsSlack {
     MESSAGE=$1
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK cBio pipelines pre-import process failed: $MESSAGE\", \"icon_emoji\": \":tired_face:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK cBio pipelines pre-import process failed: $MESSAGE\", \"icon_emoji\": \":tired_face:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 
 # Function for alerting slack channel of any failures
 function sendImportFailureMessageMskPipelineLogsSlack {
     MESSAGE=$1
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK cBio pipelines import process failed: $MESSAGE\", \"icon_emoji\": \":tired_face:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK cBio pipelines import process failed: $MESSAGE\", \"icon_emoji\": \":tired_face:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 
 # Function for alerting slack channel of successful imports
 function sendImportSuccessMessageMskPipelineLogsSlack {
     STUDY_ID=$1
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK cBio pipelines import success: $STUDY_ID\", \"icon_emoji\": \":tada:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK cBio pipelines import success: $STUDY_ID\", \"icon_emoji\": \":tada:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 
 function printTimeStampedDataProcessingStepMessage {

--- a/import-scripts/import-pdx-data.sh
+++ b/import-scripts/import-pdx-data.sh
@@ -27,13 +27,13 @@ declare -a study_list
 # Function for alerting slack channel of any failures
 function sendFailureMessageMskPipelineLogsSlack {
     MESSAGE=$1
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"$MESSAGE\", \"icon_emoji\": \":tired_face:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"$MESSAGE\", \"icon_emoji\": \":tired_face:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 
 # Function for alerting slack channel of successful imports
 function sendSuccessMessageMskPipelineLogsSlack {
     MESSAGE=$1
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"$MESSAGE\", \"icon_emoji\": \":tada:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"$MESSAGE\", \"icon_emoji\": \":tada:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 
 function setMercurialRootDirForDirectory {
@@ -175,6 +175,7 @@ IMPORTER_JAR_FILENAME=$PORTAL_HOME/lib/msk-cmo-importer.jar
 IMPORTER_DEBUG_PORT=27182
 CRDB_FETCHER_JAR_FILENAME="$PORTAL_HOME/lib/crdb_fetcher.jar"
 importer_notification_file=$(mktemp $CRDB_PDX_TMPDIR/importer-update-notification.$now.XXXXXX)
+SLACK_PIPELINES_MONITOR_URL=`cat $SLACK_URL_FILE`
 JAVA_DEBUG_ARGS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$IMPORTER_DEBUG_PORT"
 JAVA_CRDB_FETCHER_ARGS="-jar $CRDB_FETCHER_JAR_FILENAME"
 JAVA_IMPORTER_ARGS="$JAVA_PROXY_ARGS $JAVA_DEBUG_ARGS -Dspring.profiles.active=dbcp -Djava.io.tmpdir=$CRDB_PDX_TMPDIR -ea -cp $IMPORTER_JAR_FILENAME org.mskcc.cbio.importer.Admin"

--- a/import-scripts/import-temp-study.sh
+++ b/import-scripts/import-temp-study.sh
@@ -41,7 +41,7 @@ function usage {
 
 function sendFailureMessageMskPipelineLogsSlack {
     MESSAGE=$1
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK temporary study import process failed: $MESSAGE\", \"icon_emoji\": \":tired_face:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK temporary study import process failed: $MESSAGE\", \"icon_emoji\": \":tired_face:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 
 # set default value(s)
@@ -124,6 +124,7 @@ fi
 JAVA_DEBUG_ARGS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=27182"
 JAVA_IMPORTER_ARGS="$JAVA_PROXY_ARGS $JAVA_DEBUG_ARGS -Dspring.profiles.active=dbcp -Djava.io.tmpdir=$TMP_DIRECTORY -ea -cp $IMPORTER_JAR_FILENAME org.mskcc.cbio.importer.Admin"
 GROUP_FOR_HIDING_BACKUP_STUDIES="KSBACKUP"
+SLACK_PIPELINES_MONITOR_URL=`cat $SLACK_URL_FILE`
 
 # define validator notification filename based on cancer study id, remove if already exists, touch new file
 now=$(date "+%Y-%m-%d-%H-%M-%S")

--- a/import-scripts/monitor-redis-and-restart.sh
+++ b/import-scripts/monitor-redis-and-restart.sh
@@ -14,6 +14,7 @@ REDIS_BINARY=$REDIS_HOME/src/redis-server
 REDIS_PING_FAST_TIMEOUT=3
 REDIS_PING_SLOW_TIMEOUT=3
 MAX_REDIS_PING_ATTEMPTS=10
+SLACK_PIPELINES_MONITOR_URL=`cat $SLACK_URL_FILE`
 DEBUG_MODE=0
 
 if ! which redis-cli >> /dev/null ; then
@@ -24,7 +25,7 @@ fi
 # Function for alerting slack channel of any failures
 function sendRedisRestartNotification {
     MESSAGE=$1
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"redis server monitor script : $MESSAGE\", \"icon_emoji\": \":flushed:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"redis server monitor script : $MESSAGE\", \"icon_emoji\": \":flushed:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 #" this comment "fixes" the syntax coloring in vi
 

--- a/import-scripts/refresh-cdd-oncotree-cache.sh
+++ b/import-scripts/refresh-cdd-oncotree-cache.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 EMAIL_LIST="cbioportal-pipelines@cbio.mskcc.org"
+SLACK_PIPELINES_MONITOR_URL=`cat $SLACK_URL_FILE`
 MAX_ATTEMPTS=5
 
 function usage {
@@ -48,7 +49,7 @@ fi
 function sendFailureMessageSlackEmail {
     MESSAGE_BODY=$1
     SUBJECT_MESSAGE=$2
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK cBio pipelines recache process status: $MESSAGE_BODY\", \"icon_emoji\": \":fire:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK cBio pipelines recache process status: $MESSAGE_BODY\", \"icon_emoji\": \":fire:\"}" $SLACK_PIPELINES_MONITOR_URL
     echo -e "$MESSAGE_BODY" | mail -s "$SUBJECT_MESSAGE" $EMAIL_LIST
 }
 
@@ -56,7 +57,7 @@ function sendFailureMessageSlackEmail {
 function sendSuccessMessageSlackEmail {
     MESSAGE_BODY=$1
     SUBJECT_MESSAGE=$2
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK cBio pipelines recache process status: $MESSAGE_BODY\", \"icon_emoji\": \":arrows_counterclockwise:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"MSK cBio pipelines recache process status: $MESSAGE_BODY\", \"icon_emoji\": \":arrows_counterclockwise:\"}" $SLACK_PIPELINES_MONITOR_URL
     echo -e "$MESSAGE_BODY" | mail -s "$SUBJECT_MESSAGE" $EMAIL_LIST
 }
 

--- a/import-scripts/rsync_jenkins_test_properties.sh
+++ b/import-scripts/rsync_jenkins_test_properties.sh
@@ -10,7 +10,7 @@ JENKINS_SRV_PIPELINES_CREDENTIALS=$JENKINS_SRV_HOME_DIRECTORY/pipelines-credenti
 JENKINS_SRV_GIT_CREDENTIALS=$JENKINS_SRV_HOME_DIRECTORY/git-credentials
 # Function for alerting slack channel that something failed
 function sendFailureMessageMskPipelineLogsSlack {
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"$1\", \"icon_emoji\": \":boom:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"cbioportal_importer\", \"text\": \"$1\", \"icon_emoji\": \":boom:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 
 if ! [ -f $PATH_TO_AUTOMATION_SCRIPT ] ; then
@@ -19,11 +19,14 @@ if ! [ -f $PATH_TO_AUTOMATION_SCRIPT ] ; then
 fi
 
 . $PATH_TO_AUTOMATION_SCRIPT
+
 # local jenkins staging paths
 LOCAL_PROPERTIES_DIRECTORY=$PIPELINES_CONFIG_HOME/properties/
 LOCAL_JENKINS_DIRECTORY=$PIPELINES_CONFIG_HOME/jenkins/
 LOCAL_PIPELINES_CREDENTIALS=$PORTAL_HOME/pipelines-credentials/
 LOCAL_GIT_CREDENTIALS=$PIPELINES_CONFIG_HOME/git/git-credentials
+
+SLACK_PIPELINES_MONITOR_URL=`cat $SLACK_URL_FILE`
 
 cd $LOCAL_PROPERTIES_DIRECTORY
 git pull

--- a/integration-tests/run-cron-integration-tests.sh
+++ b/integration-tests/run-cron-integration-tests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-TESTING_DIRECTORY=/var/lib/jenkins/tempdir
+JENKINS_USER_HOME_DIRECTORY=/var/lib/jenkins
+JENKINS_PIPELINES_CREDENTIALS=$JENKINS_USER_HOME_DIRECTORY/pipelines-credentials
+TESTING_DIRECTORY=$JENKINS_USER_HOME_DIRECTORY/tempdir
+
 if [ ! -d $TESTING_DIRECTORY ] ; then
     mkdir -p $TESTING_DIRECTORY
 fi
@@ -11,11 +14,12 @@ CMO_PIPELINES_DIRECTORY="$(pwd)"
 CMO_REDCAP_DIRECTORY=$CMO_PIPELINES_DIRECTORY/redcap
 CMO_INTEGRATION_TESTS_DIRECTORY=$CMO_PIPELINES_DIRECTORY/integration-tests
 REDCAP_JAR=$CMO_REDCAP_DIRECTORY/redcap_pipeline/target/redcap_pipeline.jar
+SLACK_PIPELINES_MONITOR_URL=`cat $JENKINS_PIPELINES_CREDENTIALS/slack.url`
 TEST_SUCCESS=0
 
 # Function for alerting slack channel of any failures
 function sendFailureMessageMskPipelineLogsSlack {
-    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"jenkins\", \"text\": \"Redcap ID mappings integration test failed! Please fix before the production run.\", \"icon_emoji\": \":face_palm:\"}" https://hooks.slack.com/services/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
+    curl -X POST --data-urlencode "payload={\"channel\": \"#msk-pipeline-logs\", \"username\": \"jenkins\", \"text\": \"Redcap ID mappings integration test failed! Please fix before the production run.\", \"icon_emoji\": \":face_palm:\"}" $SLACK_PIPELINES_MONITOR_URL
 }
 
 mkdir -p $REDCAP_EXPORTS_DIRECTORY $LIB_DIRECTORY


### PR DESCRIPTION
Closes #661 
- Slack token is broken, Slack invalidates webhook URL when it is found in a code sharing repository
- mechanism changed, webhook URL now saved in `pipeline-credentials/slack.url` and cat-ed for url
- if approved, new link also propagated to oncotree/cdd application.properties and WARs redeployed
