### PR TITLE
Allow Different Clusters for Persistence Clearing

### DIFF
--- a/import-scripts/pipelines_eks/automation-environment.sh
+++ b/import-scripts/pipelines_eks/automation-environment.sh
@@ -40,6 +40,7 @@ export START_TRIAGE_IMPORT_TRIGGER_FILENAME=$PORTAL_HOME/import-trigger/triage-i
 export KILL_TRIAGE_IMPORT_TRIGGER_FILENAME=$PORTAL_HOME/import-trigger/triage-import-kill-request
 export TRIAGE_IMPORT_IN_PROGRESS_FILENAME=$PORTAL_HOME/import-trigger/triage-import-in-progress
 export TRIAGE_IMPORT_KILLING_FILENAME=$PORTAL_HOME/import-trigger/triage-import-killing
+export PUBLIC_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/public-cluster-config
 
 #######################
 # SSL args (for AWS + redcap)


### PR DESCRIPTION
- k8s config file stored separately
- specific portals will set the k8s config arg 
- commands will use --kubeconfig setting to access other cluster