### PR TITLE
Temporarily re-enable RAINDANCE fetching and imports

### DIFF
--- a/import-scripts/automation-environment.sh
+++ b/import-scripts/automation-environment.sh
@@ -77,6 +77,7 @@ export MSK_IMPACT_CONSUME_TRIGGER=$MSK_DMP_TMPDIR/mskimpact_consume_trigger.txt
 export MSK_HEMEPACT_CONSUME_TRIGGER=$MSK_DMP_TMPDIR/mskimpact_heme_consume_trigger.txt
 export MSK_ARCHER_CONSUME_TRIGGER=$MSK_DMP_TMPDIR/mskarcher_consume_trigger.txt
 export MSK_ACCESS_CONSUME_TRIGGER=$MSK_DMP_TMPDIR/mskaccess_consume_trigger.txt
+export MSK_RAINDANCE_IMPORT_TRIGGER=$MSK_DMP_TMPDIR/mskraindance_import_trigger.txt
 export MSK_ARCHER_IMPORT_TRIGGER=$MSK_DMP_TMPDIR/mskarcher_import_trigger.txt
 export MSK_SOLID_HEME_IMPORT_TRIGGER=$MSK_DMP_TMPDIR/msk_solid_heme_import_trigger.txt
 export MSK_KINGS_IMPORT_TRIGGER=$MSK_DMP_TMPDIR/kingscounty_import_trigger.txt
@@ -119,6 +120,7 @@ export FMI_BATLEVI_DATA_HOME=$FOUNDATION_DATA_HOME/mixed/lymphoma/mskcc/foundati
 export REDCAP_BACKUP_DATA_HOME=$PORTAL_DATA_HOME/redcap-snapshot
 export MSKIMPACT_REDCAP_BACKUP=$REDCAP_BACKUP_DATA_HOME/mskimpact
 export HEMEPACT_REDCAP_BACKUP=$REDCAP_BACKUP_DATA_HOME/mskimpact_heme
+export RAINDANCE_REDCAP_BACKUP=$REDCAP_BACKUP_DATA_HOME/mskraindance
 export ARCHER_REDCAP_BACKUP=$REDCAP_BACKUP_DATA_HOME/mskarcher
 export ACCESS_REDCAP_BACKUP=$REDCAP_BACKUP_DATA_HOME/mskaccess
 

--- a/import-scripts/cvr_dmp_endpoint_utility.py
+++ b/import-scripts/cvr_dmp_endpoint_utility.py
@@ -32,11 +32,13 @@ MASTERLIST_MSKIMPACT = 'dmp.tokens.retrieve_master_list.impact'
 MASTERLIST_HEMEPACT = 'dmp.tokens.retrieve_master_list.heme'
 MASTERLIST_ARCHER = 'dmp.tokens.retrieve_master_list.archer'
 MASTERLIST_ACCESS = 'dmp.tokens.retrieve_master_list.access'
+MASTERLIST_RAINDANCE = 'dmp.tokens.retrieve_master_list.rdts'
 
 RETRIEVE_VARIANTS_MSKIMPMACT = 'dmp.tokens.retrieve_variants.impact'
 RETRIEVE_VARIANTS_HEMEPACT = 'dmp.tokens.retrieve_variants.heme'
 RETRIEVE_VARIANTS_ARCHER = 'dmp.tokens.retrieve_variants.archer'
 RETRIEVE_VARIANTS_ACCESS = 'dmp.tokens.retrieve_variants.access'
+RETRIEVE_VARIANTS_RAINDANCE = 'dmp.tokens.retrieve_variants.rdts'
 RETIREVE_GML_VARIANTS = 'dmp.tokens.retrieve_gml_variants'
 
 REQUIRED_PROPERTIES = [
@@ -55,10 +57,12 @@ REQUIRED_PROPERTIES = [
     MASTERLIST_HEMEPACT,
     MASTERLIST_ARCHER,
     MASTERLIST_ACCESS,
+    MASTERLIST_RAINDANCE,
     RETRIEVE_VARIANTS_MSKIMPMACT,
     RETRIEVE_VARIANTS_HEMEPACT,
     RETRIEVE_VARIANTS_ARCHER,
     RETRIEVE_VARIANTS_ACCESS,
+    RETRIEVE_VARIANTS_RAINDANCE,
     RETIREVE_GML_VARIANTS
 ]
 
@@ -82,7 +86,7 @@ RETRIEVE_VARIANTS_DMP_SAMPLE_ID = 'dmp_sample_id'
 
 CONSUME_AFFECTED_ROWS = 'affectedRows'
 
-DMP_STUDY_IDS = ['mskimpact', 'mskimpact_heme', 'mskarcher', 'mskaccess']
+DMP_STUDY_IDS = ['mskimpact', 'mskimpact_heme', 'mskraindance', 'mskarcher', 'mskaccess']
 DMP_SAMPLE_ID_PATTERN = re.compile('P-\d+-(T|N)\d+-(IH|TB|TS|AH|AS|IM|XS)\d+')
 
 MASTERLIST_CHECK_ARG_DESCRIPTION = '[optional] Fetches masterlist for study and reports samples from samples file that are missing from masterlist.'
@@ -110,10 +114,12 @@ class PortalProperties(object):
         self.masterlist_hemepact = properties[MASTERLIST_HEMEPACT]
         self.masterlist_archer = properties[MASTERLIST_ARCHER]
         self.masterlist_access = properties[MASTERLIST_ACCESS]
+        self.masterlist_raindance = properties[MASTERLIST_RAINDANCE]
         self.retrieve_variants_mskimpact = properties[RETRIEVE_VARIANTS_MSKIMPMACT]
         self.retrieve_variants_hemepact = properties[RETRIEVE_VARIANTS_HEMEPACT]
         self.retrieve_variants_archer = properties[RETRIEVE_VARIANTS_ARCHER]
         self.retrieve_variants_access = properties[RETRIEVE_VARIANTS_ACCESS]
+        self.retrieve_variants_raindance = properties[RETRIEVE_VARIANTS_RAINDANCE]
         self.retrieve_gml_variants = properties[RETIREVE_GML_VARIANTS]
         self.is_germline_mode = germline_mode
 
@@ -155,6 +161,8 @@ class PortalProperties(object):
             return self.masterlist_archer
         if study_id == 'mskaccess':
             return self.masterlist_access
+        if study_id == 'mskraindance':
+            return self.masterlist_raindance
 
     def get_study_retrieve_variants_endpoint(self, study_id):
         if self.is_germline_mode:
@@ -167,6 +175,8 @@ class PortalProperties(object):
             return self.retrieve_variants_archer
         if study_id == 'mskaccess':
             return self.retrieve_variants_access
+        if study_id == 'mskraindance':
+            return self.retrieve_variants_raindance
 
     def get_dmp_server(self):
         if self.is_germline_mode:

--- a/import-scripts/dmp-import-vars-functions.sh
+++ b/import-scripts/dmp-import-vars-functions.sh
@@ -281,6 +281,30 @@ function import_access_ddp_to_redcap {
     return $return_value
 }
 
+# Function for importing raindance cvr files to redcap
+function import_raindance_cvr_to_redcap {
+    return_value=0
+    if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_clinical_mskraindance_data_clinical.txt mskraindance_data_clinical ; then return_value=1 ; fi
+    return $return_value
+}
+
+# Function for importing raindance supp date files to redcap
+function import_raindance_supp_date_to_redcap {
+    return_value=0
+    if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_clinical_mskraindance_data_clinical_supp_date.txt mskraindance_data_clinical_supp_date ; then return_value=1 ; fi
+    return $return_value
+}
+
+# Function for importing raindance ddp files to redcap
+function import_raindance_ddp_to_redcap {
+    return_value=0
+    if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_clinical_ddp.txt mskraindance_data_clinical_ddp_demographics ; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_chemotherapy.txt mskraindance_timeline_chemotherapy_ddp; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_radiation.txt mskraindance_timeline_radiation_ddp ; then return_value=1 ; fi
+    # if ! import_project_to_redcap $MSK_RAINDANCE_DATA_HOME/data_timeline_ddp_surgery.txt mskraindance_data_timeline_surgery_ddp ; then return_value=1 ; fi
+    return $return_value
+}
+
 # Function for removing raw clinical and timeline files from study directory
 function remove_raw_clinical_timeline_data_files {
     STUDY_DIRECTORY=$1


### PR DESCRIPTION
Most of the changes from this commit were added back: https://github.com/knowledgesystems/cmo-pipelines/commit/52019d9b40edd5685826359fca18bc0ecb6e67ab#diff-49c2b99a42cebabac5dcb4b827363a33


RAINDANCE data fetching and imports will be temporarily enabled again as part of an ongoing effort to recover missing RAINDANCE samples from the frozen data set. This effort is related to [JIRA ticket 11](http://virgo1.mskcc.org:8080/browse/CDCA-11).

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>