### PR TITLE
use standard regular expression format for sample

### DIFF
--- a/import-scripts/archer_fusions_merger.py
+++ b/import-scripts/archer_fusions_merger.py
@@ -27,8 +27,8 @@ SAMPLES_MISSING_CLINICAL_DATA = set()
 
 MSKIMPACT_STUDY_ID = "mskimpact"
 HEMEPACT_STUDY_ID = "mskimpact_heme"
-IMPACT_SAMPLE_PATTERN = re.compile('(P-\d*-T\d\d)-IM\S\d*')
-HEME_SAMPLE_PATTERN = re.compile('(P-\d*-T\d\d)-IH\S\d*')
+IMPACT_SAMPLE_PATTERN = re.compile('(P-\d*-T\d\d)-IM\d*')
+HEME_SAMPLE_PATTERN = re.compile('(P-\d*-T\d\d)-IH\d*')
 
 STUDY_SAMPLE_REGEX_PATTERNS = {
 	MSKIMPACT_STUDY_ID:IMPACT_SAMPLE_PATTERN,


### PR DESCRIPTION
- the impact and heme sample matches here were more permissive than in other scripts, accepting patterns such as : P-0000001-T01-IH or P-0000001-T01-IHA