### PR TITLE
updates to persistence cache and kubeconfig for new EKS cluster

### DIFF
--- a/import-scripts/clear_cbioportal_persistence_cache.sh
+++ b/import-scripts/clear_cbioportal_persistence_cache.sh
@@ -41,9 +41,9 @@ portal_to_deployment_map["sclc"]="eks-sclc"
 
 unset portal_to_cache_service_list
 declare -A portal_to_cache_service_list
-portal_to_cache_service_list["public"]="cbioportal-public-persistence-redis-master cbioportal-public-persistence-redis-slave"
-portal_to_cache_service_list["genie-public"]="cbioportal-persistence-redis-genie-master cbioportal-persistence-redis-genie-slave"
-portal_to_cache_service_list["genie-private"]="cbioportal-persistence-redis-genie-master cbioportal-persistence-redis-genie-slave"
+portal_to_cache_service_list["public"]="cbioportal-public-persistence-redis-master cbioportal-public-persistence-redis-replicas"
+portal_to_cache_service_list["genie-public"]="cbioportal-persistence-redis-genie-master cbioportal-persistence-redis-genie-replicas"
+portal_to_cache_service_list["genie-private"]="cbioportal-persistence-redis-genie-master cbioportal-persistence-redis-genie-replicas"
 portal_to_cache_service_list["genie-archive"]=""
 portal_to_cache_service_list["triage"]="triage-cbioportal-persistence-redis-master triage-cbioportal-persistence-redis-replicas"
 portal_to_cache_service_list["hgnc"]=""

--- a/import-scripts/pipelines_eks/automation-environment.sh
+++ b/import-scripts/pipelines_eks/automation-environment.sh
@@ -103,7 +103,7 @@ export START_DEVDB_IMPORT_TRIGGER_FILENAME=$PORTAL_HOME/import-trigger/devdb-imp
 export KILL_DEVDB_IMPORT_TRIGGER_FILENAME=$PORTAL_HOME/import-trigger/devdb-import-kill-request
 export DEVDB_IMPORT_IN_PROGRESS_FILENAME=$PORTAL_HOME/import-trigger/devdb-import-in-progress
 export DEVDB_IMPORT_KILLING_FILENAME=$PORTAL_HOME/import-trigger/devdb-import-killing
-export PUBLIC_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/public-cluster-config
+export PUBLIC_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/public-eks-config
 
 #######################
 # SSL args (for AWS + redcap)


### PR DESCRIPTION
- persistence cache, new version of redis in EKS cluster uses different syntax
- kubeconfig name - for interacting with new cluster when clearing cache