### PR TITLE
Set default "max samples to remove" for ACCESS as -1

### DIFF
--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -468,7 +468,9 @@ if [ $IMPORT_STATUS_ACCESS -eq 0 ] ; then
     # fetch new/updated access samples using CVR Web service (must come after git fetching).
     printTimeStampedDataProcessingStepMessage "CVR fetch for access"
     # access has -b option to block warnings for samples with zero variants (all samples will have zero variants)
-    $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_ACCESS_DATA_HOME -n data_clinical_mskaccess_data_clinical.txt -i mskaccess -s -b $CVR_TEST_MODE_ARGS
+    # set max number of records to "remove" from MSKACCESS to "-1" -> this value will prevent any samples from being removed from the existing dataset
+    # as a precaution since MSKACCESS master list endpoint does not exist
+    $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_ACCESS_DATA_HOME -n data_clinical_mskaccess_data_clinical.txt -i mskaccess -s -b $CVR_TEST_MODE_ARGS -r -1
     if [ $? -gt 0 ] ; then
         echo "CVR ACCESS fetch failed!"
         echo "This will not affect importing of mskimpact"


### PR DESCRIPTION
This is a precaution to prevent samples from being dropped from MSKACCESS since a master list endpoint does not exist for this cohort.