### PR TITLE
Fix Fetchers/Integration Tests

### DIFF
--- a/cvr/pom.xml
+++ b/cvr/pom.xml
@@ -92,11 +92,6 @@
       <version>19.0</version>
       <type>jar</type>
     </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.9.4</version>
-    </dependency>
   </dependencies>
 
   <repositories>

--- a/darwin/pom.xml
+++ b/darwin/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator-annotation-processor</artifactId>
-      <version>4.1.0.Final</version>
+      <version>5.1.3.Final</version>
     </dependency>
     <dependency>
       <groupId>javax.el</groupId>

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/BatchConfiguration.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/BatchConfiguration.java
@@ -204,13 +204,13 @@ public class BatchConfiguration {
     @Bean
     public Step mskimpactEmailStep() {
         return stepBuilderFactory.get("mskimpactEmailStep")
-        .tasklet(darwinEmailTasklet())
+        .tasklet(darwinFetchEmailTasklet())
         .build();
     }
 
     @Bean
     @StepScope
-    public Tasklet darwinEmailTasklet() {
+    public Tasklet darwinFetchEmailTasklet() {
         return new DarwinEmailTasklet();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
       <groupId>log4j</groupId>
       <artifactId>apache-log4j-extras</artifactId>
       <version>1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
     </dependency>
     <!-- other deps -->
     <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.9.4</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>

--- a/redcap/pom.xml
+++ b/redcap/pom.xml
@@ -38,6 +38,14 @@
                   <mainClass>org.mskcc.cmo.ks.redcap.RedcapPipeline</mainClass>
                 </transformer>
               </transformers>
+              <filters>
+                <filter>
+                    <artifact>*:*</artifact>
+                    <excludes>
+                        <exclude>**/Log4j2Plugins.data</exclude>
+                    </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawTimelineDataStepListener.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawTimelineDataStepListener.java
@@ -45,10 +45,10 @@ public class RawTimelineDataStepListener implements StepExecutionListener {
 
     @Autowired
     public ClinicalDataSource clinicalDataSource;
-    
-    private final List<String> standardTimelineDataFields = Arrays.asList(new String[] { "PATIENT_ID", "START_DATE", "STOP_DATE", "EVENT_TYPE"});    
+
+    private final List<String> standardTimelineDataFields = new ArrayList<String>(Arrays.asList("PATIENT_ID", "START_DATE", "STOP_DATE", "EVENT_TYPE"));
     private final Logger log = Logger.getLogger(RawTimelineDataStepListener.class);
-    
+
     @Override
     public void beforeStep(StepExecution se) {
         se.getExecutionContext().put("standardTimelineDataFields", standardTimelineDataFields);

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineDataStepListener.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineDataStepListener.java
@@ -51,10 +51,10 @@ public class TimelineDataStepListener implements StepExecutionListener {
 
     @Autowired
     public ClinicalDataSource clinicalDataSource;
-    
-    private final List<String> standardTimelineDataFields = Arrays.asList(new String[] { "PATIENT_ID", "START_DATE", "STOP_DATE", "EVENT_TYPE"});    
+
+    private final List<String> standardTimelineDataFields = new ArrayList<String>(Arrays.asList("PATIENT_ID", "START_DATE", "STOP_DATE", "EVENT_TYPE"));
     private final Logger log = Logger.getLogger(TimelineDataStepListener.class);
-    
+
     @Override
     public void beforeStep(StepExecution se) {
         se.getExecutionContext().put("standardTimelineDataFields", standardTimelineDataFields);


### PR DESCRIPTION
Includes fixes for:

**-  Getting redcap to work with raw timeline exports**
```
org.springframework.batch.core.JobExecutionException: Flow execution ended unexpectedly
	at org.springframework.batch.core.job.flow.FlowJob.doExecute(FlowJob.java:143)
...

Caused by: java.lang.IllegalArgumentException: Unable to deserialize the execution context
	at org.springframework.batch.core.repository.dao.JdbcExecutionContextDao$ExecutionContextRowMapper.mapRow(JdbcExecutionContextDao.java:328)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: The class with java.util.Arrays$ArrayList and name of java.util.Arrays$ArrayList is not trusted. 
```

**- Getting integration tests to pass in jenkins** 
```
Exception in thread "main" java.lang.AbstractMethodError: org.apache.logging.log4j.core.config.ConfigurationFactory.getConfiguration(Lorg/apache/logging/log4j/core/config/ConfigurationSource;)Lorg/apache/logging/log4j/core/config/Configuration;
```

**- Getting crdb/darwin fetch to work again**
```
2021-08-15 20:02:55 [main] ERROR org.springframework.boot.SpringApplication - Application run failed
java.lang.NoClassDefFoundError: org/joda/time/YearMonth
```
```

***************************
APPLICATION FAILED TO START
***************************

Description:

The bean 'darwinEmailTasklet', defined in BeanDefinition defined in class path resource [org/mskcc/cmo/ks/darwin/pipeline/BatchConfiguration.class], could not be registered. A bean with that name has already been defined in URL
```