### PR TITLE
SMILE Connection Error Handling

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
@@ -112,7 +112,11 @@ public class BatchConfiguration {
 
     @Bean
     public Gateway messagingGateway() throws Exception {
-        messagingGateway.connect();
+        try {
+            messagingGateway.connect();
+        } catch (Exception e) {
+            log.warn("Unable to connect to NATS server, no samples will be published.");
+        }
         return messagingGateway;
     }
 

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/smile/SmilePublisherTasklet.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/smile/SmilePublisherTasklet.java
@@ -50,6 +50,11 @@ public class SmilePublisherTasklet implements Tasklet {
             return RepeatStatus.FINISHED;
         }
 
+        if (!messagingGateway.isConnected()) {
+            log.info("Unable to conenct to SMILE, samples will not be published.");
+            return RepeatStatus.FINISHED;
+        }
+
         // nothing to do if our reference list is empty
         if (cvrSampleListUtil.getSmileSamplesToPublishList().isEmpty()) {
             log.info("No samples to publish to SMILE");

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/smile/SmilePublisherTasklet.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/smile/SmilePublisherTasklet.java
@@ -51,7 +51,7 @@ public class SmilePublisherTasklet implements Tasklet {
         }
 
         if (!messagingGateway.isConnected()) {
-            log.info("Unable to conenct to SMILE, samples will not be published.");
+            log.info("Unable to connect to SMILE, samples will not be published.");
             return RepeatStatus.FINISHED;
         }
 


### PR DESCRIPTION
Original Bug
---------
In the event a NATS server connection could not be established, an exception would be thrown due to an inability to create the bean and entire pipeline would fail

Fix
---------
Catch the exception and continue
Update the SmileTasklet to skip publishing if connection is not established 

TODO/???
----------
Bean does not shutdown gracefully due to how the `shutdown()` method is implemented [here](https://github.com/mskcc/smile-messaging-java/blob/master/src/main/java/org/mskcc/cmo/messaging/impl/JSGatewayImpl.java#L204) 

Spring automatically calls the `shutdown()` method for beans and an exception is being thrown. However, this happens after the job completes on application shutdown. Might be okay to merge and leave this for a future fix? 
