### PR TITLE
Prune git lfs cache after cleanup

### DIFF
--- a/import-scripts/datasource-repo-cleanup.sh
+++ b/import-scripts/datasource-repo-cleanup.sh
@@ -43,6 +43,11 @@ function cleanupGithubRepository {
     if [ $return_value -gt 0 ] ; then
         return $return_value
     fi
+    echo "git lfs prune"
+    git lfs prune ; return_value=$?
+    if [ $return_value -gt 0 ] ; then
+        return $return_value
+    fi
     return $return_value
 }
 


### PR DESCRIPTION
`git lfs prune` will purge cached files which we do not need. This will help us minimize disk space that's unnecessarily being taken up. 


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>