### PR TITLE
use standard cookie parsing in ddp

### DIFF
--- a/ddp/ddp_pipeline/src/main/resources/naaccr_race.json
+++ b/ddp/ddp_pipeline/src/main/resources/naaccr_race.json
@@ -8,7 +8,7 @@
   ],
   "3": [
     "American Indian, Aleutian, or Eskimo (includes all indigenous populations of the Western hemisphere)",
-    "NATIVE AMERICAN-AM IND/ALASKA"
+    "NATIVE AMERICAN-AM IND\/ALASKA"
   ],
   "4": [
     "Chinese"
@@ -54,7 +54,7 @@
     "Micronesian, NOS"
   ],
   "21": [
-    "Chamorro/Chamoru"
+    "Chamorro\/Chamoru"
   ],
   "22": [
     "Guamanian, NOS"
@@ -85,7 +85,7 @@
   ],
   "96": [
     "Other Asian, including Asian, NOS and Oriental, NOS",
-    "ASIAN-FAR EAST/INDIAN SUBCONT"
+    "ASIAN-FAR EAST\/INDIAN SUBCONT"
   ],
   "97": [
     "Pacific Islander, NOS"


### PR DESCRIPTION
- the default HttpClient configuration is unable to parse the cookie format now used by the ddp API. Use a custom configuration with CookieSpecs.STANDARD
- also harmonize the forward slash escaping in naacr json files (which are now removed from pipelines-configuration)