### PR TITLE
Remove Annotated MAF before Import

### DIFF
--- a/import-scripts/subset_and_merge_crdb_pdx_studies.py
+++ b/import-scripts/subset_and_merge_crdb_pdx_studies.py
@@ -580,8 +580,7 @@ def annotate_maf(destination_to_source_mapping, root_directory, annotator_jar):
         # if annotation succeeded then replace original maf with annotated maf
         # otherwise remove annotated maf if exists in destination study directory
         if annotator_status == 0:
-            shutil.copy(annot_maf, orig_maf)
-            os.remove(annot_maf)
+            shutil.move(annot_maf, orig_maf)
             DESTINATION_STUDY_STATUS_FLAGS[destination][ANNOTATION_SUCCESS] = True
         else:
             if os.path.isfile(annot_maf):

--- a/import-scripts/subset_and_merge_crdb_pdx_studies.py
+++ b/import-scripts/subset_and_merge_crdb_pdx_studies.py
@@ -581,6 +581,7 @@ def annotate_maf(destination_to_source_mapping, root_directory, annotator_jar):
         # otherwise remove annotated maf if exists in destination study directory
         if annotator_status == 0:
             shutil.copy(annot_maf, orig_maf)
+            os.remove(annot_maf)
             DESTINATION_STUDY_STATUS_FLAGS[destination][ANNOTATION_SUCCESS] = True
         else:
             if os.path.isfile(annot_maf):


### PR DESCRIPTION
think this is related to the file renaming effort from a while back where we merge all data_mutations* into one profile - data_mutations_annotated wasn't getting imported but now it's getting merged into data_mutations_extended. 

To fix this we just make sure to remove the mutations_annotated file from the dir as part of processing