### PR TITLE
Use somatic session id for master list endpoint even in gml mode

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
@@ -114,7 +114,9 @@ public class CVRPipeline {
         }
         else if (gml) {
             // SessionID is gotten from a spring bean in the SessionConfiguration and passed through here as a param
+            // add session id from somatic server for calling master list endpoint as well
             builder.addString("sessionId", ctx.getBean(SessionConfiguration.GML_SESSION, String.class));
+            builder.addString("gmlMasterListSessionId", ctx.getBean(SessionConfiguration.SESSION_ID, String.class));
             jobName = BatchConfiguration.GML_JOB;
         }
         else {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/samplelist/CvrSampleListsTasklet.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/samplelist/CvrSampleListsTasklet.java
@@ -64,6 +64,9 @@ public class CvrSampleListsTasklet implements Tasklet {
     @Value("#{jobParameters[gmlMode]}")
     private Boolean gmlMode;
 
+    @Value("#{jobParameters[gmlMasterListSessionId]}")
+    private String gmlMasterListSessionId;
+
     @Autowired
     public CVRUtilities cvrUtilities;
 
@@ -175,7 +178,14 @@ public class CvrSampleListsTasklet implements Tasklet {
     }
 
     private Set<String> generateDmpMasterList() {
-        String dmpUrl = dmpServerName + dmpRetrieveMasterListRoute + "/" + sessionId + "/" + masterListTokensMap.get(studyId);
+        String dmpUrl = dmpServerName + dmpRetrieveMasterListRoute + "/";
+        if (gmlMode) {
+            dmpUrl += gmlMasterListSessionId;
+        } else {
+            dmpUrl += sessionId;
+        }
+        dmpUrl += "/" + masterListTokensMap.get(studyId);
+
         RestTemplate restTemplate = new RestTemplate();
         HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = getRequestEntity();
         ResponseEntity<CVRMasterList> responseEntity = restTemplate.exchange(dmpUrl, HttpMethod.GET, requestEntity, CVRMasterList.class);


### PR DESCRIPTION
When running the CVR pipeline in the germline mode, we generate a session ID via the draco server.

This session ID generated is no longer compatible with the master list web service hosted on the new CVR server (lynx server)

Fixes: 

Instead of using the germline session ID for querying the masterlist endpoint while running in germline mode, use the somatic session ID generated from the lynx server.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>