### PR TITLE
Add NATS messaging to CVR "consume" step 

### DIFF
--- a/cvr/pom.xml
+++ b/cvr/pom.xml
@@ -14,6 +14,12 @@
   </parent>
 
   <dependencies>
+    <!-- smile messaging dependency -->
+    <dependency>
+      <groupId>com.github.mskcc</groupId>
+      <artifactId>smile-messaging-java</artifactId>
+      <version>1.3.1.RELEASE</version>
+    </dependency>
     <dependency>
       <groupId>org.mskcc.cmo.ks</groupId>
       <artifactId>common</artifactId>

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/CVRPipeline.java
@@ -136,6 +136,7 @@ public class CVRPipeline {
             checkExceptions(jobExecution, jobParameters, emailUtil);
         }
         log.info("Shutting down CVR Pipeline");
+        System.exit(SpringApplication.exit(ctx));
     }
 
     private static void launchConsumeSamplesJob(String[] args, String jsonFilename, boolean testingMode, boolean gml) throws Exception {
@@ -168,6 +169,7 @@ public class CVRPipeline {
             checkExceptions(jobExecution, jobParameters, emailUtil);
         }
         log.info("Shutting down Consume Sample Job");
+        System.exit(SpringApplication.exit(ctx));
     }
 
     private static void checkExceptions(JobExecution jobExecution, JobParameters jobParameters, EmailUtil emailUtil) {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CvrSampleListUtil.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CvrSampleListUtil.java
@@ -61,6 +61,9 @@ public class CvrSampleListUtil {
     private Set<String> whitelistedSamplesWithZeroVariants = new HashSet<>();
     private Set<String> nonWhitelistedZeroVariantSamples = new HashSet<>();
     private Set<String> newUnreportedSamplesWithZeroVariants = new HashSet<>();
+    // list of samples that were successfully consumed and whose metadata should
+    // be published to the smile server (https://github.com/mskcc/smile-server)
+    private Set<String> smileSamplesToPublishList = new HashSet<>();
 
     Logger log = Logger.getLogger(CvrSampleListUtil.class);
 
@@ -403,6 +406,31 @@ public class CvrSampleListUtil {
      */
     public void setNewUnreportedSamplesWithZeroVariants(Set<String> newUnreportedSamplesWithZeroVariants) {
         this.newUnreportedSamplesWithZeroVariants = newUnreportedSamplesWithZeroVariants;
+    }
+
+    /**
+     * Returns list of samples that were consumed successfully and whose metadata should
+     * be published to SMILE.
+     * @return
+     */
+    public Set<String> getSmileSamplesToPublishList() {
+        return smileSamplesToPublishList;
+    }
+
+    /**
+     * @param smileSamplesToPublishList the list of samples consumed successfully to set
+     */
+    public void setSmileSamplesToPublishList(Set<String> smileSamplesToPublishList) {
+        this.smileSamplesToPublishList = smileSamplesToPublishList;
+    }
+
+    /**
+     * Updates list of samples consumed successfully. This list is used to determine which samples metadata
+     * should be published to SMILE.
+     * @param sampleId
+     */
+    public void updateSmileSamplesToPublishList(String sampleId) {
+        this.smileSamplesToPublishList.add(sampleId);
     }
 
     /**

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/consume/ConsumeSampleWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/consume/ConsumeSampleWriter.java
@@ -35,6 +35,7 @@ package org.cbioportal.cmo.pipelines.cvr.consume;
 import java.util.List;
 import org.apache.log4j.Logger;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
 import org.cbioportal.cmo.pipelines.cvr.model.CVRConsumeSample;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
@@ -54,35 +55,38 @@ import org.springframework.web.client.RestTemplate;
  * @author ochoaa
  */
 public class ConsumeSampleWriter implements ItemStreamWriter<String> {
-    
+
     @Value("${dmp.server_name}")
     private String dmpServerName;
 
     @Value("${dmp.gml_server_name}")
     private String dmpGmlServerName;
-    
+
     @Value("${dmp.tokens.consume_sample}")
     private String dmpConsumeSample;
-    
+
     @Value("${dmp.tokens.consume_gml_sample}")
     private String dmpConsumeGmlSample;
-    
+
     @Value("#{jobParameters[sessionId]}")
     private String sessionId;
-    
+
     @Value("#{jobParameters[testingMode]}")
     private boolean testingMode;
 
     @Value("#{jobParameters[gmlMode]}")
     private Boolean gmlMode;
-    
+
     @Autowired
     public CVRUtilities cvrUtilities;
-    
+
+    @Autowired
+    public CvrSampleListUtil cvrSampleListUtil;
+
     private String dmpConsumeUrl;
-    
+
     Logger log = Logger.getLogger(ConsumeSampleWriter.class);
-    
+
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
         // determine which dmp server url to use based on the file basename
@@ -108,10 +112,10 @@ public class ConsumeSampleWriter implements ItemStreamWriter<String> {
             }
             else {
                 consumeSample(sampleId);
-            }            
+            }
         }
     }
-    
+
     private void consumeSample(String sampleId) {
         HttpEntity requestEntity = getRequestEntity();
         RestTemplate restTemplate = new RestTemplate();
@@ -133,6 +137,11 @@ public class ConsumeSampleWriter implements ItemStreamWriter<String> {
             if (responseEntity.getBody().getaffectedRows()==1) {
                 String message = "Sample "+ sampleId +" consumed succesfully";
                 log.info(message);
+                // skip adding gml samples to this list since it is for smile only
+                // and smile is not taking in gml sample metadata
+                if (!gmlMode) {
+                    cvrSampleListUtil.updateSmileSamplesToPublishList(sampleId);
+                }
             }
         } catch (org.springframework.web.client.RestClientResponseException e) {
             log.error("Error consuming sample " + sampleId + " response body is: '" + e.getResponseBodyAsString() + "'");
@@ -140,11 +149,11 @@ public class ConsumeSampleWriter implements ItemStreamWriter<String> {
             log.error("Error consuming sample " + sampleId + "(" + e + ")");
         }
     }
-    
+
     private HttpEntity getRequestEntity() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         return new HttpEntity<Object>(headers);
     }
-    
+
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/smile/SmilePublisherTasklet.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/smile/SmilePublisherTasklet.java
@@ -1,0 +1,90 @@
+package org.cbioportal.cmo.pipelines.cvr.smile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.*;
+import java.util.*;
+import org.apache.log4j.Logger;
+import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
+import org.cbioportal.cmo.pipelines.cvr.model.CVRData;
+import org.cbioportal.cmo.pipelines.cvr.model.CVRMergedResult;
+import org.cbioportal.cmo.pipelines.cvr.model.CVRMetaData;
+import org.mskcc.cmo.messaging.Gateway;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class SmilePublisherTasklet implements Tasklet {
+    @Value("#{jobParameters[testingMode]}")
+    private boolean testingMode;
+
+    @Value("#{jobParameters[jsonFilename]}")
+    private String jsonFilename;
+
+    @Value("${smile.dmp_new_sample_topic}")
+    private String smileDmpNewSampleTopic;
+
+    @Autowired
+    private CvrSampleListUtil cvrSampleListUtil;
+
+    @Autowired
+    private CVRUtilities cvrUtilities;
+
+    @Autowired
+    private Gateway messagingGateway;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Logger log = Logger.getLogger(SmilePublisherTasklet.class);
+
+    @Override
+    public RepeatStatus execute(StepContribution sc, ChunkContext cc) throws Exception {
+        if (testingMode) {
+            log.info("[TEST MODE] samples will not be published to smile");
+            return RepeatStatus.FINISHED;
+        }
+
+        // nothing to do if our reference list is empty
+        if (cvrSampleListUtil.getSmileSamplesToPublishList().isEmpty()) {
+            log.info("No samples to publish to SMILE");
+            return RepeatStatus.FINISHED;
+        }
+        // iterate through json file and if sample id is in list of samples that were
+        // consumed successfully then publish its metadata to smile
+        List<CVRMetaData> sampleMetadataList = loadSampleMetadataFromJson();
+        for (CVRMetaData sample : sampleMetadataList) {
+            log.info("Publishing sample metadata to SMILE: " + sample.getDmpSampleId());
+            messagingGateway.publish(smileDmpNewSampleTopic, mapper.writeValueAsString(sample));
+        }
+
+        return RepeatStatus.FINISHED;
+    }
+
+    private List<CVRMetaData> loadSampleMetadataFromJson() {
+        File cvrFile = new File(jsonFilename);
+        CVRData cvrData = new CVRData();
+        try {
+            cvrData = cvrUtilities.readJson(cvrFile);
+        } catch (IOException e) {
+            log.error("Error reading file: " + cvrFile.getName());
+            throw new ItemStreamException(e);
+        }
+
+        // add sample metadata to list that should be published to smile
+        Set<String> samplesToPublish = cvrSampleListUtil.getSmileSamplesToPublishList();
+        List<CVRMetaData> sampleMetadataList = new ArrayList();
+        for (CVRMergedResult result : cvrData.getResults()) {
+            if (samplesToPublish.contains(result.getMetaData().getDmpSampleId())) {
+                sampleMetadataList.add(result.getMetaData());
+            }
+        }
+        return sampleMetadataList;
+    }
+
+}

--- a/cvr/src/main/resources/application.properties.EXAMPLE
+++ b/cvr/src/main/resources/application.properties.EXAMPLE
@@ -49,3 +49,27 @@ dmp.email.recipient=
 
 # computational pathology settings
 comppath.wsv.baseurl=https://slides-dev.mskcc.org/viewer?ids=IMAGE_ID.svs@annotation=off
+
+# smile connection properties
+
+# smile publishing topic
+smile.dmp_new_sample_topic=
+
+# these properties are built into the smile nats message lib (github.com/mskcc/smile-messaging-java)
+# smile publishing failures log file
+smile.publishing_failures_filepath=
+
+# smile nats ssl
+nats.tls_channel=
+nats.keystore_path=
+nats.truststore_path=
+nats.key_password=
+nats.store_password=
+
+# smile nats connection proprties
+nats.consumer_name=
+nats.consumer_password=
+nats.url=
+nats.filter_subject=
+nats.request_wait_time_in_seconds=
+


### PR DESCRIPTION
Adds NATS messaging to CVR "consume" step

Samples that are consumed successfully will also have their metadata published to SMILE

Signed-off-by: Angelica Ochoa <ochoaa@mskcc.org>

