### PR TITLE
Fix invalid NCBI_Build values in mutations files

### DIFF
--- a/import-scripts/standardize_mutations_data.py
+++ b/import-scripts/standardize_mutations_data.py
@@ -15,13 +15,19 @@ import os
 import validation_utils
 
 ERROR_FILE = sys.stderr
-OUTPUT_FILE = sys.stdout
 
 
 def main():
     # Receive path to clinical file as an argument
     parser = argparse.ArgumentParser(prog='standardize_mutations_data.py')
-    parser.add_argument('-f', '--filename', dest='filename', action='store', required=True, help='path to data_mutations.txt file')
+    parser.add_argument(
+        '-f',
+        '--filename',
+        dest='filename',
+        action='store',
+        required=True,
+        help='path to data_mutations.txt file',
+    )
 
     args = parser.parse_args()
     filename = args.filename

--- a/import-scripts/standardize_mutations_data.py
+++ b/import-scripts/standardize_mutations_data.py
@@ -1,0 +1,43 @@
+#! /usr/bin/env python
+
+""" standardize_mutations_data.py
+This script rewrites a mutations file standardize all 'NCBI_Build' values to include the prefix 'GRCh'.
+Usage:
+    python standardize_mutations_data.py --filename $INPUT_MUTATIONS_FILE
+Example:
+    python standardize_mutations_data.py --filename /path/to/data_mutations.txt
+"""
+
+import sys
+import argparse
+import os
+
+import validation_utils
+
+ERROR_FILE = sys.stderr
+OUTPUT_FILE = sys.stdout
+
+
+def main():
+    # Receive path to clinical file as an argument
+    parser = argparse.ArgumentParser(prog='standardize_mutations_data.py')
+    parser.add_argument('-f', '--filename', dest='filename', action='store', required=True, help='path to data_mutations.txt file')
+
+    args = parser.parse_args()
+    filename = args.filename
+
+    # Check that the mutations file exists
+    if not os.path.exists(filename):
+        print >> ERROR_FILE, 'No such file: ' + filename
+        parser.print_help()
+
+    # Standardize the mutations file
+    try:
+        validation_utils.standardize_mutations_file(filename)
+    except ValueError as error:
+        print >> ERROR_FILE, 'Unable to write standardized mutations data: ' + error
+        sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/import-scripts/update-az-mskimpact.sh
+++ b/import-scripts/update-az-mskimpact.sh
@@ -252,6 +252,17 @@ function standardize_cna_data() {
     $PYTHON_BINARY $PORTAL_HOME/scripts/standardize_cna_data.py -f "$DATA_CNA_INPUT_FILEPATH"
 }
 
+function standardize_mutations_data() {
+    MUTATIONS_EXTD_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_mutations_extended.txt"
+    MUTATIONS_MAN_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_mutations_manual.txt"
+    NSOUT_MUTATIONS_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_nonsignedout_mutations.txt"
+
+    # Standardize the mutations files to check for valid values in the 'NCBI_Build' column
+    $PYTHON_BINARY $PORTAL_HOME/import-scripts/standardize_mutations_data.py -f "$MUTATIONS_EXTD_INPUT_FILEPATH" &&
+    $PYTHON_BINARY $PORTAL_HOME/import-scripts/standardize_mutations_data.py -f "$MUTATIONS_MAN_INPUT_FILEPATH" &&
+    $PYTHON_BINARY $PORTAL_HOME/import-scripts/standardize_mutations_data.py -f "$NSOUT_MUTATIONS_INPUT_FILEPATH"
+}
+
 function anonymize_age_at_seq_with_cap() {
     PATIENT_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_clinical_patient.txt"
     PATIENT_OUTPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_clinical_patient.txt.os_months_trunc"
@@ -307,7 +318,8 @@ if [ $? -gt 0 ] ; then
 fi
 
 # ------------------------------------------------------------------------------------------------------------------------
-# 3. Remove Part A non-consented patients + samples
+# 3. Post-process the dataset
+
 printTimeStampedDataProcessingStepMessage "Subset and merge of Part A Consented patients for AstraZeneca MSK-IMPACT"
 
 # Generate subset of Part A consented patients from MSK-Impact
@@ -333,7 +345,7 @@ if [ $? -gt 0 ] ; then
     report_error "ERROR: Failed to write out subsetted data for AstraZeneca MSK-IMPACT. Exiting."
 fi
 
-printTimeStampedDataProcessingStepMessage "Filter clinical attribute columns, add metadata headers, and anonymize age at sequencing for AstraZeneca MSK-IMPACT"
+printTimeStampedDataProcessingStepMessage "Filter clinical attribute columns, add metadata headers, standardize data files, and anonymize age at sequencing for AstraZeneca MSK-IMPACT"
 
 # Filter clinical attribute columns from clinical files
 if ! filter_clinical_attribute_columns ; then
@@ -355,6 +367,11 @@ if ! standardize_cna_data ; then
     report_error "ERROR: Failed to standardize blank CNA data values to NA for AstraZeneca MSK-IMPACT. Exiting."
 fi
 
+# Standardize mutations files
+if ! standardize_mutations_data ; then
+    report_error "ERROR: Failed to standardize mutations files for AstraZeneca MSK-IMPACT. Exiting."
+fi
+
 # Anonymize ages
 if ! anonymize_age_at_seq_with_cap ; then
     report_error "ERROR: Failed to anonymize AGE_AT_SEQUENCING_REPORTED_YEARS for AstraZeneca MSK-IMPACT. Exiting."
@@ -367,7 +384,7 @@ if ! filter_files_in_delivery_directory ; then
     report_error "ERROR: Failed to filter non-delivered files for AstraZeneca MSK-IMPACT. Exiting."
 fi
 
-# Remove temporary directory now that the subset has been merged
+# Remove temporary directory now that the subset has been merged and post-processed
 if [[ -d "$AZ_TMPDIR" && "$AZ_TMPDIR" != "/" ]] ; then
     rm -rf "$AZ_TMPDIR" "$AZ_MSK_IMPACT_DATA_HOME/part_a_subset.txt"
 fi

--- a/import-scripts/update-az-mskimpact.sh
+++ b/import-scripts/update-az-mskimpact.sh
@@ -258,9 +258,9 @@ function standardize_mutations_data() {
     NSOUT_MUTATIONS_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_nonsignedout_mutations.txt"
 
     # Standardize the mutations files to check for valid values in the 'NCBI_Build' column
-    $PYTHON_BINARY $PORTAL_HOME/import-scripts/standardize_mutations_data.py -f "$MUTATIONS_EXTD_INPUT_FILEPATH" &&
-    $PYTHON_BINARY $PORTAL_HOME/import-scripts/standardize_mutations_data.py -f "$MUTATIONS_MAN_INPUT_FILEPATH" &&
-    $PYTHON_BINARY $PORTAL_HOME/import-scripts/standardize_mutations_data.py -f "$NSOUT_MUTATIONS_INPUT_FILEPATH"
+    $PYTHON_BINARY $PORTAL_HOME/scripts/standardize_mutations_data.py -f "$MUTATIONS_EXTD_INPUT_FILEPATH" &&
+    $PYTHON_BINARY $PORTAL_HOME/scripts/standardize_mutations_data.py -f "$MUTATIONS_MAN_INPUT_FILEPATH" &&
+    $PYTHON_BINARY $PORTAL_HOME/scripts/standardize_mutations_data.py -f "$NSOUT_MUTATIONS_INPUT_FILEPATH"
 }
 
 function anonymize_age_at_seq_with_cap() {

--- a/import-scripts/validation_utils.py
+++ b/import-scripts/validation_utils.py
@@ -139,13 +139,10 @@ def fix_invalid_ncbi_build_values(mutations_file):
                     continue
                 # Only process the 'NCBI_Build' column
                 # Prepend 'GRCh' to the data value if it doesn't already contain this prefix
-                processed_data = []
-                for index, data_value in enumerate(data):
-                    if index == ncbi_build_index and data_value and not data_value.startswith(ncbi_build_value_prefix):
-                        processed_data.append(ncbi_build_value_prefix + data_value)
-                    else:
-                        processed_data.append(data_value)
-                to_write.append("\t".join(processed_data))
+                ncbi_value = data[ncbi_build_index]
+                if ncbi_value and not ncbi_value.startswith(ncbi_build_value_prefix):
+                    data[ncbi_build_index] = ncbi_build_value_prefix + ncbi_value
+                to_write.append("\t".join(data))
 
     clinicalfile_utils.write_data_list_to_file(mutations_file, to_write)
 

--- a/import-scripts/validation_utils.py
+++ b/import-scripts/validation_utils.py
@@ -100,6 +100,55 @@ def fill_in_blank_gene_panel_values(gene_matrix_file):
 
     clinicalfile_utils.write_data_list_to_file(gene_matrix_file, to_write)
 
+def standardize_mutations_file(mutations_file):
+    """
+        Various processes for standardizing a mutations file.
+        Other steps can be added in the future if necessary.
+    """
+    if not os.path.isfile(mutations_file):
+        print "Specified mutations file (%s) does not exist, no changes made..." % (mutations_file)
+        return
+    fix_invalid_ncbi_build_values(mutations_file)
+
+def fix_invalid_ncbi_build_values(mutations_file):
+    """
+        Checks for invalid NCBI_Build data values, ie, any data value
+        not starting with prefix 'GRCh'. If an invalid value is found,
+        'GRCh' is prepended to the value.
+    """
+    header_processed = False
+    header = []
+    to_write = []
+
+    with open(mutations_file, "r") as f:
+        ncbi_build_value_prefix = "GRCh"
+        for line in f.readlines():
+            data = line.rstrip("\n").split("\t")
+            if line.startswith("#"):
+                # Automatically add commented out lines
+                to_write.append(line.rstrip("\n"))
+            else:
+                if not header_processed:
+                    header = data
+                    ncbi_build_index = clinicalfile_utils.get_index_for_column(header, "NCBI_Build")
+                    if ncbi_build_index == -1:
+                        print "NCBI_Build column not found in mutations file %s." % (mutations_file)
+                        return
+                    to_write.append(line.rstrip("\n"))
+                    header_processed = True
+                    continue
+                # Only process the 'NCBI_Build' column
+                # Prepend 'GRCh' to the data value if it doesn't already contain this prefix
+                processed_data = []
+                for index, data_value in enumerate(data):
+                    if index == ncbi_build_index and data_value and not data_value.startswith(ncbi_build_value_prefix):
+                        processed_data.append(ncbi_build_value_prefix + data_value)
+                    else:
+                        processed_data.append(data_value)
+                to_write.append("\t".join(processed_data))
+
+    clinicalfile_utils.write_data_list_to_file(mutations_file, to_write)
+
 def remove_duplicate_rows(filename, record_identifier_column):
     """
         Drop and log duplicate records - where records are identified by the values under specified column (record_identifier_column)


### PR DESCRIPTION
Import of az_mskimpact is failing with public import tools in part due to invalid NCBI_Build values in the mutations files. This PR introduces the `standardize_mutations_files.py` script to check for invalid values (those that don't begin with 'GRCh') and correct them (prepend 'GRCh'). This script will be called on each update of the az_mskimpact dataset.