### PR TITLE
CVR webservice uses new server

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/consume/ConsumeSampleWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/consume/ConsumeSampleWriter.java
@@ -54,11 +54,8 @@ import org.springframework.web.client.RestTemplate;
  */
 public class ConsumeSampleWriter implements ItemStreamWriter<String> {
     
-    @Value("#{jobParameters[jsonFilename]}")
-    private String jsonFilename;
-    
-    @Value("${dmp.server_name}")
-    private String dmpServerName;
+    @Value("${dmp.consume_server_name}")
+    private String dmpConsumeServerName;
 
     @Value("${dmp.gml_server_name}")
     private String dmpGmlServerName;
@@ -92,7 +89,7 @@ public class ConsumeSampleWriter implements ItemStreamWriter<String> {
             this.dmpConsumeUrl = dmpGmlServerName + dmpConsumeGmlSample + "/" + sessionId + "/";
         }
         else {
-            this.dmpConsumeUrl = dmpServerName + dmpConsumeSample + "/" + sessionId + "/";
+            this.dmpConsumeUrl = dmpConsumeServerName + dmpConsumeSample + "/" + sessionId + "/";
         }
     }
 

--- a/cvr/src/main/resources/application.properties.EXAMPLE
+++ b/cvr/src/main/resources/application.properties.EXAMPLE
@@ -5,6 +5,7 @@ chunk=
 
 # dmp
 dmp.server_name=
+dmp.consume_server_name=
 dmp.user_name=
 dmp.password=
 dmp.tokens.create_session=create_session


### PR DESCRIPTION
CVR webservice calls now point to new server except for the consume endpoint which still points to the old server. 

Added a new property that holds the DMP server name for the consume endpoint. 

Other webservice calls will automatically use the new server once the `application.properties` is updated for the CVR fetcher. The change has been made to the properties file and the update is pending the review and merge of this PR. 


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>