### PR TITLE
use the login shell path for automation

### DIFF
--- a/import-scripts/automation-environment.sh
+++ b/import-scripts/automation-environment.sh
@@ -13,7 +13,7 @@ export PYTHON3_BINARY=/data/tools/python3.4.10/bin/python3
 export MAVEN_BINARY=/data/tools/mvn
 export HG_BINARY=/usr/bin/hg
 export GIT_BINARY=/usr/local/bin/git
-export PATH=/data/tools:/data/tools/python2.7/bin:/data/tools/python3.4.10/bin:$PATH
+export PATH=$(bash --login -c 'echo $PATH')
 
 #######################
 # environment variables for top-level data repositories / code bases


### PR DESCRIPTION
Scripts invoked via crontab do not receive environment initialization via
/etc/profile (or ~/.bash_profile).
This is because crontab executions are non-interactive non-login invocations.
Therefore any required tools / applications which are not on the very basic
(/usr/bin:/bin) PATH are not available during script execution.

This change sets PATH (of the current shell) to match the PATH of a login
shell (which does get /etc/profile and also ~/.bash_profile initialization).
So long as the system is properly configured so that the user connected to
the crontab has a correct PATH set for their login shell, the pipelines
scripts will function correctly: this removes system-specificity in scripts.