### PR TITLE
Update study-id argument to generate_case_lists.py to reflect new cancer_study_identifier for AZ MSKImpact

### DIFF
--- a/import-scripts/update-az-mskimpact.sh
+++ b/import-scripts/update-az-mskimpact.sh
@@ -237,7 +237,7 @@ function generate_case_lists() {
             return 1
         fi
     fi
-    $PYTHON_BINARY /data/portal-cron/scripts/generate_case_lists.py --case-list-config-file $CASE_LIST_CONFIG_FILE --case-list-dir $CASE_LIST_DIR --study-dir $AZ_MSK_IMPACT_DATA_HOME --study-id mskimpact -o
+    $PYTHON_BINARY /data/portal-cron/scripts/generate_case_lists.py --case-list-config-file $CASE_LIST_CONFIG_FILE --case-list-dir $CASE_LIST_DIR --study-dir $AZ_MSK_IMPACT_DATA_HOME --study-id az_msk_impact -o
 }
 
 # ------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
We want to change the cancer_study_identifier for AZ MSKImpact to "az_msk_impact". This PR propagates that change to the `generate_case_lists.py` script so that it is correctly updated in the case list files.