### PR TITLE
Correctly handle no change to clinical files in changelog generation script

### DIFF
--- a/import-scripts/generate_az_study_changelog_py3.py
+++ b/import-scripts/generate_az_study_changelog_py3.py
@@ -147,13 +147,18 @@ class DataHandler:
 
         # Obtain git diff for the file
         diff_info = g.diff('--unified=0', '--', self.data_path)
-        lines = diff_info.split('\n')
 
+        # Check if there is a git diff to process
+        if not diff_info:
+            return
+
+        lines = diff_info.split('\n')
         for line in lines:
             tokens = line.split('\t')
 
             # Git prepends each line of git diff with a '+' or '-'
             # We will use this to correctly parse the changes to each line
+
             mode = tokens[0][0]
             tokens[0] = tokens[0][1:]
 


### PR DESCRIPTION
Changelog generation script fails when there is no git diff to parse. This PR fixes that bug and now runs successfully even if the clinical files haven't changed.