### PR TITLE
add a safety lockout from 1:50am to 2:15am for cvr

### DIFF
--- a/import-scripts/date-and-time-handling-functions.sh
+++ b/import-scripts/date-and-time-handling-functions.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+
+# This library of bash functions provide time handling and management capabilities.
+# The primary purpose is to support the observance of certain "lockout" time periods
+# where particular network resources will not be interacted with because these are
+# observed periods of instability in those servers.
+#
+# The library is scaled to a granularity of minutes, and time periods are specified
+# using a "hour_minute" format string, such as "1820" which represents 6:20 pm. The
+# valid range for an hour_minute string is 0000 (midnight) to 2359 (11:59 pm).
+#
+# Natural number durations in minutes can be used to define the length of a period
+# from a specified start time. Periods are properly handled when they extend into
+# the following day (when the duration leads to a end time which occurs on the day
+# after the day on which the start time began. Durations must be less than one
+# full day, so only one midnight transition is supported.
+#
+# General comparison of times in hour_minute format is available through the
+# compareHourMinuteStrings() function, and timestamp acquisition in the hour_minute
+# format for the current time of day is available through the captureDayHourMinute()
+# function. The main function provided is waitWhileWithinTimePeriod(), which will
+# observe a pause during a "lockout" time period.
+
+# GLOBAL CONSTANTS
+TIME_COMPARISON_1_EQ_2_CODE=0
+TIME_COMPARISON_1_LT_2_CODE=1
+TIME_COMPARISON_2_LT_1_CODE=2
+TIME_COMPARISON_ERROR_CODE=99
+DEFAULT_SLEEP_INTERVAL_SECONDS=30
+
+# GLOBAL VARIABLES for returning values from called functions
+captured_day_of_week=0
+captured_hour_minute=0
+digit_string_with_zero_prefix_stripped=0
+computed_minutes_since_midnight=0
+computed_start_hour_minute_from_minutes_since_midnight=0
+computed_start_hour_minute_plus_minutes_result=0
+computed_start_hour_minute_plus_minutes_next_day_flag=0
+
+# FUNCTIONS
+
+# sets captured_day_of_week and captured_hour_minute according to the current time
+function captureDayHourMinute() {
+    split_day_hour_minute_re='^([0-9])(.*)$'
+    day_hour_minute=$(date +"%w%H%M")
+    if [[ "$day_hour_minute" =~ $split_day_hour_minute_re ]] ; then
+        captured_day_of_week="${BASH_REMATCH[1]}"
+        captured_hour_minute="${BASH_REMATCH[2]}"
+    else
+        captured_day_of_week=0
+        captured_hour_minute=0
+    fi
+}
+
+# checks if argument is a string containing only 1 to 4 digits ([0-9])
+# returns 0 for yes/success, 1 for no/failure
+function stringIs1to4Digits() {
+    s=$1
+    one_to_four_digits_re='^[0-9][0-9]?[0-9]?[0-9]?$'
+    if [[ "$s" =~ $one_to_four_digits_re ]] ; then
+        return 0
+    fi
+    return 1
+}
+
+# expected input is a natural number, possibly with a prefix including one or more zeros
+# if function is successful digit_string_with_zero_prefix_stripped is set to the same number without the zeros prefix (if all zeros, a single 0 is returned)
+function stripZeroPrefixFromDigitString() {
+    number=$1
+    drop_zero_prefix_re='^0*([0-9]+)$'
+    if [[ "$number" =~ $drop_zero_prefix_re ]] ; then
+        digit_string_with_zero_prefix_stripped="${BASH_REMATCH[1]}"
+        if [ -z "$digit_string_with_zero_prefix_stripped" ] ; then
+            digit_string_with_zero_prefix_stripped="0"
+        fi
+        return 0
+    fi
+    digit_string_with_zero_prefix_stripped=0
+    return 1
+}
+
+# sets computed_minutes_since_midnight and returns 0 on success
+# expected input is HHMM string : (from 0000 to 2359) : return 0 for success
+function computeMinutesSinceMidnightFromHourMinute() {
+    hour_minute="$1"
+    computed_minutes_since_midnight=0
+    if ! stringIs1to4Digits "$hour_minute" ; then
+        return 1
+    fi
+    # zero prefix must be removed before doing math .. or bash interprets strings as octal
+    if stripZeroPrefixFromDigitString "$hour_minute" ; then
+        hour_minute=$digit_string_with_zero_prefix_stripped
+    else
+        return 1
+    fi
+    if [ "$hour_minute" -lt 60 ] ; then
+        computed_minutes_since_midnight=$hour_minute # 0 - 59 means minutes since midnight
+        return 0
+    fi
+    if [ "$hour_minute" -lt 100 ] ; then
+        return 1 # 60 - 99 are not valid ... MM cannot be over 59
+    fi
+    split_hour_minute_re='^([0-9]+)([0-5][0-9])$'
+    if [[ "$hour_minute" =~ $split_hour_minute_re ]] ; then
+        hour_field="${BASH_REMATCH[1]}"
+        minute_field="${BASH_REMATCH[2]}"
+        stripZeroPrefixFromDigitString "$hour_field"
+        hour_field="$digit_string_with_zero_prefix_stripped"
+        stripZeroPrefixFromDigitString "$minute_field"
+        minute_field="$digit_string_with_zero_prefix_stripped"
+        if [ $hour_field -gt 23 ] ; then
+            return 1 # maximum hour is 23
+        fi
+        computed_minutes_since_midnight=$(( $hour_field * 60 + $minute_field ))
+        return 0
+    fi
+    return 1
+}
+
+# expected input is 2 hour_minute strings of format HHMM : (from 0000 to 2359)
+# returns:
+#   TIME_COMPARISON_ERROR_CODE if either string is malformated
+#   TIME_COMPARISON_1_EQ_2_CODE if the two times are equivalent
+#   TIME_COMPARISON_1_LT_2_CODE if time string 1 is less than time string 2
+#   TIME_COMPARISON_2_LT_1_CODE if time string 2 is less than time string 1
+function compareHourMinuteStrings() {
+    hour_minute_1=$1
+    hour_minute_2=$2
+    minutes_since_midnight_1=0
+    minutes_since_midnight_2=0
+    if computeMinutesSinceMidnightFromHourMinute $hour_minute_1 ; then
+        minutes_since_midnight_1=$computed_minutes_since_midnight
+    else
+        return $TIME_COMPARISON_ERROR_CODE
+    fi
+    if computeMinutesSinceMidnightFromHourMinute $hour_minute_2 ; then
+        minutes_since_midnight_2=$computed_minutes_since_midnight
+    else
+        return $TIME_COMPARISON_ERROR_CODE
+    fi
+    if [ "$minutes_since_midnight_1" == "$minutes_since_midnight_2" ] ; then
+        return $TIME_COMPARISON_1_EQ_2_CODE
+    fi
+    if [ "$minutes_since_midnight_1" -lt "$minutes_since_midnight_2" ] ; then
+        return $TIME_COMPARISON_1_LT_2_CODE
+    fi
+    if [ "$minutes_since_midnight_1" -gt "$minutes_since_midnight_2" ] ; then
+        return $TIME_COMPARISON_2_LT_1_CODE
+    fi
+    return $TIME_COMPARISON_ERROR_CODE
+}
+
+# expected input is a count of minutes since midnight (max: 1439)
+# if function succeeds, computed_start_hour_minute_from_minutes_since_midnight is set to the hour_minute string of format HHMM : (from 0000 to 2359)
+# return value is 0 on success
+function computeStartHourMinuteFromMinutesSinceMidnight() {
+    minutes_since_midnight=$1
+    if stripZeroPrefixFromDigitString "$minutes_since_midnight" ; then
+        minutes_since_midnight=$digit_string_with_zero_prefix_stripped
+    else
+        return 1
+    fi
+    # period must be within one day
+    if [ "$minutes_since_midnight" -gt 1439 ] ; then
+        return 1
+    fi
+    hours=$(( $minutes_since_midnight / 60 ))
+    minutes=$(( $minutes_since_midnight % 60 ))
+    computed_start_hour_minute_from_minutes_since_midnight=$(printf "%02d%02d" $hours $minutes)
+    return 0
+}
+
+# expected input is an hour_minute strings of format HHMM : (from 0000 to 2359) and an (integer) duration count of minutes (max: 1439)
+# if function succeeds, computed_start_hour_minute_plus_minutes_result is set to the hour_minute string of the start time plus duration minutes
+# if result is the following day, computed_start_hour_minute_plus_minutes_next_day_flag is set to 1, otherwise it is set to 0
+# return value is 0 on success
+function computeStartHourMinutePlusMinutes() {
+    start_hour_minute=$1
+    duration_minutes=$2
+    computed_start_hour_minute_plus_minutes_result=0
+    computed_start_hour_minute_plus_minutes_next_day_flag=0
+    start_minutes_since_midnight=0
+    if computeMinutesSinceMidnightFromHourMinute $start_hour_minute ; then
+        start_minutes_since_midnight=$computed_minutes_since_midnight
+    else
+        return 1
+    fi
+    if stripZeroPrefixFromDigitString "$duration_minutes" ; then
+        duration_minutes=$digit_string_with_zero_prefix_stripped
+    else
+        return 1
+    fi
+    if [ "$duration_minutes" -gt 1439 ] ; then
+        # maximum duration is 23 hours 59 minutes, so the end time cannot be later than the following day
+        return 1
+    fi
+    end_minutes_since_midnight=$(( $start_minutes_since_midnight + $duration_minutes ))
+    if [ "$end_minutes_since_midnight" -gt 1439 ] ; then
+        computed_start_hour_minute_plus_minutes_next_day_flag=1
+        end_minutes_since_midnight=$(( $end_minutes_since_midnight - 1440 ))
+    fi
+    if computeStartHourMinuteFromMinutesSinceMidnight $end_minutes_since_midnight ; then
+        computed_start_hour_minute_plus_minutes_result=$computed_start_hour_minute_from_minutes_since_midnight
+        return 0
+    fi
+    return 1
+}
+
+# receives 6 arguments (see below) that define (first 4) the time period and (last 2) the current day/time
+# returns 0 if the provided current day/hour_minute is within the period start/end, or 1 otherwise
+#   This function is written to allow a time period which begins at any specified start time
+#   (such as '1530' for starting the time period at 3:30 pm local time) and lasting up until the end time
+#   specified in the same format. Time periods which begin before midnight and end after midnight are
+#   supported, and so there is an argument "period_next_day_flag" which should be provided as '1' if the
+#   end time should be interpreted as occurring on the following day from the start_time (or as '0' if
+#   the start time and end time are to be interpreted as occurring on the same day.)
+#   The argument "period_start_day_of_week" should be the weekday number of the day on which the time period
+#   begins (such as '0' for Sunday, '1' for Monday, etc).
+#   The current day of the week (as a weekday number) and the current hour_minute (such as 1540) is used
+#   to compute a binary indication of whether or not we are in the time period. Time periods which
+#   span midnight are evaluated with separate logic from those which do not. The approach here is:
+#   For periods which do not span midnight:
+#       We are in the time period if all of these are true:
+#       -  the current time is at or after the start time
+#       -  the current time is not at or after the end time
+#       -  we are on the same day as the time period (midnight has not passed while waiting)
+#   For periods which do span midnight there are two caes:
+#       We are in the time period if (case 1) all of these are true:
+#       -  the current time is at or after the start time
+#       -  we are on the same day as the time period start (midnight has not passed while waiting)
+#       or if (case 2) all of these are true:
+#       -  the current time is not at or after the end time
+#       -  we are on day following the time period start (midnight has passed while waiting)
+#   If (through erroneous input arguments or bug) an error occurs, we default to returning '1'
+function currentlyWithinTimePeriod() {
+    period_start_hour_minute=$1 # period start hour_minutes in HHMM format
+    period_end_hour_minute=$2 # period end hour_minutes in HHMM format
+    period_start_day_of_week=$3 # period_start day of week in [0-6] format
+    period_next_day_flag=$4 # period_next_day_flag as 0/1 for false/true
+    current_day_of_week=$5 # current day of week in [0-6] format
+    current_hour_minute=$6 # current hour_minutes in HHMM format
+    midnight_has_passed_while_waiting_flag=0 # 0=no 1=yes
+    if [ "$period_start_day_of_week" -ne "$current_day_of_week" ] ; then
+        midnight_has_passed_while_waiting_flag=1
+    fi
+    if [ "$period_next_day_flag" -eq 0 ] ; then
+        # time period is entirely within the current day
+        if [ "$midnight_has_passed_while_waiting_flag" -eq 1 ] ; then
+            return 1 # we have passed the entire day of the period
+        fi
+        # when the period start and end are both on the same day, we check whether we are after the start and before the end
+        compareHourMinuteStrings "$current_hour_minute" "$period_start_hour_minute"
+        result=$?
+        if [ "$result" == "$TIME_COMPARISON_1_LT_2_CODE" ] ; then
+            return 1 # we are not yet at the start of the period
+        fi
+        if [ "$result" == "$TIME_COMPARISON_1_EQ_2_CODE" ] ; then
+            return 0 # we are at the start of the period ... we are within
+        fi
+        if [ "$result" == "$TIME_COMPARISON_2_LT_1_CODE" ] ; then
+            # we have passed the period start ... check period end
+            compareHourMinuteStrings "$current_hour_minute" "$period_end_hour_minute"
+            result=$?
+            if [ "$result" == "$TIME_COMPARISON_1_LT_2_CODE" ] ; then
+                return 0 # we are not yet at the end of the period ... we are within
+            fi
+            if [ "$result" == "$TIME_COMPARISON_1_EQ_2_CODE" ] || [ "$result" == "$TIME_COMPARISON_2_LT_1_CODE" ] ; then
+                return 1 # we have reached the end of the period or passed it
+            fi
+        fi
+    else
+        # time period spans midnight and ends in the following day (period end is on the day following period start)
+        # to support this, we detect whether the current day is on the period start day or on the period end day
+        # if the current day is on the period start day, we check if we have passed the start time
+        # if the current day is on the period end day, we check if we are before the end time
+        if [ "$midnight_has_passed_while_waiting_flag" -eq 1 ] ; then
+            # we are on the day after the period started - check if we are before the end of the period end hour_minute
+            compareHourMinuteStrings "$current_hour_minute" "$period_end_hour_minute"
+            result=$?
+            if [ "$result" == "$TIME_COMPARISON_1_LT_2_CODE" ] ; then
+                return 0 # we are not yet at the end of the period ... we are within
+            fi
+            if [ "$result" == "$TIME_COMPARISON_1_EQ_2_CODE" ] || [ "$result" == "$TIME_COMPARISON_2_LT_1_CODE" ] ; then
+                return 1 # we have reached the end of the period or passed it
+            fi
+        else
+            # we are on the same day the period starts - check if we have reached the period start hour_minute
+            compareHourMinuteStrings "$current_hour_minute" "$period_start_hour_minute"
+            result=$?
+            if [ "$result" == "$TIME_COMPARISON_1_LT_2_CODE" ] ; then
+                return 1 # we are not yet at the start of the period
+            fi
+            if [ "$result" == "$TIME_COMPARISON_1_EQ_2_CODE" ] || [ "$result" == "$TIME_COMPARISON_2_LT_1_CODE" ] ; then
+                return 0 # we have reached the start of the period or passed it ... we are within
+            fi
+        fi
+    fi
+    return 1 # an error occurred - return default
+}
+
+# if the current time is within the time period, this function will enter a sleep loop until that is no longer true
+function waitWithinTimePeriodDetailed() {
+    period_start_hour_minute="$1"
+    period_end_hour_minute="$2"
+    period_start_day_of_week="$3"
+    period_next_day_flag="$4"
+    sleep_interval_seconds="$5"
+    captureDayHourMinute
+    current_day_of_week="$captured_day_of_week"
+    current_hour_minute="$captured_hour_minute"
+    # so long as the current day/time is within the time period, we continue to sleep
+    while currentlyWithinTimePeriod "$period_start_hour_minute" "$period_end_hour_minute" "$period_start_day_of_week" "$period_next_day_flag" "$current_day_of_week" "$current_hour_minute" ; do
+        sleep $sleep_interval_seconds
+        captureDayHourMinute
+        current_day_of_week="$captured_day_of_week"
+        current_hour_minute="$captured_hour_minute"
+    done
+    return 0
+}
+
+# this is a convenience function which converts the time period start time and duration into start time, end time, start date, and a flag indicating whether midnight is spanned by the time period
+# an optional third argument provides the sleep interval per cycle
+# it then calls the waitWithinTimePeriodDetailed() function
+function waitWhileWithinTimePeriod() {
+    period_start_hour_minute="$1"
+    period_duration_minutes="$2"
+    sleep_interval_seconds="$3"
+    captureDayHourMinute
+    period_start_day_of_week="$captured_day_of_week"
+    computeStartHourMinutePlusMinutes "$period_start_hour_minute" "$period_duration_minutes"
+    period_end_hour_minute="$computed_start_hour_minute_plus_minutes_result"
+    period_next_day_flag="$computed_start_hour_minute_plus_minutes_next_day_flag"
+    if ! stringIs1to4Digits "$sleep_interval_seconds" ; then
+        sleep_interval_seconds="$DEFAULT_SLEEP_INTERVAL_SECONDS"
+    fi
+    waitWithinTimePeriodDetailed "$period_start_hour_minute" "$period_end_hour_minute" "$period_start_day_of_week" "$period_next_day_flag" "$sleep_interval_seconds"
+    return 0
+}

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -199,6 +199,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
 
     if [ $IMPORT_STATUS_IMPACT -eq 0 ] ; then
         # fetch new/updated IMPACT samples using CVR Web service   (must come after git fetching)
+        waitOutDmpTumorServerInstabilityPeriod
         printTimeStampedDataProcessingStepMessage "CVR fetch for mskimpact"
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_IMPACT_DATA_HOME -n data_clinical_mskimpact_data_clinical_cvr.txt -i mskimpact -r 150 $CVR_TEST_MODE_ARGS
         if [ $? -gt 0 ] ; then
@@ -228,11 +229,14 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                     cd $MSK_IMPACT_DATA_HOME ; $GIT_BINARY add ./* ; $GIT_BINARY commit -m "Latest MSKIMPACT Dataset: CVR"
                 fi
                 # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
+                waitOutDmpTumorServerInstabilityPeriod
+                waitOutDmpGermlineServerInstabilityPeriod
                 $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt -m $MSK_IMPACT_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD
             fi
         fi
 
         # fetch new/updated IMPACT germline samples using CVR Web service   (must come after normal cvr fetching)
+        waitOutDmpGermlineServerInstabilityPeriod
         printTimeStampedDataProcessingStepMessage "CVR germline fetch for mskimpact"
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_IMPACT_DATA_HOME -n data_clinical_mskimpact_data_clinical_cvr.txt -g -i mskimpact $CVR_TEST_MODE_ARGS
         if [ $? -gt 0 ] ; then
@@ -314,6 +318,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
 
     if [ $IMPORT_STATUS_HEME -eq 0 ] ; then
         # fetch new/updated heme samples using CVR Web service (must come after git fetching). Threshold is set to 50 since heme contains only 190 samples (07/12/2017)
+        waitOutDmpTumorServerInstabilityPeriod
         printTimeStampedDataProcessingStepMessage "CVR fetch for hemepact"
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_HEMEPACT_DATA_HOME -n data_clinical_hemepact_data_clinical.txt -i mskimpact_heme -r 50 $CVR_TEST_MODE_ARGS
         if [ $? -gt 0 ] ; then
@@ -337,6 +342,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
             fi
         fi
         # fetch new/updated HEMEPACT germline samples using CVR Web service   (must come after normal cvr fetching)
+        waitOutDmpGermlineServerInstabilityPeriod
         printTimeStampedDataProcessingStepMessage "CVR germline fetch for hemepact"
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_HEMEPACT_DATA_HOME -n data_clinical_hemepact_data_clinical.txt -g -i mskimpact_heme $CVR_TEST_MODE_ARGS
         if [ $? -gt 0 ] ; then
@@ -388,6 +394,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
 
     if [ $IMPORT_STATUS_ARCHER -eq 0 ] ; then
         # fetch new/updated archer samples using CVR Web service (must come after git fetching).
+        waitOutDmpTumorServerInstabilityPeriod
         printTimeStampedDataProcessingStepMessage "CVR fetch for archer"
         # archer has -b option to block warnings for samples with zero variants (all samples will have zero variants)
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_ARCHER_UNFILTERED_DATA_HOME -n data_clinical_mskarcher_data_clinical.txt -i mskarcher -s -b -r 50 $CVR_TEST_MODE_ARGS
@@ -437,6 +444,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
 
     if [ $IMPORT_STATUS_ACCESS -eq 0 ] ; then
         # fetch new/updated access samples using CVR Web service (must come after git fetching).
+        waitOutDmpTumorServerInstabilityPeriod
         printTimeStampedDataProcessingStepMessage "CVR fetch for access"
         # access has -b option to block warnings for samples with zero variants (all samples will have zero variants)
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_ACCESS_DATA_HOME -n data_clinical_mskaccess_data_clinical.txt -i mskaccess -s -b -r 50 $CVR_TEST_MODE_ARGS

--- a/import-scripts/test/test_dmp-import-vars-functions.sh
+++ b/import-scripts/test/test_dmp-import-vars-functions.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+
+test_source_file="./import-scripts/date-and-time-handling-functions.sh"
+echo "unit tests of '$test_source_file' beginning"
+if ! source "$test_source_file" ; then
+    echo "could not source file '$test_source_file'"
+    exit 1 
+fi
+
+failure_count=0
+
+#--------------------------------------------------------------------------------
+echo
+echo "testing function stringIs1to4Digits()"
+
+declare -a test_string_is_1_to_4_digits_success_expected_cases
+test_string_is_1_to_4_digits_success_expected_cases+=("0")
+test_string_is_1_to_4_digits_success_expected_cases+=("9")
+test_string_is_1_to_4_digits_success_expected_cases+=("00")
+test_string_is_1_to_4_digits_success_expected_cases+=("99")
+test_string_is_1_to_4_digits_success_expected_cases+=("000")
+test_string_is_1_to_4_digits_success_expected_cases+=("999")
+test_string_is_1_to_4_digits_success_expected_cases+=("0000")
+test_string_is_1_to_4_digits_success_expected_cases+=("9999")
+declare -a test_string_is_1_to_4_digits_failure_expected_cases
+test_string_is_1_to_4_digits_failure_expected_cases+=("")
+test_string_is_1_to_4_digits_failure_expected_cases+=(" ")
+test_string_is_1_to_4_digits_failure_expected_cases+=("a")
+test_string_is_1_to_4_digits_failure_expected_cases+=("z")
+test_string_is_1_to_4_digits_failure_expected_cases+=("!")
+test_string_is_1_to_4_digits_failure_expected_cases+=("0a0")
+test_string_is_1_to_4_digits_failure_expected_cases+=("0.0")
+test_string_is_1_to_4_digits_failure_expected_cases+=("0 0")
+test_string_is_1_to_4_digits_failure_expected_cases+=(" 0000")
+test_string_is_1_to_4_digits_failure_expected_cases+=("0000a")
+test_string_is_1_to_4_digits_failure_expected_cases+=("a0000")
+test_string_is_1_to_4_digits_failure_expected_cases+=("0000 ")
+test_string_is_1_to_4_digits_failure_expected_cases+=("00001")
+test_string_is_1_to_4_digits_failure_expected_cases+=("10000")
+test_string_is_1_to_4_digits_failure_expected_cases+=("-1")
+test_string_is_1_to_4_digits_failure_expected_cases+=("-1000")
+
+index=0
+while [ $index -lt ${#test_string_is_1_to_4_digits_success_expected_cases[@]} ] ; do
+    arg="${test_string_is_1_to_4_digits_success_expected_cases[$index]}"
+    if stringIs1to4Digits "$arg" ; then
+        echo stringIs1to4Digits \"$arg\" ... pass
+    else
+        echo stringIs1to4Digits \"$arg\" expected zero status, but received non-zero ... fail
+        failure_count=$(( $failure_count + 1 ))
+    fi
+    index=$(( $index + 1 ))
+done
+index=0
+while [ $index -lt ${#test_string_is_1_to_4_digits_failure_expected_cases[@]} ] ; do
+    arg="${test_string_is_1_to_4_digits_failure_expected_cases[$index]}"
+    if stringIs1to4Digits "$arg" ; then
+        echo stringIs1to4Digits \"$arg\" expected non-zero status, but received zero ... fail
+        failure_count=$(( $failure_count + 1 ))
+    else
+        echo stringIs1to4Digits \"$arg\" ... pass
+    fi
+    index=$(( $index + 1 ))
+done
+
+#--------------------------------------------------------------------------------
+echo
+echo "testing function stripZeroPrefixFromDigitString()"
+
+declare -a strip_zero_prefix_from_digit_string_case_to_expected
+strip_zero_prefix_from_digit_string_case_to_expected+=("" "fail")
+strip_zero_prefix_from_digit_string_case_to_expected+=("a" "fail")
+strip_zero_prefix_from_digit_string_case_to_expected+=(" " "fail")
+strip_zero_prefix_from_digit_string_case_to_expected+=("0" "0")
+strip_zero_prefix_from_digit_string_case_to_expected+=("00" "0")
+strip_zero_prefix_from_digit_string_case_to_expected+=("000" "0")
+strip_zero_prefix_from_digit_string_case_to_expected+=("0000" "0")
+strip_zero_prefix_from_digit_string_case_to_expected+=("00000" "0")
+strip_zero_prefix_from_digit_string_case_to_expected+=("9" "9")
+strip_zero_prefix_from_digit_string_case_to_expected+=("99" "99")
+strip_zero_prefix_from_digit_string_case_to_expected+=("999" "999")
+strip_zero_prefix_from_digit_string_case_to_expected+=("9999" "9999")
+strip_zero_prefix_from_digit_string_case_to_expected+=("99999" "99999")
+strip_zero_prefix_from_digit_string_case_to_expected+=("09" "9")
+strip_zero_prefix_from_digit_string_case_to_expected+=("099" "99")
+strip_zero_prefix_from_digit_string_case_to_expected+=("0999" "999")
+strip_zero_prefix_from_digit_string_case_to_expected+=("09999" "9999")
+strip_zero_prefix_from_digit_string_case_to_expected+=("099999" "99999")
+strip_zero_prefix_from_digit_string_case_to_expected+=("009" "9")
+strip_zero_prefix_from_digit_string_case_to_expected+=("0099" "99")
+strip_zero_prefix_from_digit_string_case_to_expected+=("00999" "999")
+strip_zero_prefix_from_digit_string_case_to_expected+=("009999" "9999")
+strip_zero_prefix_from_digit_string_case_to_expected+=("0099999" "99999")
+strip_zero_prefix_from_digit_string_case_to_expected+=("0090" "90")
+strip_zero_prefix_from_digit_string_case_to_expected+=("00990" "990")
+strip_zero_prefix_from_digit_string_case_to_expected+=("009990" "9990")
+strip_zero_prefix_from_digit_string_case_to_expected+=("0099990" "99990")
+strip_zero_prefix_from_digit_string_case_to_expected+=("00999990" "999990")
+
+index=0
+while [ $index -lt ${#strip_zero_prefix_from_digit_string_case_to_expected[@]} ] ; do
+    expected_index=$(( $index + 1 ))
+    arg="${strip_zero_prefix_from_digit_string_case_to_expected[$index]}"
+    expected=${strip_zero_prefix_from_digit_string_case_to_expected[$expected_index]}
+    if stripZeroPrefixFromDigitString "$arg" ; then
+        if [ "$expected" == "fail" ] ; then
+            echo stripZeroPrefixFromDigitString \"$arg\" expected non-zero status, but received zero ... fail
+            failure_count=$(( $failure_count + 1 ))
+        else
+            if [ "$expected" == "$digit_string_with_zero_prefix_stripped" ] ; then
+                echo stripZeroPrefixFromDigitString \"$arg\" ... pass
+            else
+                echo stripZeroPrefixFromDigitString \"$arg\" expected result \"$expected\" but received \"$digit_string_with_zero_prefix_stripped\" ... fail
+                failure_count=$(( $failure_count + 1 ))
+            fi
+        fi
+    else
+        if [ "$expected" == "fail" ] ; then
+            echo stripZeroPrefixFromDigitString \"$arg\" ... pass
+        else
+            echo stripZeroPrefixFromDigitString \"$arg\" expected result \"$expected\" but received non-zero status ... fail
+            failure_count=$(( $failure_count + 1 ))
+        fi
+    fi
+    index=$(( $index + 2 ))
+done
+
+#--------------------------------------------------------------------------------
+echo
+echo "testing function computeMinutesSinceMidnightFromHourMinute()"
+
+declare -a compute_minutes_since_midnight_from_hour_minute_case_to_expected
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("" "fail")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("a" "fail")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=(" " "fail")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("0" "0")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("00" "0")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("000" "0")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("0000" "0")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("00000" "fail")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("9999" "fail")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("9999" "fail")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("2360" "fail")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("2399" "fail")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("2400" "fail")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("0060" "fail")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("0059" "59")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("0100" "60")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("0200" "120")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("0210" "130")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("0201" "121")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("2259" "1379")
+compute_minutes_since_midnight_from_hour_minute_case_to_expected+=("2359" "1439")
+
+index=0
+while [ $index -lt ${#compute_minutes_since_midnight_from_hour_minute_case_to_expected[@]} ] ; do
+    expected_index=$(( $index + 1 ))
+    arg="${compute_minutes_since_midnight_from_hour_minute_case_to_expected[$index]}"
+    expected=${compute_minutes_since_midnight_from_hour_minute_case_to_expected[$expected_index]}
+    if computeMinutesSinceMidnightFromHourMinute "$arg" ; then
+        if [ "$expected" == "fail" ] ; then
+            echo computeMinutesSinceMidnightFromHourMinute \"$arg\" expected non-zero status, but received zero ... fail
+            failure_count=$(( $failure_count + 1 ))
+        else
+            if [ "$expected" == "$computed_minutes_since_midnight" ] ; then
+                echo computeMinutesSinceMidnightFromHourMinute \"$arg\" ... pass
+            else
+                echo computeMinutesSinceMidnightFromHourMinute \"$arg\" expected result \"$expected\" but received \"$computed_minutes_since_midnight\" ... fail
+                failure_count=$(( $failure_count + 1 ))
+            fi
+        fi
+    else
+        if [ "$expected" == "fail" ] ; then
+            echo computeMinutesSinceMidnightFromHourMinute \"$arg\" ... pass
+        else
+            echo computeMinutesSinceMidnightFromHourMinute \"$arg\" expected result \"$expected\" but received non-zero status ... fail
+            failure_count=$(( $failure_count + 1 ))
+        fi
+    fi
+    index=$(( $index + 2 ))
+done
+
+#--------------------------------------------------------------------------------
+echo
+echo "testing function compareHourMinuteStrings()"
+
+declare -a compare_hour_minute_strings_case_to_expected
+compare_hour_minute_strings_case_to_expected+=("" "1000" "$TIME_COMPARISON_ERROR_CODE")
+compare_hour_minute_strings_case_to_expected+=("a" "1000" "$TIME_COMPARISON_ERROR_CODE")
+compare_hour_minute_strings_case_to_expected+=(" " "1000" "$TIME_COMPARISON_ERROR_CODE")
+compare_hour_minute_strings_case_to_expected+=("1000" "" "$TIME_COMPARISON_ERROR_CODE")
+compare_hour_minute_strings_case_to_expected+=("1000" "a" "$TIME_COMPARISON_ERROR_CODE")
+compare_hour_minute_strings_case_to_expected+=("1000" " " "$TIME_COMPARISON_ERROR_CODE")
+compare_hour_minute_strings_case_to_expected+=("0" "0" "$TIME_COMPARISON_1_EQ_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("00" "0" "$TIME_COMPARISON_1_EQ_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("000" "0" "$TIME_COMPARISON_1_EQ_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("0000" "0" "$TIME_COMPARISON_1_EQ_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("0000" "0000" "$TIME_COMPARISON_1_EQ_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("0001" "0001" "$TIME_COMPARISON_1_EQ_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("1009" "1009" "$TIME_COMPARISON_1_EQ_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("0000" "0001" "$TIME_COMPARISON_1_LT_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("0000" "1009" "$TIME_COMPARISON_1_LT_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("0000" "2359" "$TIME_COMPARISON_1_LT_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("2358" "2359" "$TIME_COMPARISON_1_LT_2_CODE")
+compare_hour_minute_strings_case_to_expected+=("0001" "0000" "$TIME_COMPARISON_2_LT_1_CODE")
+compare_hour_minute_strings_case_to_expected+=("1009" "0000" "$TIME_COMPARISON_2_LT_1_CODE")
+compare_hour_minute_strings_case_to_expected+=("2359" "0000" "$TIME_COMPARISON_2_LT_1_CODE")
+compare_hour_minute_strings_case_to_expected+=("2359" "2358" "$TIME_COMPARISON_2_LT_1_CODE")
+
+index=0
+while [ $index -lt ${#compare_hour_minute_strings_case_to_expected[@]} ] ; do
+    arg2_index=$(( $index + 1 ))
+    expected_index=$(( $index + 2 ))
+    arg1="${compare_hour_minute_strings_case_to_expected[$index]}"
+    arg2="${compare_hour_minute_strings_case_to_expected[$arg2_index]}"
+    expected=${compare_hour_minute_strings_case_to_expected[$expected_index]}
+    compareHourMinuteStrings "$arg1" "$arg2"
+    actual=$?
+    if [ "$actual" == "$expected" ] ; then
+        echo compareHourMinuteStrings \"$arg1\" \"$arg2\" ... pass
+    else
+        echo compareHourMinuteStrings \"$arg1\" \"$arg2\" expected \"$expected\" status, but received \"$actual\" ... fail
+        failure_count=$(( $failure_count + 1 ))
+    fi
+    index=$(( $index + 3 ))
+done
+
+#--------------------------------------------------------------------------------
+echo
+echo "testing function computeStartHourMinuteFromMinutesSinceMidnight()"
+
+declare -a compute_start_hour_minute_from_minutes_since_midnight_case_to_expected
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("" "fail")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("a" "fail")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=(" " "fail")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("0" "0000")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("00" "0000")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("000" "0000")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("0000" "0000")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("59" "0059")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("059" "0059")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("0059" "0059")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("60" "0100")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("120" "0200")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("130" "0210")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("121" "0201")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("1379" "2259")
+compute_start_hour_minute_from_minutes_since_midnight_case_to_expected+=("1439" "2359")
+
+index=0
+while [ $index -lt ${#compute_start_hour_minute_from_minutes_since_midnight_case_to_expected[@]} ] ; do
+    expected_index=$(( $index + 1 ))
+    arg="${compute_start_hour_minute_from_minutes_since_midnight_case_to_expected[$index]}"
+    expected=${compute_start_hour_minute_from_minutes_since_midnight_case_to_expected[$expected_index]}
+    computeStartHourMinuteFromMinutesSinceMidnight "$arg"
+    exit_status=$?
+    if [ "$exit_status" -ne 0 ] ; then
+        if [ "$expected" == "fail" ] ; then
+            echo computeStartHourMinuteFromMinutesSinceMidnight \"$arg\" ... pass
+        else
+            echo computeStartHourMinuteFromMinutesSinceMidnight \"$arg\" expected zero exit status, but received non-zero ... fail
+            failure_count=$(( $failure_count + 1 ))
+        fi
+    else
+        actual=$computed_start_hour_minute_from_minutes_since_midnight
+        if [ "$actual" == "$expected" ] ; then
+            echo computeStartHourMinuteFromMinutesSinceMidnight \"$arg\" ... pass
+        else
+            echo computeStartHourMinuteFromMinutesSinceMidnight \"$arg\" expected \"$expected\" status, but received \"$actual\" ... fail
+            failure_count=$(( $failure_count + 1 ))
+        fi
+    fi
+    index=$(( $index + 2 ))
+done
+
+#--------------------------------------------------------------------------------
+echo
+echo "testing function computeStartHourMinutePlusMinutes()"
+
+declare -a compute_start_hour_minute_plus_minutes_case_to_expected
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "" "fail" "fail")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "a" "fail" "fail")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" " " "fail" "fail")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "0" "0000" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "00" "0000" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "000" "0000" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "0000" "0000" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "59" "0059" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "059" "0059" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "0059" "0059" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "60" "0100" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "120" "0200" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "130" "0210" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "121" "0201" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "1379" "2259" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("0000" "1439" "2359" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("1900" "0000" "1900" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("1900" "59" "1959" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("1900" "059" "1959" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("1900" "0059" "1959" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("1900" "60" "2000" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("1900" "120" "2100" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("1900" "130" "2110" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("1900" "121" "2101" "0")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("1900" "1379" "1759" "1")
+compute_start_hour_minute_plus_minutes_case_to_expected+=("1900" "1439" "1859" "1")
+
+index=0
+while [ $index -lt ${#compute_start_hour_minute_plus_minutes_case_to_expected[@]} ] ; do
+    arg2_index=$(( $index + 1 ))
+    expected_index=$(( $index + 2 ))
+    next_day_flag_index=$(( $index + 3 ))
+    arg1="${compute_start_hour_minute_plus_minutes_case_to_expected[$index]}"
+    arg2="${compute_start_hour_minute_plus_minutes_case_to_expected[$arg2_index]}"
+    expected=${compute_start_hour_minute_plus_minutes_case_to_expected[$expected_index]}
+    expected_next_day_flag=${compute_start_hour_minute_plus_minutes_case_to_expected[$next_day_flag_index]}
+    computeStartHourMinutePlusMinutes "$arg1" "$arg2"
+    exit_status=$?
+    actual="$computed_start_hour_minute_plus_minutes_result"
+    actual_next_day_flag="$computed_start_hour_minute_plus_minutes_next_day_flag"
+    if [ "$exit_status" -ne 0 ] ; then
+        if [ "$expected" == "fail" ] ; then
+            echo computeStartHourMinutePlusMinutes \"$arg1\" \"$arg2\" ... pass
+        else
+            echo computeStartHourMinutePlusMinutes \"$arg1\" \"$arg2\" expected zero exit status, but received non-zero ... fail
+            failure_count=$(( $failure_count + 1 ))
+        fi
+    else
+        actual=$computed_start_hour_minute_from_minutes_since_midnight
+        if [ "$actual" == "$expected" ] && [ "$actual_next_day_flag" == "$expected_next_day_flag" ] ; then
+            echo computeStartHourMinutePlusMinutes \"$arg1\" \"$arg2\" ... pass
+        else
+            echo computeStartHourMinutePlusMinutes \"$arg1\" \"$arg2\" expected \"$expected\" results and \"$expected_next_day_flag\" next_day_flag, but received \"$actual\" and \"$actual_next_day_flag\" ... fail
+            failure_count=$(( $failure_count + 1 ))
+        fi
+    fi
+    index=$(( $index + 4 ))
+done
+
+#--------------------------------------------------------------------------------
+echo
+echo "testing function currentlyWithinTimePeriod()"
+
+declare -a currently_within_time_period_case_to_expected
+currently_within_time_period_case_to_expected+=("0000" "1200" "1" "0" "1" "0000" "0")
+currently_within_time_period_case_to_expected+=("0000" "1200" "1" "0" "1" "0001" "0")
+currently_within_time_period_case_to_expected+=("0001" "1200" "1" "0" "1" "1159" "0")
+currently_within_time_period_case_to_expected+=("0000" "1200" "1" "0" "1" "1200" "1")
+currently_within_time_period_case_to_expected+=("0000" "1200" "1" "0" "1" "1201" "1")
+currently_within_time_period_case_to_expected+=("0000" "1200" "1" "0" "2" "0000" "1")
+currently_within_time_period_case_to_expected+=("0001" "1200" "1" "0" "1" "0000" "1")
+currently_within_time_period_case_to_expected+=("0001" "1200" "1" "0" "1" "0001" "0")
+currently_within_time_period_case_to_expected+=("0001" "1200" "1" "0" "1" "0002" "0")
+currently_within_time_period_case_to_expected+=("0001" "1200" "1" "0" "1" "1159" "0")
+currently_within_time_period_case_to_expected+=("0001" "1200" "1" "0" "1" "1200" "1")
+currently_within_time_period_case_to_expected+=("0001" "1200" "1" "0" "1" "1201" "1")
+currently_within_time_period_case_to_expected+=("0001" "1200" "1" "0" "1" "2359" "1")
+currently_within_time_period_case_to_expected+=("0001" "1200" "1" "0" "2" "0000" "1")
+currently_within_time_period_case_to_expected+=("1200" "2359" "1" "0" "1" "1159" "1")
+currently_within_time_period_case_to_expected+=("1200" "2359" "1" "0" "1" "1201" "0")
+currently_within_time_period_case_to_expected+=("1200" "2359" "1" "0" "1" "1201" "0")
+currently_within_time_period_case_to_expected+=("1200" "2359" "1" "0" "1" "2359" "1")
+currently_within_time_period_case_to_expected+=("1200" "2359" "1" "0" "2" "0000" "1")
+currently_within_time_period_case_to_expected+=("1200" "2359" "1" "0" "2" "0001" "1")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "1" "0000" "1")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "1" "0001" "1")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "1" "2259" "1")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "1" "2300" "0")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "1" "2301" "0")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "1" "2359" "0")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "2" "0000" "0")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "2" "0001" "0")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "2" "0059" "0")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "2" "0100" "1")
+currently_within_time_period_case_to_expected+=("2300" "0100" "1" "1" "2" "2330" "1")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "1" "0000" "1")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "1" "0001" "1")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "1" "2259" "1")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "1" "2300" "0")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "1" "2301" "0")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "1" "2359" "0")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "2" "0000" "1")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "2" "0001" "1")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "2" "0059" "1")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "2" "0100" "1")
+currently_within_time_period_case_to_expected+=("2300" "0000" "1" "1" "2" "2330" "1")
+
+index=0
+while [ $index -lt ${#currently_within_time_period_case_to_expected[@]} ] ; do
+    arg2_index=$(( $index + 1 ))
+    arg3_index=$(( $index + 2 ))
+    arg4_index=$(( $index + 3 ))
+    arg5_index=$(( $index + 4 ))
+    arg6_index=$(( $index + 5 ))
+    expected_index=$(( $index + 6 ))
+    arg1="${currently_within_time_period_case_to_expected[$index]}"
+    arg2="${currently_within_time_period_case_to_expected[$arg2_index]}"
+    arg3="${currently_within_time_period_case_to_expected[$arg3_index]}"
+    arg4="${currently_within_time_period_case_to_expected[$arg4_index]}"
+    arg5="${currently_within_time_period_case_to_expected[$arg5_index]}"
+    arg6="${currently_within_time_period_case_to_expected[$arg6_index]}"
+    expected=${currently_within_time_period_case_to_expected[$expected_index]}
+    currentlyWithinTimePeriod "$arg1" "$arg2" "$arg3" "$arg4" "$arg5" "$arg6"
+    actual=$?
+    if [ "$actual" -ne 0 ] ; then
+        if [ "$expected" -ne 0 ] ; then
+            echo currentlyWithinTimePeriod \"$arg1\" \"$arg2\" \"$arg3\" \"$arg4\" \"$arg5\" \"$arg6\" ... pass
+        else
+            echo currentlyWithinTimePeriod \"$arg1\" \"$arg2\" \"$arg3\" \"$arg4\" \"$arg5\" \"$arg6\" expected zero exit status, but received non-zero ... fail
+            failure_count=$(( $failure_count + 1 ))
+        fi
+    else
+        if [ "$expected" -ne 0 ] ; then
+            echo currentlyWithinTimePeriod \"$arg1\" \"$arg2\" \"$arg3\" \"$arg4\" \"$arg5\" \"$arg6\" expected non-zero exit status, but received zero ... fail
+            failure_count=$(( $failure_count + 1 ))
+        else
+            echo currentlyWithinTimePeriod \"$arg1\" \"$arg2\" \"$arg3\" \"$arg4\" \"$arg5\" \"$arg6\" ... pass
+        fi
+    fi
+    index=$(( $index + 7 ))
+done
+
+#--------------------------------------------------------------------------------
+echo
+echo "testing results"
+echo "  count of failed test cases: $failure_count"
+echo
+echo "testing complete."
+exit $failure_count


### PR DESCRIPTION
- functions added to dmp-import-vars-functions.sh to wait during tumor / germline lockout periods
- hardcoded constants allow setting start time (HHMM) and duration in minutes for both tumor and germline lockout periods
- unit test script written
- appropriate calls to wait() functions made before cvr operations