### PR TITLE
Standardize blank values in CNA file to NA

### DIFF
--- a/import-scripts/standardize_cna_data.py
+++ b/import-scripts/standardize_cna_data.py
@@ -17,13 +17,19 @@ import os
 import validation_utils
 
 ERROR_FILE = sys.stderr
-OUTPUT_FILE = sys.stdout
 
 
 def main():
     # Receive path to clinical file as an argument
     parser = argparse.ArgumentParser(prog='standardize_cna_data.py')
-    parser.add_argument('-f', '--filename', dest='filename', action='store', required=True, help='path to data_CNA.txt file')
+    parser.add_argument(
+        '-f',
+        '--filename',
+        dest='filename',
+        action='store',
+        required=True,
+        help='path to data_cna.txt file',
+    )
 
     args = parser.parse_args()
     filename = args.filename

--- a/import-scripts/standardize_cna_data.py
+++ b/import-scripts/standardize_cna_data.py
@@ -1,0 +1,45 @@
+#! /usr/bin/env python
+
+""" standardize_cna_data.py
+This script rewrites a CNA file to replace all NA placeholders/blank values with 'NA'.
+
+Usage:
+    python standardize_cna_data.py --filename $INPUT_CNA_FILE
+Example:
+    python standardize_cna_data.py --filename /path/to/data_CNA.txt
+
+"""
+
+import sys
+import argparse
+import os
+
+import validation_utils
+
+ERROR_FILE = sys.stderr
+OUTPUT_FILE = sys.stdout
+
+
+def main():
+    # Receive path to clinical file as an argument
+    parser = argparse.ArgumentParser(prog='standardize_cna_data.py')
+    parser.add_argument('-f', '--filename', dest='filename', action='store', required=True, help='path to data_CNA.txt file')
+
+    args = parser.parse_args()
+    filename = args.filename
+
+    # Check that the CNA file exists
+    if not os.path.exists(filename):
+        print >> ERROR_FILE, 'No such file: ' + filename
+        parser.print_help()
+
+    # Standardize blank values in the CNA file to 'NA'
+    try:
+        validation_utils.standardize_cna_file(filename)
+    except ValueError as error:
+        print >> ERROR_FILE, 'Unable to write standardized CNA data: ' + error
+        sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/import-scripts/standardize_cna_data.py
+++ b/import-scripts/standardize_cna_data.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 """ standardize_cna_data.py
 This script rewrites a CNA file to replace all blank values with 'NA'.
@@ -6,7 +6,7 @@ This script rewrites a CNA file to replace all blank values with 'NA'.
 Usage:
     python standardize_cna_data.py --filename $INPUT_CNA_FILE
 Example:
-    python standardize_cna_data.py --filename /path/to/data_CNA.txt
+    python standardize_cna_data.py --filename /path/to/data_cna.txt
 
 """
 

--- a/import-scripts/standardize_cna_data.py
+++ b/import-scripts/standardize_cna_data.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 """ standardize_cna_data.py
-This script rewrites a CNA file to replace all NA placeholders/blank values with 'NA'.
+This script rewrites a CNA file to replace all blank values with 'NA'.
 
 Usage:
     python standardize_cna_data.py --filename $INPUT_CNA_FILE

--- a/import-scripts/update-az-mskimpact.sh
+++ b/import-scripts/update-az-mskimpact.sh
@@ -246,6 +246,17 @@ function standardize_clinical_data() {
     mv "$SAMPLE_OUTPUT_FILEPATH" "$SAMPLE_INPUT_FILEPATH"
 }
 
+function standardize_cna_data() {
+    DATA_CNA_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_CNA.txt"
+    DATA_CNA_OUTPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_CNA.txt.standardized"
+
+    # Standardize the CNA file to use NA for blank values
+    $PYTHON_BINARY $PORTAL_HOME/scripts/standardize_cna_data.py -f "$DATA_CNA_INPUT_FILEPATH" > "$DATA_CNA_OUTPUT_FILEPATH" &&
+
+    # Rewrite the CNA file with the standardized data
+    mv "$DATA_CNA_INPUT_FILEPATH" "$DATA_CNA_OUTPUT_FILEPATH"
+}
+
 function anonymize_age_at_seq_with_cap() {
     PATIENT_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_clinical_patient.txt"
     PATIENT_OUTPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_clinical_patient.txt.os_months_trunc"
@@ -342,6 +353,11 @@ fi
 # Standardize blank clinical data values to NA
 if ! standardize_clinical_data ; then
     report_error "ERROR: Failed to standardize blank clinical data values to NA for AstraZeneca MSK-IMPACT. Exiting."
+fi
+
+# Standardize blank CNA data values to NA
+if ! standardize_cna_data ; then
+    report_error "ERROR: Failed to standardize blank CNA data values to NA for AstraZeneca MSK-IMPACT. Exiting."
 fi
 
 # Anonymize ages

--- a/import-scripts/update-az-mskimpact.sh
+++ b/import-scripts/update-az-mskimpact.sh
@@ -247,14 +247,9 @@ function standardize_clinical_data() {
 }
 
 function standardize_cna_data() {
-    DATA_CNA_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_CNA.txt"
-    DATA_CNA_OUTPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_CNA.txt.standardized"
-
     # Standardize the CNA file to use NA for blank values
-    $PYTHON_BINARY $PORTAL_HOME/scripts/standardize_cna_data.py -f "$DATA_CNA_INPUT_FILEPATH" > "$DATA_CNA_OUTPUT_FILEPATH" &&
-
-    # Rewrite the CNA file with the standardized data
-    mv "$DATA_CNA_INPUT_FILEPATH" "$DATA_CNA_OUTPUT_FILEPATH"
+    DATA_CNA_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_CNA.txt"
+    $PYTHON_BINARY $PORTAL_HOME/scripts/standardize_cna_data.py -f "$DATA_CNA_INPUT_FILEPATH"
 }
 
 function anonymize_age_at_seq_with_cap() {

--- a/import-scripts/validation_utils.py
+++ b/import-scripts/validation_utils.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-import argparse
 import os
-import sys
 
 import clinicalfile_utils
 import generate_case_lists


### PR DESCRIPTION
Import of az_mskimpact is failing with public import tools in part due to blank values in the `data_CNA.txt` file. This PR introduces the `standardize_cna_data.py` script and calls it on each update of the az_mskimpact dataset.