### PR TITLE
Restore add-age-at-seq-report for genie and update calculation logic

### DIFF
--- a/import-scripts/add-age-at-seq-report.py
+++ b/import-scripts/add-age-at-seq-report.py
@@ -1,0 +1,150 @@
+import sys
+import optparse
+import csv
+import os
+import math
+from datetime import datetime
+
+ERROR_FILE = sys.stderr
+OUTPUT_FILE = sys.stdout
+
+# globals
+AGE_AT_SEQ_REPORT_FIELD = 'AGE_AT_SEQ_REPORT'
+AGE_FIELD = 'AGE'
+SEQ_DATE_FIELD = 'SEQ_DATE'
+AVERAGE_DAYS_PER_YEAR = 365.2422
+
+PATIENT_SAMPLE_MAP = {}
+SAMPLE_SEQ_DATE_MAP = {}
+PATIENT_AGE = {}
+
+
+def load_sample_seq_date(seq_date_file, convert_to_days):
+	""" Loads SEQ_DATE from seq date file provided. """
+	data_file = open(seq_date_file, 'rU')
+	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
+
+	for line in data_reader:
+		# skip samples not found in the clinical file
+		if not line['SAMPLE_ID'] in PATIENT_SAMPLE_MAP.keys():
+			continue
+		seq_date = datetime.strptime(line['SEQ_DATE'], '%a, %d %b %Y %H:%M:%S %Z')
+		difference_in_years = int(math.ceil(((datetime.now() - seq_date).days)/AVERAGE_DAYS_PER_YEAR))
+		try:
+			age_at_seq_report_value = (PATIENT_AGE[line['PATIENT_ID']] - difference_in_years)
+			if convert_to_days:
+				age_at_seq_report_value = age_at_seq_report_value*AVERAGE_DAYS_PER_YEAR
+			SAMPLE_SEQ_DATE_MAP[line['SAMPLE_ID']] = str(int(math.ceil(age_at_seq_report_value)))
+		except KeyError:
+			print "Patient age not found for '" + line['PATIENT_ID'] + "'"
+			SAMPLE_SEQ_DATE_MAP[line['SAMPLE_ID']] = 'NA'
+
+
+def load_patient_age(age_file):
+	""" Loads AGE from age file. """
+	data_file = open(age_file, 'rU')
+	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
+
+	for line in data_reader:
+		# skip records not found in clinical file 
+		if not line['PATIENT_ID'] in PATIENT_SAMPLE_MAP.values():
+			continue
+		PATIENT_AGE[line['PATIENT_ID']] = int(line['AGE'])
+
+
+def load_patient_sample_mapping(clinical_file):
+	""" Loads patient-sample mapping. """
+	data_file = open(clinical_file, 'rU')
+	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
+	for line in data_reader:
+		PATIENT_SAMPLE_MAP[line['SAMPLE_ID']] = line['PATIENT_ID']
+	data_file.close()
+
+
+def add_age_at_seq_report(clinical_file):
+	header = get_file_header(clinical_file)
+
+	# add age at seq report column in not already present
+	if not AGE_AT_SEQ_REPORT_FIELD in header:
+		header.append(AGE_AT_SEQ_REPORT_FIELD)
+	output_data = ['\t'.join(header)]
+
+	data_file = open(clinical_file, 'rU')
+	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
+	for line in data_reader:
+		line[AGE_AT_SEQ_REPORT_FIELD] = SAMPLE_SEQ_DATE_MAP[line['SAMPLE_ID']]
+		formatted_data = map(lambda x: line.get(x, ''), header)
+		output_data.append('\t'.join(formatted_data))
+	data_file.close()
+	output_file = open(clinical_file, 'w')
+	output_file.write('\n'.join(output_data))
+	output_file.close()
+	print 'Finished adding age at seq report'
+
+
+def get_file_header(filename):
+	""" Returns the file header. """
+	data_file = open(filename, 'rU')
+	filedata = [x for x in data_file.readlines() if not x.startswith('#')]
+	header = map(str.strip, filedata[0].split('\t'))
+	data_file.close()
+	return header
+
+
+def validate_file_header(filename, key_column):
+	""" Validates that the key column exists in the file header. """
+	if not key_column in get_file_header(filename):
+		print >> ERROR_FILE, "Could not find key column '" + key_column + "' in file header for: " + filename + "! Please make sure this column exists before running script."
+		usage()
+
+def usage():
+	print >> OUTPUT_FILE, "add-age-at-seq-report.py --clinical-file [path/to/clinical/file] --seq-date-file [path/to/seq/date/file] --age-file [path/to/age/file] --convert-to-days [true|false]"
+	sys.exit(2)
+
+def main():
+	# get command line stuff
+	parser = optparse.OptionParser()
+	parser.add_option('-f', '--clinical-file', action = 'store', dest = 'clinfile')
+	parser.add_option('-s', '--seq-date-file', action = 'store', dest = 'seqdatefile')
+	parser.add_option('-a', '--age-file', action = 'store', dest = 'agefile')
+	parser.add_option('-c', '--convert-to-days', action = 'store', dest = 'convertdays')
+
+	(options, args) = parser.parse_args()
+	clinical_file = options.clinfile
+	seq_date_file = options.seqdatefile
+	age_file = options.agefile
+	convert_to_days_flag = options.convertdays
+
+
+	if not clinical_file or not seq_date_file or not age_file:
+		print >> ERROR_FILE, "Clinical file, seq date file, and age file must be provided."
+		usage()
+
+	if not os.path.exists(clinical_file):
+		print >> ERROR_FILE, "No such file: " + clinical_file
+		usage()
+
+	if not os.path.exists(seq_date_file):
+		print >> ERROR_FILE, "No such file: " + seq_date_file
+		uage()
+
+	if not os.path.exists(age_file):
+		print >> ERROR_FILE, "No such file: " + age_file
+		usage()
+
+	# validate file headers
+	validate_file_header(seq_date_file, SEQ_DATE_FIELD)
+	validate_file_header(age_file, AGE_FIELD)
+
+	convert_to_days = False
+	if convert_to_days_flag != None and convert_to_days_flag != '' and convert_to_days_flag.lower() == 'true':
+		convert_to_days = True
+
+	load_patient_sample_mapping(clinical_file)
+	load_patient_age(age_file)
+	load_sample_seq_date(seq_date_file, convert_to_days)
+	add_age_at_seq_report(clinical_file)
+
+
+if __name__ == '__main__':
+	main()

--- a/import-scripts/add-age-at-seq-report.py
+++ b/import-scripts/add-age-at-seq-report.py
@@ -80,6 +80,8 @@ def load_age_at_seq_reported_years(clinical_sample_file, convert_to_days):
 
 		# Convert AGE_AT_SEQ_REPORTED_YEARS to days and store the value
 		# Default to NA if type conversion fails
+		# Note that we are performing the reverse of this calculation to keep the age at seq year value consistent:
+		# https://github.com/Sage-Bionetworks/Genie/blob/53db39ccb6e423743df49c1f0e115c9a7576af69/genie/database_to_staging.py#L1133-L1138
 		try:
 			age_at_seq_report_value = int(age_at_seq_reported_years)
 			if convert_to_days:

--- a/import-scripts/add-age-at-seq-report.py
+++ b/import-scripts/add-age-at-seq-report.py
@@ -28,7 +28,7 @@ PATIENT_ID_FIELD = 'PATIENT_ID'
 SAMPLE_ID_FIELD = 'SAMPLE_ID'
 AGE_AT_SEQ_REPORTED_YEARS_FIELD = 'AGE_AT_SEQ_REPORTED_YEARS'
 AGE_AT_SEQ_REPORT_FIELD = 'AGE_AT_SEQ_REPORT'
-AVERAGE_DAYS_PER_YEAR = 365.2422
+AVERAGE_DAYS_PER_YEAR = 365.25
 
 PATIENT_SAMPLE_MAP = {}
 SAMPLE_AGE_AT_SEQ_REPORT_MAP = {}
@@ -81,9 +81,10 @@ def load_age_at_seq_reported_years(clinical_sample_file, convert_to_days):
 		# Convert AGE_AT_SEQ_REPORTED_YEARS to days and store the value
 		# Default to NA if type conversion fails
 		try:
+			age_at_seq_report_value = int(age_at_seq_reported_years)
 			if convert_to_days:
-				age_at_seq_report_value = int(age_at_seq_reported_years) * AVERAGE_DAYS_PER_YEAR
-			SAMPLE_AGE_AT_SEQ_REPORT_MAP[sample_id] = str(int(math.floor(age_at_seq_report_value)))
+				age_at_seq_report_value = age_at_seq_report_value * AVERAGE_DAYS_PER_YEAR
+			SAMPLE_AGE_AT_SEQ_REPORT_MAP[sample_id] = str(int(math.ceil(age_at_seq_report_value)))
 		except ValueError:
 			print AGE_AT_SEQ_REPORTED_YEARS_FIELD + " not found for '" + sample_id + "'"
 			SAMPLE_AGE_AT_SEQ_REPORT_MAP[sample_id] = 'NA'

--- a/import-scripts/add-age-at-seq-report.py
+++ b/import-scripts/add-age-at-seq-report.py
@@ -1,42 +1,85 @@
 #!/usr/bin/env python
 
-import sys
-import optparse
+"""
+This script generates and writes the AGE_AT_SEQ_REPORT attribute to a given clinical file.
+This attribute represents the age, in days, of a given patient on the date that their sample
+was sequenced. This value is calculated by reading the AGE_AT_SEQ_REPORTED_YEARS attribute from
+the clinical sample file and converting its value to days. This is functionality is primarily
+used for the Genie dataset.
+
+Usage:
+	python add-age-at-seq-report.py \
+		--clinical-output-file [path/to/clinical/output/file] \
+		--clinical-sample-file [path/to/clinical/sample/file] \
+		--convert-to-days [true|false]
+"""
+
 import csv
-import os
 import math
+import optparse
+import os
+import sys
 
 ERROR_FILE = sys.stderr
 OUTPUT_FILE = sys.stdout
 
-# globals
-AGE_AT_SEQ_REPORT_FIELD = 'AGE_AT_SEQ_REPORT'
+# Global variables
+PATIENT_ID_FIELD = 'PATIENT_ID'
+SAMPLE_ID_FIELD = 'SAMPLE_ID'
 AGE_AT_SEQ_REPORTED_YEARS_FIELD = 'AGE_AT_SEQ_REPORTED_YEARS'
+AGE_AT_SEQ_REPORT_FIELD = 'AGE_AT_SEQ_REPORT'
 AVERAGE_DAYS_PER_YEAR = 365.2422
 
 PATIENT_SAMPLE_MAP = {}
 SAMPLE_AGE_AT_SEQ_REPORT_MAP = {}
 
 
-def read_sample_file(sample_file):
+def add_age_at_seq_report(clinical_output_file):
+	""" Writes AGE_AT_SEQ_REPORT attribute to the clinical output file. """
+	# Add AGE_AT_SEQ_REPORT column to header if not already present
+	header = get_file_header(clinical_output_file)
+	if not AGE_AT_SEQ_REPORT_FIELD in header:
+		header.append(AGE_AT_SEQ_REPORT_FIELD)
+	output_data = ['\t'.join(header)]
+
+	# Populate AGE_AT_SEQ_REPORT column
+	data_file = open(clinical_output_file, 'rU')
+	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
+	for line in data_reader:
+		line[AGE_AT_SEQ_REPORT_FIELD] = SAMPLE_AGE_AT_SEQ_REPORT_MAP[line[SAMPLE_ID_FIELD]]
+		formatted_data = map(lambda x: line.get(x, ''), header)
+		output_data.append('\t'.join(formatted_data))
+	data_file.close()
+
+	# Write data to file
+	output_file = open(clinical_output_file, 'w')
+	output_file.write('\n'.join(output_data))
+	output_file.close()
+	print 'Finished adding age at seq report'
+
+
+def read_clinical_sample_file(clinical_sample_file):
     """ Generator function that yields all non-commented lines from the clinical sample file. """
-    with open(sample_file, 'rU') as f:
+    with open(clinical_sample_file, 'rU') as f:
         for line in f:
             if line.startswith('#'):
                 continue
             yield line
 
 
-def load_age_at_seq_reported_years(sample_file, convert_to_days):
+def load_age_at_seq_reported_years(clinical_sample_file, convert_to_days):
 	""" Loads AGE_AT_SEQ_REPORTED_YEARS from clinical sample file and converts it to days. """
-
-	data_reader = csv.DictReader(read_sample_file(sample_file), dialect = 'excel-tab')
+	data_reader = csv.DictReader(read_clinical_sample_file(clinical_sample_file), dialect = 'excel-tab')
 	for line in data_reader:
-		sample_id = line['SAMPLE_ID']
-		# skip samples not found in the clinical file
+		sample_id = line[SAMPLE_ID_FIELD]
+
+		# Skip samples not found in the clinical file
 		if not sample_id in PATIENT_SAMPLE_MAP.keys():
 			continue
 		age_at_seq_reported_years = line[AGE_AT_SEQ_REPORTED_YEARS_FIELD]
+
+		# Convert AGE_AT_SEQ_REPORTED_YEARS to days and store the value
+		# Default to NA if type conversion fails
 		try:
 			if convert_to_days:
 				age_at_seq_report_value = int(age_at_seq_reported_years) * AVERAGE_DAYS_PER_YEAR
@@ -46,34 +89,13 @@ def load_age_at_seq_reported_years(sample_file, convert_to_days):
 			SAMPLE_AGE_AT_SEQ_REPORT_MAP[sample_id] = 'NA'
 
 
-def load_patient_sample_mapping(clinical_file):
+def load_patient_sample_mapping(clinical_output_file):
 	""" Loads patient-sample mapping. """
-	data_file = open(clinical_file, 'rU')
+	data_file = open(clinical_output_file, 'rU')
 	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
 	for line in data_reader:
-		PATIENT_SAMPLE_MAP[line['SAMPLE_ID']] = line['PATIENT_ID']
+		PATIENT_SAMPLE_MAP[line[SAMPLE_ID_FIELD]] = line[PATIENT_ID_FIELD]
 	data_file.close()
-
-
-def add_age_at_seq_report(clinical_file):
-	header = get_file_header(clinical_file)
-
-	# add age at seq report column if not already present
-	if not AGE_AT_SEQ_REPORT_FIELD in header:
-		header.append(AGE_AT_SEQ_REPORT_FIELD)
-	output_data = ['\t'.join(header)]
-
-	data_file = open(clinical_file, 'rU')
-	data_reader = csv.DictReader(data_file, dialect = 'excel-tab')
-	for line in data_reader:
-		line[AGE_AT_SEQ_REPORT_FIELD] = SAMPLE_AGE_AT_SEQ_REPORT_MAP[line['SAMPLE_ID']]
-		formatted_data = map(lambda x: line.get(x, ''), header)
-		output_data.append('\t'.join(formatted_data))
-	data_file.close()
-	output_file = open(clinical_file, 'w')
-	output_file.write('\n'.join(output_data))
-	output_file.close()
-	print 'Finished adding age at seq report'
 
 
 def get_file_header(filename):
@@ -85,52 +107,60 @@ def get_file_header(filename):
 	return header
 
 
-def validate_file_header(filename, key_column):
+def validate_file_header(filename, key_columns):
 	""" Validates that the key column exists in the file header. """
-	if not key_column in get_file_header(filename):
-		print >> ERROR_FILE, "Could not find key column '" + key_column + "' in file header for: " + filename + "! Please make sure this column exists before running script."
+	missing_columns = []
+	header = get_file_header(filename)
+
+	for column in key_columns:
+		if not column in header:
+			missing_columns.append(column)
+
+	if missing_columns:
+		print >> ERROR_FILE, "Could not find key column(s) '" + ', '.join(missing_columns) + "' in file header for: " + filename + "! Please make sure column(s) exist before running script."
 		usage()
 
 
 def usage():
-	print >> OUTPUT_FILE, "add-age-at-seq-report.py --clinical-file [path/to/clinical/file] --sample-file [path/to/sample/file] --convert-to-days [true|false]"
+	print >> OUTPUT_FILE, "add-age-at-seq-report.py --clinical-output-file [path/to/clinical/output/file] --clinical-sample-file [path/to/clinical/sample/file] --convert-to-days [true|false]"
 	sys.exit(2)
 
 
 def main():
-	# get command line stuff
+	# Get command line stuff
 	parser = optparse.OptionParser()
-	parser.add_option('-f', '--clinical-file', action = 'store', dest = 'clinfile')
-	parser.add_option('-s', '--sample-file', action = 'store', dest = 'samplefile')
+	parser.add_option('-f', '--clinical-output-file', action = 'store', dest = 'clinfile')
+	parser.add_option('-s', '--clinical-sample-file', action = 'store', dest = 'samplefile')
 	parser.add_option('-c', '--convert-to-days', action = 'store', dest = 'convertdays')
 
 	(options, args) = parser.parse_args()
-	clinical_file = options.clinfile
-	sample_file = options.samplefile
+	clinical_output_file = options.clinfile
+	clinical_sample_file = options.samplefile
 	convert_to_days_flag = options.convertdays
 
-	if not clinical_file or not sample_file:
-		print >> ERROR_FILE, "Clinical file and sample file must be provided."
+	if not clinical_output_file or not clinical_sample_file:
+		print >> ERROR_FILE, "Clinical output file and clinical sample file must be provided."
 		usage()
 
-	if not os.path.exists(clinical_file):
-		print >> ERROR_FILE, "No such file: " + clinical_file
+	if not os.path.exists(clinical_output_file):
+		print >> ERROR_FILE, "No such file: " + clinical_output_file
 		usage()
 
-	if not os.path.exists(sample_file):
-		print >> ERROR_FILE, "No such file: " + sample_file
+	if not os.path.exists(clinical_sample_file):
+		print >> ERROR_FILE, "No such file: " + clinical_sample_file
 		usage()
 
-	# validate file headers
-	validate_file_header(sample_file, AGE_AT_SEQ_REPORTED_YEARS_FIELD)
+	# Validate file headers
+	validate_file_header(clinical_output_file, [PATIENT_ID_FIELD, SAMPLE_ID_FIELD])
+	validate_file_header(clinical_sample_file, [AGE_AT_SEQ_REPORTED_YEARS_FIELD, SAMPLE_ID_FIELD])
 
 	convert_to_days = False
 	if convert_to_days_flag != None and convert_to_days_flag != '' and convert_to_days_flag.lower() == 'true':
 		convert_to_days = True
 
-	load_patient_sample_mapping(clinical_file)
-	load_age_at_seq_reported_years(sample_file, convert_to_days)
-	add_age_at_seq_report(clinical_file)
+	load_patient_sample_mapping(clinical_output_file)
+	load_age_at_seq_reported_years(clinical_sample_file, convert_to_days)
+	add_age_at_seq_report(clinical_output_file)
 
 
 if __name__ == '__main__':

--- a/import-scripts/subset-impact-data.sh
+++ b/import-scripts/subset-impact-data.sh
@@ -103,7 +103,7 @@ if [ $STUDY_ID == "genie" ]; then
 
         # add age at seq report using cvr/seq_date.txt
         echo "Adding AGE_AT_SEQ_REPORT to $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt"
-        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/add-age-at-seq-report.py --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --sample-file="$INPUT_DIRECTORY/data_clinical_sample.txt" --convert-to-days="true"
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/add-age-at-seq-report.py --clinical-output-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --clinical-sample-file="$INPUT_DIRECTORY/data_clinical_sample.txt" --convert-to-days="true"
         if [ $? -gt 0 ] ; then
             echo "Failed to add AGE_AT_SEQ_REPORT to $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt using $INPUT_DIRECTORY/data_clinical_sample.txt. Exiting..."
             exit 2l

--- a/import-scripts/subset-impact-data.sh
+++ b/import-scripts/subset-impact-data.sh
@@ -103,9 +103,9 @@ if [ $STUDY_ID == "genie" ]; then
 
         # add age at seq report using cvr/seq_date.txt
         echo "Adding AGE_AT_SEQ_REPORT to $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt"
-        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/add-age-at-seq-report.py --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --seq-date-file="$INPUT_DIRECTORY/cvr/seq_date.txt" --age-file="$INPUT_DIRECTORY/ddp/ddp_age.txt" --convert-to-days="true"
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/add-age-at-seq-report.py --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --sample-file="$INPUT_DIRECTORY/data_clinical_sample.txt" --convert-to-days="true"
         if [ $? -gt 0 ] ; then
-            echo "Failed to add AGE_AT_SEQ_REPORT to $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt using $INPUT_DIRECTORY/cvr/seq_date.txt. Exiting..."
+            echo "Failed to add AGE_AT_SEQ_REPORT to $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt using $INPUT_DIRECTORY/data_clinical_sample.txt. Exiting..."
             exit 2l
         fi
 

--- a/import-scripts/subset-impact-data.sh
+++ b/import-scripts/subset-impact-data.sh
@@ -101,6 +101,14 @@ if [ $STUDY_ID == "genie" ]; then
             exit 2
         fi
 
+        # add age at seq report using cvr/seq_date.txt
+        echo "Adding AGE_AT_SEQ_REPORT to $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt"
+        $PYTHON_BINARY $PORTAL_SCRIPTS_DIRECTORY/add-age-at-seq-report.py --clinical-file="$OUTPUT_DIRECTORY/data_clinical_supp_sample.txt" --seq-date-file="$INPUT_DIRECTORY/cvr/seq_date.txt" --age-file="$INPUT_DIRECTORY/ddp/ddp_age.txt" --convert-to-days="true"
+        if [ $? -gt 0 ] ; then
+            echo "Failed to add AGE_AT_SEQ_REPORT to $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt using $INPUT_DIRECTORY/cvr/seq_date.txt. Exiting..."
+            exit 2l
+        fi
+
         # rename GENE_PANEL to SEQ_ASSAY_ID in data_clinical_supp_sample.txt
         sed -i.bak 's/GENE_PANEL/SEQ_ASSAY_ID/' $OUTPUT_DIRECTORY/data_clinical_supp_sample.txt
         # remove temp files created


### PR DESCRIPTION
This PR:

- Reintroduces the `add-age-at-seq-report.py` script and its corresponding call in `subset-impact-data.sh` for genie. This code had previously been removed in this PR ([https://github.com/knowledgesystems/cmo-pipelines/pull/1020](https://github.com/knowledgesystems/cmo-pipelines/pull/1020)) but we still need it in order to add the `AGE_AT_SEQ_REPORT` column to genie data.
- Modifies the `add-age-at-seq-report.py` script to calculate `AGE_AT_SEQ_REPORT` by reading the `AGE_AT_SEQ_REPORTED_YEARS` attribute from the clinical sample file and converting it to days. This fixes the bug that was occurring in the prior method of calculation (described in more detail in the Age at Sequencing ADR).