### PR TITLE
GENIE subset fixes

### DIFF
--- a/import-scripts/merge-cna-records.py
+++ b/import-scripts/merge-cna-records.py
@@ -1,0 +1,100 @@
+import sys
+import os
+import optparse
+
+ERROR_FILE = sys.stderr
+OUTPUT_FILE = sys.stdout
+
+HEADER_KEYWORDS = ['hugo_symbol','entrez_gene_id']
+GENE_MERGE_LIST = {'CDKN2Ap16INK4A': 'CDKN2A',
+'CDKN2Ap14ARF': 'CDKN2A',
+'MLL': 'KMT2A',
+'MLL2': 'KMT2D',
+'MLL3': 'KMT2C',
+'MLL4': 'KMT2B',
+'FAM123B': 'AMER1',
+'MYCL1': 'MYCL'}
+
+def get_file_header(filename):
+	""" Returns the file header. """
+	data_file = open(filename, 'rU')
+	filedata = [x for x in data_file.readlines() if not x.startswith('#')]
+	header = map(str.strip, filedata[0].split('\t'))
+	data_file.close()
+	return header
+
+def merge_duplicate_cna_records(data):
+	for gene in data:
+		if len(data[gene]) > 1:
+			merge_status = 0
+			cna_data = map(lambda v: set(v), zip(*data[gene]))
+			merged_cna_data = []
+			for value in cna_data:
+				if len(value) > 1:
+					value = value - set(['NA'])
+					if len(value) > 1: value = value - set([''])
+					if len(value) > 1: value = value - set(['0'])
+					if len(value) > 1:
+						if len(value) == 2 and '-1.5' in value and '-2' in value: value.remove('-1.5')
+						else: merge_status = 1; break
+					merged_cna_data.append(map(str,value))
+				else:
+					merged_cna_data.append(map(str,value))
+			if merge_status == 1:
+				print >> ERROR_FILE, "The copy number values for gene", gene, "cannot be merged"
+			else:
+				merged_cna_data = [value[0] for value in merged_cna_data]
+				data[gene] = [merged_cna_data]
+	return(data)			
+
+def write_merged_cna_data(data,header,out_cna_filepath):
+	unmerged_data = ""
+	merged_data = ""
+	
+	for gene_symbol in data:
+		if len(data[gene_symbol]) > 1:
+			for record in data[gene_symbol]:
+				unmerged_data += gene_symbol+'\t'+'\t'.join(record)+'\n'
+		else:
+			merged_data += gene_symbol+'\t'+'\t'.join(data[gene_symbol][0])+'\n'
+	
+	if unmerged_data != "":
+		unmerged_file = open(out_cna_filepath+'data_CNA_unmerged.txt','w')
+		unmerged_file.write('\t'.join(header)+'\n')
+		unmerged_file.write(unmerged_data)
+		print >> OUTPUT_FILE, "The unmerged CNA records are written to :", out_cna_filepath+'data_CNA_unmerged.txt'
+	if merged_data != "":
+		merged_file = open(out_cna_filepath+'data_CNA_merged.txt','w')
+		merged_file.write('\t'.join(header)+'\n')
+		merged_file.write(merged_data)
+		print >> OUTPUT_FILE, "The merged CNA records are written to :", out_cna_filepath+'data_CNA_merged.txt'
+
+def main():
+	# get command line arguments
+	parser = optparse.OptionParser()
+	parser.add_option('-i', '--input-cnafile', action = 'store', dest = 'cnafile')
+	parser.add_option('-o', '--output-cna-filepath', action = 'store', dest = 'out_cna_filepath')
+
+	(options, args) = parser.parse_args()
+	cna_filename = options.cnafile
+	out_cna_filepath = options.out_cna_filepath
+	
+	header = get_file_header(cna_filename)
+
+	# load data from clinical_filename and write data to output directory
+	data_file = open(cna_filename, 'rU')
+	data_reader = [line for line in data_file.readlines() if not line.startswith('#')][1:]
+	
+	COPY_NUMBER_DATA = {}
+	for line in data_reader:
+		line = line.strip('\n').split('\t')
+		if line[0] in GENE_MERGE_LIST: line[0] = GENE_MERGE_LIST[line[0]]
+		if line[0] not in COPY_NUMBER_DATA: COPY_NUMBER_DATA[line[0]] = [line[1:]]
+		else: COPY_NUMBER_DATA[line[0]].append(line[1:])
+	
+	data = merge_duplicate_cna_records(COPY_NUMBER_DATA)
+	
+	write_merged_cna_data(data,header,out_cna_filepath)
+	
+if __name__ == '__main__':
+	main()

--- a/import-scripts/remove-duplicate-maf-variants.py
+++ b/import-scripts/remove-duplicate-maf-variants.py
@@ -1,0 +1,84 @@
+import sys
+import os
+import optparse
+
+# Script to remove duplicate maf records based on the 8 key columns.
+# Calculates VAF for each record and picks the record with high VAF
+# Formula for VAF = t_alt_count / (t_ref_count + t_alt_count) 
+
+ERROR_FILE = sys.stderr
+OUTPUT_FILE = sys.stdout
+
+KEY_COLUMNS_INDEX = []
+KEY_COLUMNS = ['Entrez_Gene_Id','Chromosome','Start_Position','End_Position','Variant_Classification','Tumor_Seq_Allele2','Tumor_Sample_Barcode','HGVSp_Short']
+MAF_DATA = {}
+
+def remove_duplicate_variants(maf_filename, comments, header, t_refc_index, t_altc_index):
+	outfile = []
+	outfile.append(comments)
+	outfile.append(header)
+	for key in MAF_DATA:
+		if len(MAF_DATA[key]) > 1:
+			vaf_ind = 0
+			vaf_value = 0
+			for val in MAF_DATA[key]:
+				#calculate VAF for each duplicate record.
+				columns = val.rstrip('\n').split('\t')
+				try:
+					VAF = int(columns[t_altc_index])/(int(columns[t_altc_index])+int(columns[t_refc_index]))
+					if VAF > vaf_value:
+						vaf_value = VAF
+						vaf_ind = MAF_DATA[key].index(val)
+						outfile.append(MAF_DATA[key][vaf_ind])
+				except:
+					print >> ERROR_FILE, 'ERROR: VAF cannot be calculated for the variant : ' + key
+					print >> ERROR_FILE, 'The t_ref_count is: '+ columns[t_refc_index]+ ' and t_alt_count is: '+ columns[t_altc_index]
+					outfile.append(val)
+		else:
+			outfile.append(MAF_DATA[key][0])
+			
+	datafile = open(maf_filename, 'w')
+	for line in outfile:
+		datafile.write(line)
+	datafile.close()
+	print >> OUTPUT_FILE, 'MAF file with duplicate variants removed is written to: ' + maf_filename
+		
+
+def main():
+	# get command line arguments
+	parser = optparse.OptionParser()
+	parser.add_option('-i', '--input-maf-file', action = 'store', dest = 'maf_file')
+
+	(options, args) = parser.parse_args()
+	maf_filename = options.maf_file
+
+	comments = ""
+	header = ""
+	
+	with open(maf_filename,'r') as maf_file:
+		for line in maf_file:
+			if line.startswith('#'):
+				comments += line
+			elif line.startswith('Hugo_Symbol'):
+				header += line
+				header_cols = line.rstrip('\n').split('\t')
+				#get the positions of the 8 key maf columns
+				for value in KEY_COLUMNS:
+					KEY_COLUMNS_INDEX.append(header_cols.index(value))
+				t_refc_index = header_cols.index('t_ref_count')
+				t_altc_index = header_cols.index('t_alt_count')
+			else:
+				reference_key = ""
+				data = line.rstrip('\n').split('\t')
+				for index in KEY_COLUMNS_INDEX:
+					reference_key += data[index]+'\t'
+				reference_key = reference_key.rstrip('\t')
+				if reference_key not in MAF_DATA:
+					MAF_DATA[reference_key] = [line]
+				else:
+					MAF_DATA[reference_key].append(line)
+	
+	remove_duplicate_variants(maf_filename, comments, header, t_refc_index, t_altc_index)
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
Fixes made:
1. **CNA Gene Merge Tool:** https://github.com/knowledgesystems/cmo-pipelines/issues/653
Script that will take a CNA file and perform the following gene merges:
CDKN2Ap16/14 -> CDKN2A
MLLs -> KMTs (MLL, MLL2, MLL3 and MLL4 -> KMT2A KMT2B KMT2C KMT2D)
FAM123B -> AMER1
MYCL1 -> MYCL

2. **Remove duplicate variants from MAF**
Script to remove duplicate maf records based on the 8 key columns (Entrez_Gene_Id, Chromosome, Start_Position, End_Position, Variant_Classification, Tumor_Seq_Allele2, Tumor_Sample_Barcode, HGVSp_Short)
Calculates VAF for each record and picks the record with high VAF
Formula for VAF = t_alt_count / (t_ref_count + t_alt_count) 

3. **Missing patient ids in patient file** https://github.com/knowledgesystems/cmo-pipelines/issues/654
Patients that have no attributes only appear in the sample clinical data file.

4. **Vital status location change** https://github.com/knowledgesystems/cmo-pipelines/issues/657
Patient vital status attributes were moved from the patient file into vital_status.txt. Since they GENIE has reversed that decision and now wants vital status information back in the patient clinical file.

5. **Change value for clinical attributes with no value** https://github.com/knowledgesystems/cmo-pipelines/issues/656
AGE_AT_SEQ_REPORT, ONCOTREE_CODE, BIRTH_YEAR, YEAR_DEATH, YEAR_CONTACT, INT_CONTACT, INT_DOD cannot be NA or blank. All attribute values should be "Unknown" when the patient/attribute or sample/attribute pair is missing a value.
Also, for attributes that take on NAACR values, like SEX, PRIMARY_RACE, SECONDARY_RACE, TERTIARY_RACE, ETHNICITY, they should take on the NAACR value for NA - (SEX = 9, RACE = 99, ETHNICITY = 9)

6. **Gene panel names missing prefix in clinical file** https://github.com/knowledgesystems/cmo-pipelines/issues/655
In the "Sequence Assay ID" column of the data_clinical_sample.txt file, IMPACT panel names should be prefixed with an "MSK-".

