### PR TITLE
PDX Bug - Metadata Header Issue w/ Duplicating Columns

### DIFF
--- a/import-scripts/clinicalfile_utils.py
+++ b/import-scripts/clinicalfile_utils.py
@@ -253,7 +253,8 @@ def duplicate_existing_attribute_to_new_attribute(clinical_file, existing_attrib
     header_processed = False
 
     if existing_attribute_name in header:
-        to_write = get_ordered_metadata_and_add_new_attribute(clinical_file, new_attribute_name)
+        if has_metadata_headers(clinical_file):
+		to_write = get_ordered_metadata_and_add_new_attribute(clinical_file, new_attribute_name)
         header = get_header(clinical_file)
         existing_attribute_index = header.index(existing_attribute_name)
         with open(clinical_file, "r") as f:

--- a/import-scripts/subset_and_merge_crdb_pdx_studies.py
+++ b/import-scripts/subset_and_merge_crdb_pdx_studies.py
@@ -569,7 +569,7 @@ def post_process_and_cleanup_destination_study_data(lib, destination_to_source_m
     """
     insert_maf_sequenced_samples_header(destination_to_source_mapping, root_directory) # step 7(a)
     annotate_maf(destination_to_source_mapping, root_directory, annotator_jar) # step 7(b)
-    add_display_sample_name_column(destination_to_source_mapping, root_directory) # step 7(c)
+    add_display_sample_name_column(lib, destination_to_source_mapping, root_directory) # step 7(c)
     generate_destination_study_case_lists(lib, destination_to_source_mapping, root_directory, case_lists_config_file) # step 7(d)
     standardize_destination_study_cna_data(destination_to_source_mapping, root_directory) # step 7(e)
     standardize_destination_study_gene_matrix_data(destination_to_source_mapping, root_directory) # step 7(f)
@@ -614,7 +614,13 @@ def annotate_maf(destination_to_source_mapping, root_directory, annotator_jar):
             if os.path.isfile(annot_maf):
                 os.remove(annot_maf)
 
-def add_display_sample_name_column(destination_to_source_mapping, root_directory):
+def add_metadata_headers(destination_directory, lib):
+        add_metadata_headers_call = generate_add_metadata_headers_call(lib, destination_directory)
+	add_metadata_headers_status = subprocess.call(add_metadata_headers_call, shell = True)
+	if add_metadata_headers_status != 0:
+	    print >> OUTPUT_FILE, "Unable to add metadata headers for study %s" % os.path.basename(os.path.normpath(destination_directory))
+	
+def add_display_sample_name_column(lib, destination_to_source_mapping, root_directory):
     """
         Adds DISPLAY_SAMPLE_ID to clinical sample file to support frontend feature which allows
         value in DISPLAY_SAMPLE_ID to be displayed over value in SAMPLE_ID. This is to allow PDX
@@ -624,6 +630,7 @@ def add_display_sample_name_column(destination_to_source_mapping, root_directory
     """
     for destination in destination_to_source_mapping:
         destination_directory = os.path.join(root_directory, destination)
+    	add_metadata_headers(destination_directory, lib)
         clinical_file = os.path.join(destination_directory, CLINICAL_SAMPLE_FILE_PATTERN)
         clinicalfile_utils.duplicate_existing_attribute_to_new_attribute(clinical_file, PDX_ID_COLUMN, DISPLAY_SAMPLE_NAME_COLUMN)
 
@@ -857,6 +864,10 @@ def generate_merge_call(lib, cancer_study_id, destination_directory, subdirector
 def generate_merge_clinical_files_call(lib, cancer_study_id, destination_directory):
     merge_clinical_files_call = 'python ' + lib + '/merge_clinical_files.py -d ' + destination_directory + ' -s ' + cancer_study_id
     return merge_clinical_files_call
+
+def generate_add_metadata_headers_call(lib, destination_directory):
+    add_metadata_headers_call = 'python ' + lib + '/add_clinical_attribute_metadata_headers -f ' + destination_directory + '/data_clinical*'
+    return add_metadata_headers_call 
 
 def generate_annotator_call(annotator_jar, destination_directory):
     annotator_call = 'java -jar ' + annotator_jar + ' -f ' + destination_directory + '/data_mutations_extended.txt ' + '-o ' + destination_directory + '/' + ANNOTATED_MAF_FILE_PATTERN + ' -i mskcc'

--- a/import-scripts/test/test_subset_and_merge_pdx.py
+++ b/import-scripts/test/test_subset_and_merge_pdx.py
@@ -309,7 +309,7 @@ class TestSubsetAndMergePDXStudies(unittest.TestCase):
             Test Step 7(c): check that DISPLAY_SAMPLE_NAME column is added to clinical header
         """
         self.setup_root_directory_with_previous_test_output("subset_timeline_files_step")
-        add_display_sample_name_column(self.mock_destination_to_source_mapping, self.root_directory)
+        add_display_sample_name_column(self.lib, self.mock_destination_to_source_mapping, self.root_directory)
         self.check_add_display_sample_name_column_step()
 
     def check_add_display_sample_name_column_step(self):


### PR DESCRIPTION
Fix to clinicalfile utils - duplicate column function no longer assumes metadataheaders are present
Add a step to PDX pipeline to add metadata headers