### PR TITLE
Backup redcap database in eks

### DIFF
--- a/import-scripts/backup-eks-dbs.sh
+++ b/import-scripts/backup-eks-dbs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DBS=("cgds_gdac" "cgds_triage" "keycloak")
+DBS=("cgds_gdac" "cgds_triage" "keycloak" "redcap")
 LOCAL_BACKUP_DIR=/data/mysql-dumps
 SLACK_URL=`cat /data/portal-cron/pipelines-credentials/mskcc-sysadmin-slack.url`
 


### PR DESCRIPTION
I added the grants in MySQL so the database user in this script has permission to dump the redcap database.