### PR TITLE
Temporarily disable import of MSKARCHER

### DIFF
--- a/import-scripts/import-dmp-impact-data.sh
+++ b/import-scripts/import-dmp-impact-data.sh
@@ -165,29 +165,30 @@ fi
 RESTART_AFTER_DMP_PIPELINES_IMPORT=0
 
 # TEMP STUDY IMPORT: MSKARCHER
-mysql --host="$DMP_DB_HOST" --user="$DMP_DB_USER" --password="$DMP_DB_PASSWORD" "$DMP_DB_DATABASE_NAME" -e "update genetic_profile set genetic_alteration_type = 'FUSION' where genetic_alteration_type = 'MUTATION_EXTENDED' and stable_id = 'mskarcher_mutations'"
-if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_ARCHER_IMPORT_TRIGGER ] ; then
-    printTimeStampedDataProcessingStepMessage "import for mskarcher"
-    bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskarcher" --temp-study-id="temporary_mskarcher" --backup-study-id="yesterday_mskarcher" --portal-name="mskarcher-portal" --study-path="$MSK_ARCHER_DATA_HOME" --notification-file="$mskarcher_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
-    if [ $? -eq 0 ] ; then
-        # Fusions are imported by ImportFusionData which is called when the genetic_alteration_type is "FUSION" in the meta_fusions.txt file (see logic in ImportProfileData)
-        # However, if a study does not have an existing genetic profile with genetic_alteration_type = "MUTATION_EXTENDED" then the study view mutations table does not show up.
-        # This is a temporary quick and dirty fix to override the genetic_alteration_type for mskarcher_mutations to "MTATION_EXTENDED" (which is imported with genetic_alteration_type = "FUSION")
-        mysql --host="$DMP_DB_HOST" --user="$DMP_DB_USER" --password="$DMP_DB_PASSWORD" "$DMP_DB_DATABASE_NAME" -e "update genetic_profile set genetic_alteration_type = 'MUTATION_EXTENDED' where genetic_alteration_type = 'FUSION' and stable_id = 'mskarcher_mutations'"
-        consumeSamplesAfterArcherImport
-        RESTART_AFTER_DMP_PIPELINES_IMPORT=1
-        IMPORT_FAIL_ARCHER=0
-    fi
-    rm $MSK_ARCHER_IMPORT_TRIGGER
-else
-    if [ $DB_VERSION_FAIL -gt 0 ] ; then
-        echo "Not importing MSKARCHER - database version is not compatible"
-    else
-        echo "Not importing MSKARCHER - something went wrong with a fetch"
-    fi
-fi
+# mysql --host="$DMP_DB_HOST" --user="$DMP_DB_USER" --password="$DMP_DB_PASSWORD" "$DMP_DB_DATABASE_NAME" -e "update genetic_profile set genetic_alteration_type = 'FUSION' where genetic_alteration_type = 'MUTATION_EXTENDED' and stable_id = 'mskarcher_mutations'"
+# if [ $DB_VERSION_FAIL -eq 0 ] && [ -f $MSK_ARCHER_IMPORT_TRIGGER ] ; then
+#     printTimeStampedDataProcessingStepMessage "import for mskarcher"
+#     bash $PORTAL_HOME/scripts/import-temp-study.sh --study-id="mskarcher" --temp-study-id="temporary_mskarcher" --backup-study-id="yesterday_mskarcher" --portal-name="mskarcher-portal" --study-path="$MSK_ARCHER_DATA_HOME" --notification-file="$mskarcher_notification_file" --tmp-directory="$MSK_DMP_TMPDIR" --email-list="$PIPELINES_EMAIL_LIST" --oncotree-version="${ONCOTREE_VERSION_TO_USE}" --importer-jar="$PORTAL_HOME/lib/msk-dmp-importer.jar" --transcript-overrides-source="mskcc"
+#     if [ $? -eq 0 ] ; then
+#         # Fusions are imported by ImportFusionData which is called when the genetic_alteration_type is "FUSION" in the meta_fusions.txt file (see logic in ImportProfileData)
+#         # However, if a study does not have an existing genetic profile with genetic_alteration_type = "MUTATION_EXTENDED" then the study view mutations table does not show up.
+#         # This is a temporary quick and dirty fix to override the genetic_alteration_type for mskarcher_mutations to "MTATION_EXTENDED" (which is imported with genetic_alteration_type = "FUSION")
+#         mysql --host="$DMP_DB_HOST" --user="$DMP_DB_USER" --password="$DMP_DB_PASSWORD" "$DMP_DB_DATABASE_NAME" -e "update genetic_profile set genetic_alteration_type = 'MUTATION_EXTENDED' where genetic_alteration_type = 'FUSION' and stable_id = 'mskarcher_mutations'"
+#         consumeSamplesAfterArcherImport
+#         RESTART_AFTER_DMP_PIPELINES_IMPORT=1
+#         IMPORT_FAIL_ARCHER=0
+#     fi
+#     rm $MSK_ARCHER_IMPORT_TRIGGER
+# else
+#     if [ $DB_VERSION_FAIL -gt 0 ] ; then
+#         echo "Not importing MSKARCHER - database version is not compatible"
+#     else
+#         echo "Not importing MSKARCHER - something went wrong with a fetch"
+#     fi
+# fi
 if [ $IMPORT_FAIL_ARCHER -gt 0 ] ; then
-    sendImportFailureMessageMskPipelineLogsSlack "ARCHER import"
+    # sendImportFailureMessageMskPipelineLogsSlack "ARCHER import"
+    sendImportFailureMessageMskPipelineLogsSlack "ARCHER import is disabled temporarily (Angelica, 08/24/2020)"
 else
     sendImportSuccessMessageMskPipelineLogsSlack "ARCHER"
 fi


### PR DESCRIPTION
Duplicate ARCHER fusion events are being introduced during import. 

This PR disables the import of the ARCHER study. The DDP and CVR updates for ARCHER will continue to run  in the mean time.



Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>