### PR TITLE
Fix Issue with DDP Vital Status Fields

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/SuppVitalStatusRecord.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/SuppVitalStatusRecord.java
@@ -59,8 +59,8 @@ public class SuppVitalStatusRecord {
         this.PATIENT_ID = compositeRecord.getDmpPatientId();
         this.YEAR_CONTACT = DDPUtils.parseYearFromDateAsString(compositeRecord.getLastContactDate());
         this.YEAR_DEATH = DDPUtils.parseYearFromDateAsString(compositeRecord.getPatientDeathDate());
-        this.INT_CONTACT = DDPUtils.getDateInDaysAsString(compositeRecord.getLastContactDate());
-        this.INT_DOD = DDPUtils.getDateInDaysAsString(compositeRecord.getPatientDeathDate());
+        this.INT_CONTACT = DDPUtils.resolveIntervalInDays(compositeRecord.getPatientBirthDate(), compositeRecord.getLastContactDate());
+        this.INT_DOD = DDPUtils.resolveIntervalInDays(compositeRecord.getPatientBirthDate(), compositeRecord.getPatientDeathDate(), true);
         this.DEAD = (!Strings.isNullOrEmpty(compositeRecord.getPatientDeathDate())) ? "True" : "False";
     }
     /**

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -166,6 +166,17 @@ public class DDPUtils {
         return anonymizePatientAge(age.intValue());
     }
 
+    /**
+     * Given two date strings, find the number of days that has elapsed between the two
+     * Order of dates does not matter
+     * Option to anonymize the interval (<18 or >90 years) if the output is used for sensitive fields
+     *
+     * @param date1
+     * @param date2
+     * @param anonymizeIntervalInDays
+     * @return
+     * @throws ParseException
+     */
     public static String resolveIntervalInDays(String date1, String date2, Boolean anonymizeIntervalInDays) throws ParseException {
         if (Strings.isNullOrEmpty(date1) || Strings.isNullOrEmpty(date2)) {
             return "NA";
@@ -177,6 +188,14 @@ public class DDPUtils {
         return intervalInDays.toString();
     }
 
+    /**
+     * Defaults function to not anonymize output if no argument is provided
+     *
+     * @param date1
+     * @param date2
+     * @return
+     * @throws ParseException
+     */
     public static String resolveIntervalInDays(String date1, String date2) throws ParseException {
         return resolveIntervalInDays(date1, date2, false);
     }
@@ -217,6 +236,12 @@ public class DDPUtils {
         return String.valueOf(age);
     }
 
+    /**
+     * Returns anonymized number of days as string.
+     *
+     * @param numberOfDays
+     * @return
+     */
     private static String anonymizeNumberOfDays(Long numberOfDays) {
         if (numberOfDays >= (90 * DAYS_TO_YEARS_CONVERSION)) {
             return String.valueOf(Math.round(90 * DAYS_TO_YEARS_CONVERSION));

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -166,6 +166,21 @@ public class DDPUtils {
         return anonymizePatientAge(age.intValue());
     }
 
+    public static String resolveIntervalInDays(String date1, String date2, Boolean anonymizeIntervalInDays) throws ParseException {
+        if (Strings.isNullOrEmpty(date1) || Strings.isNullOrEmpty(date2)) {
+            return "NA";
+        }
+        Long intervalInDays = Math.abs(getDateInDays(date1) - getDateInDays(date2));
+        if (anonymizeIntervalInDays) {
+            return anonymizeNumberOfDays(intervalInDays);
+        }
+        return intervalInDays.toString();
+    }
+
+    public static String resolveIntervalInDays(String date1, String date2) throws ParseException {
+        return resolveIntervalInDays(date1, date2, false);
+    }
+
     /**
      * Resolve and anonymize patient age at diagnosis.
      *
@@ -200,6 +215,15 @@ public class DDPUtils {
             age = 18;
         }
         return String.valueOf(age);
+    }
+
+    private static String anonymizeNumberOfDays(Long numberOfDays) {
+        if (numberOfDays >= (90 * DAYS_TO_YEARS_CONVERSION)) {
+            return String.valueOf(Math.round(90 * DAYS_TO_YEARS_CONVERSION));
+        } else if (numberOfDays <= (18 * DAYS_TO_YEARS_CONVERSION)) {
+            return String.valueOf(Math.round((18 * DAYS_TO_YEARS_CONVERSION)));
+        }
+        return String.valueOf(numberOfDays);
     }
 
     /**

--- a/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtilsTest.java
+++ b/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtilsTest.java
@@ -545,7 +545,7 @@ public class DDPUtilsTest {
      * @throws Exception
      */
     @Test
-    public void resolvePatientYearsSinceBirthTest()throws Exception {
+    public void resolvePatientYearsSinceBirthTest() throws Exception {
         wait_until_midnight_if_necessary();
         Date now = new Date();
         Calendar calendar = Calendar.getInstance();
@@ -573,6 +573,31 @@ public class DDPUtilsTest {
     public void resolvePatientYearsSinceBirthWithExceptionTest() throws Exception {
         wait_until_midnight_if_necessary();
         DDPUtils.resolveYearsSinceBirth("05/01/2000");
+    }
+
+    @Test
+    public void resolveIntervalInDaysTest() throws Exception {
+        Assert.assertEquals(DDPUtils.resolveIntervalInDays("2021-05-01","2021-05-05"), "4");
+        Assert.assertEquals(DDPUtils.resolveIntervalInDays("2021-05-05","2021-05-01"), "4");
+        Assert.assertEquals(DDPUtils.resolveIntervalInDays(null,"2021-05-05"), "NA");
+        Assert.assertEquals(DDPUtils.resolveIntervalInDays("2021-05-05",null), "NA");
+    }
+
+    @Test
+    public void resolveAnonymizedIntervalInDaysTest() throws Exception {
+        Assert.assertEquals(DDPUtils.resolveIntervalInDays("2021-05-01", "1903-04-06", true), String.valueOf(Math.round(90 * DDPUtils.DAYS_TO_YEARS_CONVERSION)));
+        Assert.assertEquals(DDPUtils.resolveIntervalInDays("2021-05-01", "2015-04-06", true), String.valueOf(Math.round(18 * DDPUtils.DAYS_TO_YEARS_CONVERSION)));
+        Assert.assertEquals(DDPUtils.resolveIntervalInDays("", "2015-04-06", true), "NA");
+    }
+
+    @Test(expected = ParseException.class)
+    public void resolveIntervalInDaysWithInvalidCharacterStringTest() throws Exception {
+        DDPUtils.resolveIntervalInDays("INVALID_DATE","2021-05-05");
+    }
+
+    @Test(expected = ParseException.class)
+    public void resolveIntervalInDaysWithInvalidNumericStringExceptionTest() throws Exception {
+        DDPUtils.resolveIntervalInDays("12301","2021-05-05");
     }
 
     /**


### PR DESCRIPTION
INT_DOD and INT_CONTACT were not calculating intervals and were just directly converting dates
Added the following:
- utility function for finding the number of days between two date strings
- anonymizing function for hiding number of days if it is greater than 90 years or less than 18 years