### PR TITLE
Fix AZ delivery script to use updated names for CNA seg data

### DIFF
--- a/import-scripts/update-az-mskimpact.sh
+++ b/import-scripts/update-az-mskimpact.sh
@@ -82,7 +82,7 @@ function filter_files_in_delivery_directory() {
     filenames_to_deliver[data_mutations_manual.txt]+=1
     filenames_to_deliver[data_nonsignedout_mutations.txt]+=1
     filenames_to_deliver[data_sv.txt]+=1
-    filenames_to_deliver[mskimpact_data_cna_hg19.seg]+=1
+    filenames_to_deliver[az_mskimpact_data_cna_hg19.seg]+=1
     filenames_to_deliver[case_lists]+=1
 
     # Meta files to deliver
@@ -93,7 +93,7 @@ function filter_files_in_delivery_directory() {
     filenames_to_deliver[meta_mutations_extended.txt]+=1
     filenames_to_deliver[meta_study.txt]+=1
     filenames_to_deliver[meta_sv.txt]+=1
-    filenames_to_deliver[mskimpact_meta_cna_hg19_seg.txt]+=1
+    filenames_to_deliver[az_mskimpact_meta_cna_hg19_seg.txt]+=1
 
     # Remove any files/directories that are not specified above
     for filepath in $AZ_MSK_IMPACT_DATA_HOME/* ; do


### PR DESCRIPTION
The "Fraction Genome Altered" chart was not being displayed for the AZ-MSKIMPACT study on the MSK instance because this attribute is added on import of the CNA seg data files, which looks for a naming file pattern consistent with the study identifier. This updates the names of the seg data files to use the correct study identifier "az_mskimpact" so they will be imported correctly and the chart can be displayed.