### PR TITLE
Fix Timeline Exports from Redcap

### DIFF
--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawTimelineDataStepListener.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawTimelineDataStepListener.java
@@ -45,10 +45,10 @@ public class RawTimelineDataStepListener implements StepExecutionListener {
 
     @Autowired
     public ClinicalDataSource clinicalDataSource;
-    
-    private final List<String> standardTimelineDataFields = Arrays.asList(new String[] { "PATIENT_ID", "START_DATE", "STOP_DATE", "EVENT_TYPE"});    
+
+    private final List<String> standardTimelineDataFields = new ArrayList<String>(Arrays.asList("PATIENT_ID", "START_DATE", "STOP_DATE", "EVENT_TYPE"));
     private final Logger log = Logger.getLogger(RawTimelineDataStepListener.class);
-    
+
     @Override
     public void beforeStep(StepExecution se) {
         se.getExecutionContext().put("standardTimelineDataFields", standardTimelineDataFields);

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineDataStepListener.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineDataStepListener.java
@@ -51,10 +51,10 @@ public class TimelineDataStepListener implements StepExecutionListener {
 
     @Autowired
     public ClinicalDataSource clinicalDataSource;
-    
-    private final List<String> standardTimelineDataFields = Arrays.asList(new String[] { "PATIENT_ID", "START_DATE", "STOP_DATE", "EVENT_TYPE"});    
+
+    private final List<String> standardTimelineDataFields = new ArrayList<String>(Arrays.asList("PATIENT_ID", "START_DATE", "STOP_DATE", "EVENT_TYPE"));
     private final Logger log = Logger.getLogger(TimelineDataStepListener.class);
-    
+
     @Override
     public void beforeStep(StepExecution se) {
         se.getExecutionContext().put("standardTimelineDataFields", standardTimelineDataFields);


### PR DESCRIPTION
```
org.springframework.batch.core.JobExecutionException: Flow execution ended unexpectedly
	at org.springframework.batch.core.job.flow.FlowJob.doExecute(FlowJob.java:143)
...

Caused by: java.lang.IllegalArgumentException: Unable to deserialize the execution context
	at org.springframework.batch.core.repository.dao.JdbcExecutionContextDao$ExecutionContextRowMapper.mapRow(JdbcExecutionContextDao.java:328)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: The class with java.util.Arrays$ArrayList and name of java.util.Arrays$ArrayList is not trusted. 
```

Flow was exiting prematurely due to new jackson mapper not being able to deserialize a class member that was not explicitly initialized as an ArrayList. 