### PR TITLE
switch code to java 11 and latest cbioportal

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,7 +25,6 @@
     </dependency>
   </dependencies>
 
-
   <build>
     <plugins>
       <plugin>

--- a/common/src/main/java/org/cbioportal/cmo/pipelines/common/util/ClinicalValueUtil.java
+++ b/common/src/main/java/org/cbioportal/cmo/pipelines/common/util/ClinicalValueUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
+ * Copyright (c) 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -30,30 +30,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.mskcc.cmo.ks.darwin.pipeline.mskimpactbrainspineclinical;
+package org.cbioportal.cmo.pipelines.common.util;
 
-import java.util.*;
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineClinical;
-import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinUtils;
-import org.springframework.batch.item.ItemProcessor;
-import org.springframework.beans.factory.annotation.Autowired;
+public class ClinicalValueUtil {
 
-/**
- *
- * @author jake
- */
-public class MskimpactBrainSpineClinicalProcessor implements ItemProcessor<MskimpactBrainSpineClinical, String> {
-
-    @Autowired
-    private DarwinUtils darwinUtils;
-
-    @Override
-    public String process(final MskimpactBrainSpineClinical darwinClinicalBrainSpine) throws Exception {
-        List<String> record = new ArrayList<>();
-        for(String field : new MskimpactBrainSpineClinical().getFieldNames()){
-            String value = darwinClinicalBrainSpine.getClass().getMethod("get"+field).invoke(darwinClinicalBrainSpine).toString();
-            record.add(darwinUtils.convertWhitespace(value));
+    public static String defaultWithNA(String value) {
+        if (value == null || value.isEmpty()) {
+            return "NA";
+        } else {
+            return value;
         }
-        return String.join("\t", record);
     }
+
+    public static String defaultWithNegativeOne(String value) {
+        if (value == null || value.isEmpty()) {
+            return "-1";
+        } else {
+            return value;
+        }
+    }
+
 }

--- a/common/src/main/java/org/cbioportal/cmo/pipelines/common/util/EmailUtil.java
+++ b/common/src/main/java/org/cbioportal/cmo/pipelines/common/util/EmailUtil.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -36,7 +36,6 @@ import java.util.*;
 import java.util.Properties;
 import javax.mail.*;
 import javax.mail.internet.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -48,7 +47,6 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class EmailUtil {
-
     @Value("${email.server}")
     private  String server;
     @Value("${email.sender}")
@@ -105,7 +103,7 @@ public class EmailUtil {
         for (Throwable exception : exceptions) {
             messages.add(ExceptionUtils.getFullStackTrace(exception));
         }
-        body += StringUtils.join(messages, "\n\n");
+        body += String.join("\n\n", messages);
         sendEmailToDefaultRecipient(subject, body);
     }
 }

--- a/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXTimelineListener.java
+++ b/crdb/src/main/java/org/mskcc/cmo/ks/crdb/pipeline/CRDBPDXTimelineListener.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2019, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,12 +32,10 @@
 
 package org.mskcc.cmo.ks.crdb.pipeline;
 
-import org.mskcc.cmo.ks.crdb.pipeline.model.CRDBPDXTimelineDataset;
-import org.cbioportal.cmo.pipelines.common.util.EmailUtil;
-
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.cbioportal.cmo.pipelines.common.util.EmailUtil;
+import org.mskcc.cmo.ks.crdb.pipeline.model.CRDBPDXTimelineDataset;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
@@ -86,9 +84,9 @@ public class CRDBPDXTimelineListener implements StepExecutionListener {
             Set<String> records = new HashSet<>();
             for (CRDBPDXTimelineDataset record : nullStartDateTimelinePatients) {
                 String[] recordDetails = {record.getPATIENT_ID(), record.getPDX_ID(), record.getEVENT_TYPE(), record.getEVENT_TYPE_DETAILED()};
-                records.add(StringUtils.join(recordDetails, "\t"));
+                records.add(String.join("\t", recordDetails));
             }
-            body.append(StringUtils.join(records, "\n"))
+            body.append(String.join("\n", records))
                 .append("\n");
             emailUtil.sendEmail(sender, new String[]{pdxRecipient, defaultRecipient}, pdxEmailSubject, body.toString());
         }

--- a/cvr/pom.xml
+++ b/cvr/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.github.genome-nexus</groupId>
       <artifactId>genome-nexus-annotation-pipeline</artifactId>
-      <version>9b1dee795db637811c31cac1338d14b109ed8420</version>
+      <version>b1ff99fd9945f15c86b2a2b5e91cc199d0bc87ea</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/CVRUtilities.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2023 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,16 +32,14 @@
 
 package org.cbioportal.cmo.pipelines.cvr;
 
-import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRClinicalRecord;
-import org.cbioportal.cmo.pipelines.cvr.model.*;
-import org.cbioportal.models.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.*;
 import java.text.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.cbioportal.cmo.pipelines.cvr.model.*;
+import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRClinicalRecord;
+import org.cbioportal.models.*;
 
 /**
  *
@@ -367,7 +365,7 @@ public class CVRUtilities {
     }
 
     private String resolveVariantType(String refAllele, String altAllele) {
-        if (!StringUtils.isEmpty(refAllele) && !StringUtils.isEmpty(altAllele)) {
+        if (refAllele != null && !refAllele.isEmpty() && altAllele != null && !altAllele.isEmpty()) {
             if (refAllele.equals("-")) {
                 return "INS";
             }
@@ -392,11 +390,13 @@ public class CVRUtilities {
         if (record.getVARIANT_TYPE().equalsIgnoreCase("INS") || record.getVARIANT_TYPE().equalsIgnoreCase("DEL")) {
             variant += "_" + record.getEND_POSITION();
             // want to capture INDEL details, so modify variant string with both if applicable
-            if (!StringUtils.isEmpty(record.getTUMOR_SEQ_ALLELE2()) && !record.getTUMOR_SEQ_ALLELE2().equals("-")) {
-                variant += "ins" + record.getTUMOR_SEQ_ALLELE2();
+            String tumorSeqAllele2 = record.getTUMOR_SEQ_ALLELE2();
+            String referenceAllele = record.getREFERENCE_ALLELE();
+            if (tumorSeqAllele2 != null && !tumorSeqAllele2.isEmpty() && !tumorSeqAllele2.equals("-")) {
+                variant += "ins" + tumorSeqAllele2;
             }
-            if (!StringUtils.isEmpty(record.getREFERENCE_ALLELE()) && !record.getREFERENCE_ALLELE().equals("-")) {
-                variant += "del" + record.getREFERENCE_ALLELE();
+            if (referenceAllele != null && !referenceAllele.isEmpty() && !referenceAllele.equals("-")) {
+                variant += "del" + referenceAllele;
             }
         }
         else {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,16 +32,15 @@
 
 package org.cbioportal.cmo.pipelines.cvr.clinical;
 
-import org.cbioportal.cmo.pipelines.cvr.model.staging.MskimpactSeqDate;
+import java.util.*;
+import org.apache.log4j.Logger;
+import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
+import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
 import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeClinicalRecord;
 import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRClinicalRecord;
-import java.util.*;
-import org.apache.commons.lang.StringUtils;
-import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
-import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
+import org.cbioportal.cmo.pipelines.cvr.model.staging.MskimpactSeqDate;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.apache.log4j.Logger;
 
 /**
  *
@@ -54,7 +53,7 @@ public class CVRClinicalDataProcessor implements ItemProcessor<CVRClinicalRecord
 
     @Autowired
     public CvrSampleListUtil cvrSampleListUtil;
-    
+
     Logger log = Logger.getLogger(CVRClinicalDataProcessor.class);
 
     @Override
@@ -75,11 +74,11 @@ public class CVRClinicalDataProcessor implements ItemProcessor<CVRClinicalRecord
         }
         CompositeClinicalRecord compRecord = new CompositeClinicalRecord();
         if (cvrSampleListUtil.getNewDmpSamples().contains(i.getSAMPLE_ID())) {
-            compRecord.setNewClinicalRecord(StringUtils.join(record, "\t"));
+            compRecord.setNewClinicalRecord(String.join("\t", record));
         } else {
-            compRecord.setOldClinicalRecord(StringUtils.join(record, "\t"));
+            compRecord.setOldClinicalRecord(String.join("\t", record));
         }
-        compRecord.setSeqDateRecord(StringUtils.join(seqDateRecord, "\t"));
+        compRecord.setSeqDateRecord(String.join("\t", seqDateRecord));
         return compRecord;
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
@@ -189,7 +189,7 @@ public class CVRClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
         File mskimpactSeqDateFile = new File(stagingDirectory, CVRUtilities.SEQ_DATE_CLINICAL_FILE);
         if (!mskimpactSeqDateFile.exists()) {
             log.error("File does not exist - skipping data loading from seq date file: " + mskimpactSeqDateFile.getName());
-			return;
+            return;
         }
         log.info("Loading seq date data from: " + mskimpactSeqDateFile.getName());
         DelimitedLineTokenizer tokenizer = new DelimitedLineTokenizer(DelimitedLineTokenizer.DELIMITER_TAB);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -34,16 +34,15 @@ package org.cbioportal.cmo.pipelines.cvr.clinical;
 
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeClinicalRecord;
 import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRClinicalRecord;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.*;
-import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeClinicalRecord;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  *
@@ -71,7 +70,7 @@ public class CVRClinicalDataWriter implements ItemStreamWriter<CompositeClinical
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
             @Override
             public void writeHeader(Writer writer) throws IOException {
-                writer.write(StringUtils.join(CVRClinicalRecord.getFieldNames(), "\t"));
+                writer.write(String.join("\t", CVRClinicalRecord.getFieldNames()));
             }
         });
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRSeqDateClinicalDataWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRSeqDateClinicalDataWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,21 +29,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.cbioportal.cmo.pipelines.cvr.clinical;
 
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeClinicalRecord;
 import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRClinicalRecord;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.*;
-import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeClinicalRecord;
-import org.springframework.beans.factory.annotation.Autowired;
-
 
 /**
  *
@@ -72,7 +71,7 @@ public class CVRSeqDateClinicalDataWriter implements ItemStreamWriter<CompositeC
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
                 @Override
                 public void writeHeader(Writer writer) throws IOException {
-                    writer.write(StringUtils.join(CVRClinicalRecord.getSeqDateFieldNames(), "\t"));
+                    writer.write(String.join("\t", CVRClinicalRecord.getSeqDateFieldNames()));
                 }
             });
             flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/cna/CVRCnaDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/cna/CVRCnaDataReader.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,15 +32,13 @@
 
 package org.cbioportal.cmo.pipelines.cvr.cna;
 
-import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeCnaRecord;
-import org.cbioportal.cmo.pipelines.cvr.*;
-import org.cbioportal.cmo.pipelines.cvr.model.*;
-
 import java.io.*;
 import java.util.*;
 import org.apache.commons.collections.map.MultiKeyMap;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.cbioportal.cmo.pipelines.cvr.*;
+import org.cbioportal.cmo.pipelines.cvr.model.*;
+import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeCnaRecord;
 import org.springframework.batch.item.*;
 import org.springframework.beans.factory.annotation.*;
 
@@ -154,7 +152,7 @@ public class CVRCnaDataReader implements ItemStreamReader<CompositeCnaRecord>{
     }
 
     private void makeRecordsList() {
-        cnaRecords.add(new CompositeCnaRecord("",cvrUtilities.CNA_HEADER_HUGO_SYMBOL + "\t" + StringUtils.join(samples,"\t")));
+        cnaRecords.add(new CompositeCnaRecord("",cvrUtilities.CNA_HEADER_HUGO_SYMBOL + "\t" + String.join("\t", samples)));
         for (String gene : genes) {
             String line = gene;
             for (String sample : samples) {
@@ -170,7 +168,7 @@ public class CVRCnaDataReader implements ItemStreamReader<CompositeCnaRecord>{
     }
 
     private void makeNewRecordsList() {
-        cnaRecords.add(new CompositeCnaRecord(cvrUtilities.CNA_HEADER_HUGO_SYMBOL + "\t" + StringUtils.join(newSamples,"\t"), ""));
+        cnaRecords.add(new CompositeCnaRecord(cvrUtilities.CNA_HEADER_HUGO_SYMBOL + "\t" + String.join("\t", newSamples), ""));
         for (String gene : genes) {
             String line = gene;
             for (String sample : newSamples) {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,10 +32,9 @@
 
 package org.cbioportal.cmo.pipelines.cvr.genepanel;
 
-import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRGenePanelRecord;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRGenePanelRecord;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -59,6 +58,6 @@ public class CVRGenePanelProcessor implements ItemProcessor<CVRGenePanelRecord, 
         for (String profile : geneticProfiles) {
             record.add(cvrUtilities.convertWhitespace(i.getPanelMap().get(profile)));
         }
-        return StringUtils.join(record, "\t");
+        return String.join("\t", record);
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelReader.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2022 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2022, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,14 +32,12 @@
 
 package org.cbioportal.cmo.pipelines.cvr.genepanel;
 
-import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRGenePanelRecord;
-import org.cbioportal.cmo.pipelines.cvr.*;
-import org.cbioportal.cmo.pipelines.cvr.model.*;
-
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
+import org.cbioportal.cmo.pipelines.cvr.*;
+import org.cbioportal.cmo.pipelines.cvr.model.*;
+import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRGenePanelRecord;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.mapping.DefaultLineMapper;
@@ -146,7 +144,7 @@ public class CVRGenePanelReader implements ItemStreamReader<CVRGenePanelRecord> 
                 if (!Arrays.asList(header).contains(profile)) {
                     String message = "File '" + genePanelMatrixFile.getName() +
                             "' is missing one or more expected genetic profiles in header: "
-                            + StringUtils.join(geneticProfiles, ",");
+                            + String.join(",", geneticProfiles);
                     log.error(message);
                     throw new ItemStreamException(message);
                 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/genepanel/CVRGenePanelWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -34,14 +34,13 @@ package org.cbioportal.cmo.pipelines.cvr.genepanel;
 
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.*;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  *
@@ -69,7 +68,7 @@ public class CVRGenePanelWriter implements ItemStreamWriter<String>{
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
             @Override
             public void writeHeader(Writer writer) throws IOException {
-                writer.write(StringUtils.join(header, "\t"));
+                writer.write(String.join("\t", header));
             }
         });
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/linkedimpactcase/LinkedMskimpactCaseProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/linkedimpactcase/LinkedMskimpactCaseProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,10 +32,9 @@
 
 package org.cbioportal.cmo.pipelines.cvr.linkedimpactcase;
 
-import org.cbioportal.cmo.pipelines.cvr.model.staging.LinkedMskimpactCaseRecord;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.model.staging.LinkedMskimpactCaseRecord;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -58,6 +57,6 @@ public class LinkedMskimpactCaseProcessor implements ItemProcessor<LinkedMskimpa
             }
             record.add(value);
         }
-        return StringUtils.join(record, "\t");
-    }        
+        return String.join("\t", record);
+    }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/linkedimpactcase/LinkedMskimpactCaseWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/linkedimpactcase/LinkedMskimpactCaseWriter.java
@@ -1,26 +1,52 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
+ * Center has been advised of the possibility of such damage.
  */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package org.cbioportal.cmo.pipelines.cvr.linkedimpactcase;
 
-import org.cbioportal.cmo.pipelines.cvr.model.staging.LinkedMskimpactCaseRecord;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
 import org.cbioportal.cmo.pipelines.cvr.model.*;
+import org.cbioportal.cmo.pipelines.cvr.model.staging.LinkedMskimpactCaseRecord;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.item.ItemStreamException;
-import org.springframework.batch.item.ItemStreamWriter;
 import org.springframework.batch.item.file.FlatFileHeaderCallback;
 import org.springframework.batch.item.file.FlatFileItemWriter;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamWriter;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.core.io.FileSystemResource;
 
@@ -35,9 +61,9 @@ public class LinkedMskimpactCaseWriter implements ItemStreamWriter<String> {
 
     @Autowired
     public CVRUtilities cvrUtilities;
-    
+
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
-    
+
     private static final Logger LOG = Logger.getLogger(LinkedMskimpactCaseWriter.class);
 
     @Override
@@ -48,11 +74,11 @@ public class LinkedMskimpactCaseWriter implements ItemStreamWriter<String> {
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
             @Override
             public void writeHeader(Writer writer) throws IOException {
-                writer.write(StringUtils.join(LinkedMskimpactCaseRecord.getFieldNames(), "\t"));
+                writer.write(String.join("\t", LinkedMskimpactCaseRecord.getFieldNames()));
             }
         });
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
-        flatFileItemWriter.open(ec);        
+        flatFileItemWriter.open(ec);
     }
 
     @Override

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/staging/CVRSvRecord.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/model/staging/CVRSvRecord.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016, 2017, 2022 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2022, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,14 +32,11 @@
 
 package org.cbioportal.cmo.pipelines.cvr.model.staging;
 
-import java.util.*;
-
 import com.google.common.base.Strings;
-import org.apache.commons.lang.StringUtils;
+import java.util.*;
 import org.cbioportal.cmo.pipelines.cvr.model.CVRSvVariant;
 import org.cbioportal.cmo.pipelines.cvr.model.GMLCnvIntragenicVariant;
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import com.google.common.base.Strings;
 
 /**
  *
@@ -414,7 +411,7 @@ public class CVRSvRecord {
         for (String fieldName : getFieldNames()) {
                 standardSvHeader.add(fieldName);
         }
-        return StringUtils.join(standardSvHeader, "\t");
+        return String.join("\t", standardSvHeader);
     }
 
     public static List<String> getFieldNames() {

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,7 +33,6 @@
 package org.cbioportal.cmo.pipelines.cvr.mutation;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
 import org.cbioportal.models.AnnotatedRecord;
 import org.springframework.batch.item.ItemProcessor;
@@ -45,7 +44,7 @@ import org.springframework.beans.factory.annotation.Value;
  * @author heinsz
  */
 public class CVRMutationDataProcessor implements ItemProcessor<AnnotatedRecord, String> {
-    
+
     @Value("#{stepExecutionContext['mutationHeader']}")
     private List<String> header;
 
@@ -70,6 +69,6 @@ public class CVRMutationDataProcessor implements ItemProcessor<AnnotatedRecord, 
                 record.add(cvrUtilities.convertWhitespace(i.getAdditionalProperties().getOrDefault(field, "")));
             }
         }
-        return StringUtils.join(record, "\t");
+        return String.join("\t", record);
     }
 }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
@@ -188,7 +188,7 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
         // annotate with GenomeNexusImpl annotator from genome nexus annotation pipeline
         // records will be partitioned inside annotator client
         // records which do not get a response back will automatically be defaulted to an AnnotatedRecord(record)
-        List<AnnotatedRecord> annotatedRecords = annotator.getAnnotatedRecordsUsingPOST(summaryStatistics, records, "mskcc", true, postIntervalSize, reannotate);
+        List<AnnotatedRecord> annotatedRecords = annotator.getAnnotatedRecordsUsingPOST(summaryStatistics, records, "mskcc", true, postIntervalSize, reannotate, "StripEntireSharedPrefix", Boolean.TRUE, Boolean.FALSE);
         for (AnnotatedRecord ar : annotatedRecords) {
             logAnnotationProgress(++annotatedVariantsCount, totalVariantsToAnnotateCount, postIntervalSize);
             mutationRecords.add(ar);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -36,7 +36,6 @@ import org.cbioportal.cmo.pipelines.cvr.*;
 
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
@@ -63,7 +62,7 @@ public class CVRMutationDataWriter implements ItemStreamWriter<String> {
 
     @Autowired
     public CVRUtilities cvrUtilities;
-    
+
     @Autowired
     private CvrSampleListUtil cvrSampleListUtil;
 
@@ -82,15 +81,15 @@ public class CVRMutationDataWriter implements ItemStreamWriter<String> {
                 if  (commentLines != null && !commentLines.isEmpty()) {
                     for (String comment : commentLines) {
                         if (comment.startsWith("#sequenced_samples")) {
-                            comment = "#sequenced_samples: " + StringUtils.join(cvrSampleListUtil.getPortalSamples(), " ") + "\n";
+                            comment = "#sequenced_samples: " + String.join(" ", cvrSampleListUtil.getPortalSamples()) + "\n";
                         }
                         writer.write(comment);
                     }
                 } else {
-                    String comment = "#sequenced_samples: " + StringUtils.join(cvrSampleListUtil.getPortalSamples(), " ") + "\n";
+                    String comment = "#sequenced_samples: " + String.join(" ", cvrSampleListUtil.getPortalSamples()) + "\n";
                     writer.write(comment);
                 }
-                writer.write(StringUtils.join(header , "\t"));
+                writer.write(String.join("\t", header));
             }
         });
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRNonSignedoutMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRNonSignedoutMutationDataReader.java
@@ -181,7 +181,7 @@ public class CVRNonSignedoutMutationDataReader implements ItemStreamReader<Annot
         // annotate with GenomeNexusImpl annotator from genome nexus annotation pipeline
         // records will be partitioned inside annotator client
         // records which do not get a response back will automatically be defaulted to an AnnotatedRecord(record)
-        List<AnnotatedRecord> annotatedRecords = annotator.getAnnotatedRecordsUsingPOST(summaryStatistics, records, "mskcc", true, postIntervalSize, reannotate);
+        List<AnnotatedRecord> annotatedRecords = annotator.getAnnotatedRecordsUsingPOST(summaryStatistics, records, "mskcc", true, postIntervalSize, reannotate, "StripEntireSharedPrefix", Boolean.TRUE, Boolean.FALSE);
         for (AnnotatedRecord ar : annotatedRecords) {
             logAnnotationProgress(++annotatedVariantsCount, totalVariantsToAnnotateCount, postIntervalSize);
             mutationRecords.add(ar);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/GMLMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/GMLMutationDataReader.java
@@ -186,7 +186,7 @@ public class GMLMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
         // annotate with GenomeNexusImpl annotator from genome nexus annotation pipeline
         // records will be partitioned inside annotator client
         // records which do not get a response back will automatically be defauled to an AnnotatedRecord(record)
-        List<AnnotatedRecord> annotatedRecords = annotator.getAnnotatedRecordsUsingPOST(summaryStatistics, records, "mskcc", true, postIntervalSize, reannotate);
+        List<AnnotatedRecord> annotatedRecords = annotator.getAnnotatedRecordsUsingPOST(summaryStatistics, records, "mskcc", true, postIntervalSize, reannotate, "StripEntireSharedPrefix", Boolean.TRUE, Boolean.FALSE);
         for (AnnotatedRecord ar : annotatedRecords) {
             logAnnotationProgress(++annotatedVariantsCount, totalVariantsToAnnotateCount, postIntervalSize);
             mutationRecords.add(ar);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/seg/CVRSegDataProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/seg/CVRSegDataProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,12 +32,11 @@
 
 package org.cbioportal.cmo.pipelines.cvr.seg;
 
+import java.util.*;
+import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
+import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
 import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeSegRecord;
 import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRSegRecord;
-import java.util.*;
-import org.apache.commons.lang.StringUtils;
-import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
-import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -52,7 +51,7 @@ public class CVRSegDataProcessor implements ItemProcessor<CVRSegRecord, Composit
 
     @Autowired
     public CvrSampleListUtil cvrSampleListUtil;
-    
+
     @Override
     public CompositeSegRecord process(CVRSegRecord i) throws Exception {
         List<String> record = new ArrayList<>();
@@ -61,9 +60,9 @@ public class CVRSegDataProcessor implements ItemProcessor<CVRSegRecord, Composit
         }
         CompositeSegRecord compRecord = new CompositeSegRecord();
         if (cvrSampleListUtil.getNewDmpSamples().contains(i.getID())) {
-            compRecord.setNewSegRecord(StringUtils.join(record, "\t").trim());
+            compRecord.setNewSegRecord(String.join("\t", record).trim());
         } else {
-            compRecord.setOldSegRecord(StringUtils.join(record, "\t").trim());
+            compRecord.setOldSegRecord(String.join("\t", record).trim());
         }
         return compRecord;
     }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/seg/CVRSegDataWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/seg/CVRSegDataWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,14 +32,12 @@
 
 package org.cbioportal.cmo.pipelines.cvr.seg;
 
-import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeSegRecord;
-import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRSegRecord;
-import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
-import org.cbioportal.cmo.pipelines.cvr.model.*;
-
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
+import org.cbioportal.cmo.pipelines.cvr.model.*;
+import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeSegRecord;
+import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRSegRecord;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
@@ -52,10 +50,10 @@ import org.springframework.core.io.FileSystemResource;
  */
 
 public class CVRSegDataWriter implements ItemStreamWriter<CompositeSegRecord> {
-    
+
     @Value("#{jobParameters[stagingDirectory]}")
     private String stagingDirectory;
-    
+
     @Value("#{jobParameters[studyId]}")
     private String studyId;
 
@@ -72,7 +70,7 @@ public class CVRSegDataWriter implements ItemStreamWriter<CompositeSegRecord> {
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
            @Override
            public void writeHeader(Writer writer) throws IOException {
-               writer.write(StringUtils.join(CVRSegRecord.getHeaderNames(),"\t"));
+               writer.write(String.join("\t", CVRSegRecord.getHeaderNames()));
            }
         });
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/sv/CVRSvDataProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/sv/CVRSvDataProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,12 +32,11 @@
 
 package org.cbioportal.cmo.pipelines.cvr.sv;
 
+import java.util.*;
+import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
+import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
 import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeSvRecord;
 import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRSvRecord;
-import java.util.*;
-import org.apache.commons.lang.StringUtils;
-import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
-import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -65,9 +64,9 @@ public class CVRSvDataProcessor implements ItemProcessor<CVRSvRecord, CompositeS
         }
         CompositeSvRecord compRecord = new CompositeSvRecord();
         if (cvrSampleListUtil.getNewDmpSamples().contains(i.getSample_ID())) {
-            compRecord.setNewSvRecord(StringUtils.join(record, "\t").trim());
+            compRecord.setNewSvRecord(String.join("\t", record).trim());
         } else {
-            compRecord.setOldSvRecord(StringUtils.join(record, "\t").trim());
+            compRecord.setOldSvRecord(String.join("\t", record).trim());
         }
         return compRecord;
     }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/sv/CVRSvDataWriter.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/sv/CVRSvDataWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -36,16 +36,15 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
-import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRSvRecord;
 import org.cbioportal.cmo.pipelines.cvr.model.composite.CompositeSvRecord;
+import org.cbioportal.cmo.pipelines.cvr.model.staging.CVRSvRecord;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.item.ItemStreamException;
-import org.springframework.batch.item.ItemStreamWriter;
 import org.springframework.batch.item.file.FlatFileHeaderCallback;
 import org.springframework.batch.item.file.FlatFileItemWriter;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/whitelist/ZeroVariantWhitelistTasklet.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/whitelist/ZeroVariantWhitelistTasklet.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,16 +32,14 @@
 
 package org.cbioportal.cmo.pipelines.cvr.whitelist;
 
+import java.io.*;
+import java.nio.file.Files;
+import java.util.*;
+import org.apache.log4j.Logger;
 import org.cbioportal.cmo.pipelines.cvr.CvrSampleListUtil;
 import org.cbioportal.cmo.pipelines.cvr.CVRUtilities;
-
-import java.io.*;
-import java.util.*;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.*;
@@ -70,7 +68,8 @@ public class ZeroVariantWhitelistTasklet implements Tasklet {
             Set<String> compiledWhitelistedSamplesWithZeroVariants = new HashSet<>(cvrSampleListUtil.getWhitelistedSamplesWithZeroVariants());
             compiledWhitelistedSamplesWithZeroVariants.addAll(cvrSampleListUtil.getNewUnreportedSamplesWithZeroVariants());
             File whitelistedSamplesFile = new File(stagingDirectory, CVRUtilities.ZERO_VARIANT_WHITELIST_FILE);
-            FileUtils.write(whitelistedSamplesFile, StringUtils.join(compiledWhitelistedSamplesWithZeroVariants, "\n") + "\n");
+            String contents = String.join("\n", compiledWhitelistedSamplesWithZeroVariants) + "\n";
+            Files.write(whitelistedSamplesFile.toPath(), contents.getBytes());
         }
         return RepeatStatus.FINISHED;
     }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactBrainSpineClinical.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactBrainSpineClinical.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,11 +29,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.cbioportal.cmo.pipelines.common.util.ClinicalValueUtil;
+
 /**
  *
  * @author jake
@@ -48,12 +50,12 @@ public class MskimpactBrainSpineClinical {
     private String OS_MONTHS;
     private String DFS_STATUS;
     private String DFS_MONTHS;
-    private String HISTOLOGY; 
+    private String HISTOLOGY;
     private String WHO_GRADE;
     private String MGMT_STATUS;
-    
+
     public MskimpactBrainSpineClinical(){}
-    
+
     public MskimpactBrainSpineClinical(
             String DMP_PATIENT_ID_BRAINSPINECLIN,
             String DMP_SAMPLE_ID_BRAINSPINECLIN,
@@ -66,28 +68,26 @@ public class MskimpactBrainSpineClinical {
             String HISTOLOGY,
             String WHO_GRADE,
             String MGMT_STATUS){
-        
-        this.DMP_PATIENT_ID_BRAINSPINECLIN =  StringUtils.isNotEmpty(DMP_PATIENT_ID_BRAINSPINECLIN) ? DMP_PATIENT_ID_BRAINSPINECLIN : "NA";
-        this.DMP_SAMPLE_ID_BRAINSPINECLIN =  StringUtils.isNotEmpty(DMP_SAMPLE_ID_BRAINSPINECLIN) ? DMP_SAMPLE_ID_BRAINSPINECLIN : "NA";
-        this.AGE =  StringUtils.isNotEmpty(AGE) ? AGE : "NA";
-        this.SEX =  StringUtils.isNotEmpty(SEX) ? SEX : "NA";
-        this.OS_STATUS =  StringUtils.isNotEmpty(OS_STATUS) ? OS_STATUS : "NA";
-        this.OS_MONTHS =  StringUtils.isNotEmpty(OS_MONTHS) ? OS_MONTHS : "NA";
-        this.DFS_STATUS =  StringUtils.isNotEmpty(DFS_STATUS) ? DFS_STATUS : "NA";
-        this.DFS_MONTHS =  StringUtils.isNotEmpty(DFS_MONTHS) ? DFS_MONTHS : "NA";
-        this.HISTOLOGY =  StringUtils.isNotEmpty(HISTOLOGY) ? HISTOLOGY : "NA";
-        this.WHO_GRADE =  StringUtils.isNotEmpty(WHO_GRADE) ? WHO_GRADE : "NA";
-        this.MGMT_STATUS =  StringUtils.isNotEmpty(MGMT_STATUS) ? MGMT_STATUS : "NA";
+
+        this.DMP_PATIENT_ID_BRAINSPINECLIN = ClinicalValueUtil.defaultWithNA(DMP_PATIENT_ID_BRAINSPINECLIN);
+        this.DMP_SAMPLE_ID_BRAINSPINECLIN = ClinicalValueUtil.defaultWithNA(DMP_SAMPLE_ID_BRAINSPINECLIN);
+        this.AGE = ClinicalValueUtil.defaultWithNA(AGE);
+        this.SEX = ClinicalValueUtil.defaultWithNA(SEX);
+        this.OS_STATUS = ClinicalValueUtil.defaultWithNA(OS_STATUS);
+        this.OS_MONTHS = ClinicalValueUtil.defaultWithNA(OS_MONTHS);
+        this.DFS_STATUS = ClinicalValueUtil.defaultWithNA(DFS_STATUS);
+        this.DFS_MONTHS = ClinicalValueUtil.defaultWithNA(DFS_MONTHS);
+        this.HISTOLOGY = ClinicalValueUtil.defaultWithNA(HISTOLOGY);
+        this.WHO_GRADE = ClinicalValueUtil.defaultWithNA(WHO_GRADE);
+        this.MGMT_STATUS = ClinicalValueUtil.defaultWithNA(MGMT_STATUS);
     }
-    
-   
 
     public String getDMP_PATIENT_ID_BRAINSPINECLIN() {
         return DMP_PATIENT_ID_BRAINSPINECLIN;
     }
 
     public void setDMP_PATIENT_ID_BRAINSPINECLIN(String DMP_PATIENT_ID_BRAINSPINECLIN) {
-        this.DMP_PATIENT_ID_BRAINSPINECLIN =  StringUtils.isNotEmpty(DMP_PATIENT_ID_BRAINSPINECLIN) ? DMP_PATIENT_ID_BRAINSPINECLIN : "NA";
+        this.DMP_PATIENT_ID_BRAINSPINECLIN = ClinicalValueUtil.defaultWithNA(DMP_PATIENT_ID_BRAINSPINECLIN);
     }
 
     public String getDMP_SAMPLE_ID_BRAINSPINECLIN() {
@@ -95,7 +95,7 @@ public class MskimpactBrainSpineClinical {
     }
 
     public void setDMP_SAMPLE_ID_BRAINSPINECLIN(String DMP_SAMPLE_ID_BRAINSPINECLIN) {
-        this.DMP_SAMPLE_ID_BRAINSPINECLIN =  StringUtils.isNotEmpty(DMP_SAMPLE_ID_BRAINSPINECLIN) ? DMP_SAMPLE_ID_BRAINSPINECLIN : "NA";
+        this.DMP_SAMPLE_ID_BRAINSPINECLIN = ClinicalValueUtil.defaultWithNA(DMP_SAMPLE_ID_BRAINSPINECLIN);
     }
 
     public String getAGE() {
@@ -103,7 +103,7 @@ public class MskimpactBrainSpineClinical {
     }
 
     public void setAGE(String AGE) {
-        this.AGE =  StringUtils.isNotEmpty(AGE) ? AGE : "NA";
+        this.AGE = ClinicalValueUtil.defaultWithNA(AGE);
     }
 
     public String getSEX() {
@@ -111,7 +111,7 @@ public class MskimpactBrainSpineClinical {
     }
 
     public void setSEX(String SEX) {
-        this.SEX =  StringUtils.isNotEmpty(SEX) ? SEX : "NA";
+        this.SEX = ClinicalValueUtil.defaultWithNA(SEX);
     }
 
     public String getOS_STATUS() {
@@ -119,7 +119,7 @@ public class MskimpactBrainSpineClinical {
     }
 
     public void setOS_STATUS(String OS_STATUS) {
-        this.OS_STATUS =  StringUtils.isNotEmpty(OS_STATUS) ? OS_STATUS : "NA";
+        this.OS_STATUS = ClinicalValueUtil.defaultWithNA(OS_STATUS);
     }
 
     public String getOS_MONTHS() {
@@ -127,7 +127,7 @@ public class MskimpactBrainSpineClinical {
     }
 
     public void setOS_MONTHS(String OS_MONTHS) {
-        this.OS_MONTHS =  StringUtils.isNotEmpty(OS_MONTHS) ? OS_MONTHS : "NA";
+        this.OS_MONTHS = ClinicalValueUtil.defaultWithNA(OS_MONTHS);
     }
 
     public String getDFS_STATUS() {
@@ -135,7 +135,7 @@ public class MskimpactBrainSpineClinical {
     }
 
     public void setDFS_STATUS(String DFS_STATUS) {
-        this.DFS_STATUS =  StringUtils.isNotEmpty(DFS_STATUS) ? DFS_STATUS : "NA";
+        this.DFS_STATUS = ClinicalValueUtil.defaultWithNA(DFS_STATUS);
     }
 
     public String getDFS_MONTHS() {
@@ -143,7 +143,7 @@ public class MskimpactBrainSpineClinical {
     }
 
     public void setDFS_MONTHS(String DFS_MONTHS) {
-        this.DFS_MONTHS =  StringUtils.isNotEmpty(DFS_MONTHS) ? DFS_MONTHS : "NA";
+        this.DFS_MONTHS = ClinicalValueUtil.defaultWithNA(DFS_MONTHS);
     }
 
     public String getHISTOLOGY() {
@@ -151,7 +151,7 @@ public class MskimpactBrainSpineClinical {
     }
 
     public void setHISTOLOGY(String HISTOLOGY) {
-        this.HISTOLOGY =  StringUtils.isNotEmpty(HISTOLOGY) ? HISTOLOGY : "NA";
+        this.HISTOLOGY = ClinicalValueUtil.defaultWithNA(HISTOLOGY);
     }
 
     public String getWHO_GRADE() {
@@ -159,7 +159,7 @@ public class MskimpactBrainSpineClinical {
     }
 
     public void setWHO_GRADE(String WHO_GRADE) {
-        this.WHO_GRADE =  StringUtils.isNotEmpty(WHO_GRADE) ? WHO_GRADE : "NA";
+        this.WHO_GRADE = ClinicalValueUtil.defaultWithNA(WHO_GRADE);
     }
 
     public String getMGMT_STATUS() {
@@ -167,14 +167,14 @@ public class MskimpactBrainSpineClinical {
     }
 
     public void setMGMT_STATUS(String MGMT_STATUS) {
-        this.MGMT_STATUS =  StringUtils.isNotEmpty(MGMT_STATUS) ? MGMT_STATUS : "NA";
+        this.MGMT_STATUS = ClinicalValueUtil.defaultWithNA(MGMT_STATUS);
     }
-    
+
     @Override
     public String toString(){
         return ToStringBuilder.reflectionToString(this);
     }
-    
+
     public List<String> getFieldNames(){
         List<String> fieldNames = new ArrayList<>();
         fieldNames.add("DMP_SAMPLE_ID_BRAINSPINECLIN");
@@ -188,9 +188,10 @@ public class MskimpactBrainSpineClinical {
         fieldNames.add("WHO_GRADE");
         fieldNames.add("MGMT_STATUS");
         fieldNames.add("DMP_PATIENT_ID_BRAINSPINECLIN");
-        
+
         return fieldNames;
     }
+
     public List<String> getHeaders(){
         List<String> fieldNames = new ArrayList<>();
         fieldNames.add("SAMPLE_ID");
@@ -204,9 +205,8 @@ public class MskimpactBrainSpineClinical {
         fieldNames.add("WHO_GRADE");
         fieldNames.add("MGMT_STATUS");
         fieldNames.add("PATIENT_ID");
-        
+
         return fieldNames;
     }
-
 
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactBrainSpineTimeline.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactBrainSpineTimeline.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,6 +29,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.StringUtils;
+import org.cbioportal.cmo.pipelines.common.util.ClinicalValueUtil;
 
 /**
  *
@@ -101,32 +102,32 @@ public class MskimpactBrainSpineTimeline {
             String DIAGNOSTIC_TYPE,
             String DIAGNOSTIC_TYPE_DETAILED,
             String SOURCE) {
-        this.DMT_PATIENT_ID_BRAINSPINETMLN  =  StringUtils.isNotEmpty(DMT_PATIENT_ID_BRAINSPINETMLN) ? DMT_PATIENT_ID_BRAINSPINETMLN : "NA";
-        this.DMP_PATIENT_ID_MIN_BRAINSPINETMLN  =  StringUtils.isNotEmpty(DMP_PATIENT_ID_MIN_BRAINSPINETMLN) ? DMP_PATIENT_ID_MIN_BRAINSPINETMLN : "NA";
-        this.DMP_PATIENT_ID_MAX_BRAINSPINETMLN  =  StringUtils.isNotEmpty(DMP_PATIENT_ID_MAX_BRAINSPINETMLN) ? DMP_PATIENT_ID_MAX_BRAINSPINETMLN : "NA";
-        this.DMP_PATIENT_ID_COUNT_BRAINSPINETMLN  =  StringUtils.isNotEmpty(DMP_PATIENT_ID_COUNT_BRAINSPINETMLN) ? DMP_PATIENT_ID_COUNT_BRAINSPINETMLN : "NA";
-        this.DMP_PATIENT_ID_ALL_BRAINSPINETMLN  =  StringUtils.isNotEmpty(DMP_PATIENT_ID_ALL_BRAINSPINETMLN) ? DMP_PATIENT_ID_ALL_BRAINSPINETMLN : "NA";
-        this.START_DATE  =  StringUtils.isNotEmpty(START_DATE) ? START_DATE : "NA";
-        this.STOP_DATE  =  StringUtils.isNotEmpty(STOP_DATE) ? STOP_DATE : "NA";
-        this.EVENT_TYPE  =  StringUtils.isNotEmpty(EVENT_TYPE) ? EVENT_TYPE : "NA";
-        this.TREATMENT_TYPE  =  StringUtils.isNotEmpty(TREATMENT_TYPE) ? TREATMENT_TYPE : "NA";
-        this.SUBTYPE  =  StringUtils.isNotEmpty(SUBTYPE) ? SUBTYPE : "NA";
-        this.AGENT  =  StringUtils.isNotEmpty(AGENT) ? AGENT : "NA";
-        this.SPECIMEN_REFERENCE_NUMBER =  StringUtils.isNotEmpty(SPECIMEN_REFERENCE_NUMBER) ? SPECIMEN_REFERENCE_NUMBER : "NA";
-        this.SPECIMEN_SITE =  StringUtils.isNotEmpty(SPECIMEN_SITE) ? SPECIMEN_SITE : "NA";
-        this.SPECIMEN_TYPE =  StringUtils.isNotEmpty(SPECIMEN_TYPE) ? SPECIMEN_TYPE : "NA";
-        this.STATUS =  StringUtils.isNotEmpty(STATUS) ? STATUS : "NA";
-        this.KARNOFSKY_PERFORMANCE_SCORE =  StringUtils.isNotEmpty(KARNOFSKY_PERFORMANCE_SCORE) ? KARNOFSKY_PERFORMANCE_SCORE : "NA";
-        this.SURGERY_DETAILS =  StringUtils.isNotEmpty(SURGERY_DETAILS) ? SURGERY_DETAILS : "NA";
-        this.EVENT_TYPE_DETAILED =  StringUtils.isNotEmpty(EVENT_TYPE_DETAILED) ? EVENT_TYPE_DETAILED : "NA";
-        this.HISTOLOGY =  StringUtils.isNotEmpty(HISTOLOGY) ? HISTOLOGY : "NA";
-        this.WHO_GRADE =  StringUtils.isNotEmpty(WHO_GRADE) ? WHO_GRADE : "NA";
-        this.MGMT_STATUS =  StringUtils.isNotEmpty(MGMT_STATUS) ? MGMT_STATUS : "NA";
-        this.SOURCE_PATHOLOGY =  StringUtils.isNotEmpty(SOURCE_PATHOLOGY) ? SOURCE_PATHOLOGY : "NA";
-        this.NOTE =  StringUtils.isNotEmpty(NOTE) ? NOTE : "NA";
-        this.DIAGNOSTIC_TYPE =  StringUtils.isNotEmpty(DIAGNOSTIC_TYPE) ? DIAGNOSTIC_TYPE : "NA";
-        this.DIAGNOSTIC_TYPE_DETAILED =  StringUtils.isNotEmpty(DIAGNOSTIC_TYPE_DETAILED) ? DIAGNOSTIC_TYPE_DETAILED : "NA";
-        this.SOURCE =  StringUtils.isNotEmpty(SOURCE) ? SOURCE : "NA";
+        this.DMT_PATIENT_ID_BRAINSPINETMLN  =  ClinicalValueUtil.defaultWithNA(DMT_PATIENT_ID_BRAINSPINETMLN);
+        this.DMP_PATIENT_ID_MIN_BRAINSPINETMLN  =  ClinicalValueUtil.defaultWithNA(DMP_PATIENT_ID_MIN_BRAINSPINETMLN);
+        this.DMP_PATIENT_ID_MAX_BRAINSPINETMLN  =  ClinicalValueUtil.defaultWithNA(DMP_PATIENT_ID_MAX_BRAINSPINETMLN);
+        this.DMP_PATIENT_ID_COUNT_BRAINSPINETMLN  =  ClinicalValueUtil.defaultWithNA(DMP_PATIENT_ID_COUNT_BRAINSPINETMLN);
+        this.DMP_PATIENT_ID_ALL_BRAINSPINETMLN  =  ClinicalValueUtil.defaultWithNA(DMP_PATIENT_ID_ALL_BRAINSPINETMLN);
+        this.START_DATE  =  ClinicalValueUtil.defaultWithNA(START_DATE);
+        this.STOP_DATE  =  ClinicalValueUtil.defaultWithNA(STOP_DATE);
+        this.EVENT_TYPE  =  ClinicalValueUtil.defaultWithNA(EVENT_TYPE);
+        this.TREATMENT_TYPE  =  ClinicalValueUtil.defaultWithNA(TREATMENT_TYPE);
+        this.SUBTYPE  =  ClinicalValueUtil.defaultWithNA(SUBTYPE);
+        this.AGENT  =  ClinicalValueUtil.defaultWithNA(AGENT);
+        this.SPECIMEN_REFERENCE_NUMBER =  ClinicalValueUtil.defaultWithNA(SPECIMEN_REFERENCE_NUMBER);
+        this.SPECIMEN_SITE =  ClinicalValueUtil.defaultWithNA(SPECIMEN_SITE);
+        this.SPECIMEN_TYPE =  ClinicalValueUtil.defaultWithNA(SPECIMEN_TYPE);
+        this.STATUS =  ClinicalValueUtil.defaultWithNA(STATUS);
+        this.KARNOFSKY_PERFORMANCE_SCORE =  ClinicalValueUtil.defaultWithNA(KARNOFSKY_PERFORMANCE_SCORE);
+        this.SURGERY_DETAILS =  ClinicalValueUtil.defaultWithNA(SURGERY_DETAILS);
+        this.EVENT_TYPE_DETAILED =  ClinicalValueUtil.defaultWithNA(EVENT_TYPE_DETAILED);
+        this.HISTOLOGY =  ClinicalValueUtil.defaultWithNA(HISTOLOGY);
+        this.WHO_GRADE =  ClinicalValueUtil.defaultWithNA(WHO_GRADE);
+        this.MGMT_STATUS =  ClinicalValueUtil.defaultWithNA(MGMT_STATUS);
+        this.SOURCE_PATHOLOGY =  ClinicalValueUtil.defaultWithNA(SOURCE_PATHOLOGY);
+        this.NOTE =  ClinicalValueUtil.defaultWithNA(NOTE);
+        this.DIAGNOSTIC_TYPE =  ClinicalValueUtil.defaultWithNA(DIAGNOSTIC_TYPE);
+        this.DIAGNOSTIC_TYPE_DETAILED =  ClinicalValueUtil.defaultWithNA(DIAGNOSTIC_TYPE_DETAILED);
+        this.SOURCE =  ClinicalValueUtil.defaultWithNA(SOURCE);
     }
 
     public String getDMT_PATIENT_ID_BRAINSPINETMLN() {
@@ -134,7 +135,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setDMT_PATIENT_ID_BRAINSPINETMLN(String DMT_PATIENT_ID_BRAINSPINETMLN) {
-        this.DMT_PATIENT_ID_BRAINSPINETMLN =  StringUtils.isNotEmpty(DMT_PATIENT_ID_BRAINSPINETMLN)  ? DMT_PATIENT_ID_BRAINSPINETMLN : "NA" ;
+        this.DMT_PATIENT_ID_BRAINSPINETMLN =  ClinicalValueUtil.defaultWithNA(DMT_PATIENT_ID_BRAINSPINETMLN);
     }
 
     public String getDMP_PATIENT_ID_MIN_BRAINSPINETMLN() {
@@ -142,7 +143,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setDMP_PATIENT_ID_MIN_BRAINSPINETMLN(String DMP_PATIENT_ID_MIN_BRAINSPINETMLN) {
-        this.DMP_PATIENT_ID_MIN_BRAINSPINETMLN =  StringUtils.isNotEmpty(DMP_PATIENT_ID_MIN_BRAINSPINETMLN)  ? DMP_PATIENT_ID_MIN_BRAINSPINETMLN : "NA" ;
+        this.DMP_PATIENT_ID_MIN_BRAINSPINETMLN =  ClinicalValueUtil.defaultWithNA(DMP_PATIENT_ID_MIN_BRAINSPINETMLN);
     }
 
     public String getDMP_PATIENT_ID_MAX_BRAINSPINETMLN() {
@@ -150,7 +151,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setDMP_PATIENT_ID_MAX_BRAINSPINETMLN(String DMP_PATIENT_ID_MAX_BRAINSPINETMLN) {
-        this.DMP_PATIENT_ID_MAX_BRAINSPINETMLN =  StringUtils.isNotEmpty(DMP_PATIENT_ID_MAX_BRAINSPINETMLN)  ? DMP_PATIENT_ID_MAX_BRAINSPINETMLN : "NA" ;
+        this.DMP_PATIENT_ID_MAX_BRAINSPINETMLN =  ClinicalValueUtil.defaultWithNA(DMP_PATIENT_ID_MAX_BRAINSPINETMLN);
     }
 
     public String getDMP_PATIENT_ID_COUNT_BRAINSPINETMLN() {
@@ -158,7 +159,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setDMP_PATIENT_ID_COUNT_BRAINSPINETMLN(String DMP_PATIENT_ID_COUNT_BRAINSPINETMLN) {
-        this.DMP_PATIENT_ID_COUNT_BRAINSPINETMLN =  StringUtils.isNotEmpty(DMP_PATIENT_ID_COUNT_BRAINSPINETMLN)  ? DMP_PATIENT_ID_COUNT_BRAINSPINETMLN : "NA" ;
+        this.DMP_PATIENT_ID_COUNT_BRAINSPINETMLN =  ClinicalValueUtil.defaultWithNA(DMP_PATIENT_ID_COUNT_BRAINSPINETMLN);
     }
 
     public String getDMP_PATIENT_ID_ALL_BRAINSPINETMLN() {
@@ -166,7 +167,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setDMP_PATIENT_ID_ALL_BRAINSPINETMLN(String DMP_PATIENT_ID_ALL_BRAINSPINETMLN) {
-        this.DMP_PATIENT_ID_ALL_BRAINSPINETMLN =  StringUtils.isNotEmpty(DMP_PATIENT_ID_ALL_BRAINSPINETMLN)  ? DMP_PATIENT_ID_ALL_BRAINSPINETMLN : "NA" ;
+        this.DMP_PATIENT_ID_ALL_BRAINSPINETMLN =  ClinicalValueUtil.defaultWithNA(DMP_PATIENT_ID_ALL_BRAINSPINETMLN);
     }
 
     public String getSTART_DATE() {
@@ -174,7 +175,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setSTART_DATE(String START_DATE) {
-        this.START_DATE =  StringUtils.isNotEmpty(START_DATE)  ? START_DATE : "NA" ;
+        this.START_DATE =  ClinicalValueUtil.defaultWithNA(START_DATE);
     }
 
     public String getSTOP_DATE() {
@@ -182,7 +183,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setSTOP_DATE(String STOP_DATE) {
-        this.STOP_DATE =  StringUtils.isNotEmpty(STOP_DATE)  ? STOP_DATE : "NA" ;
+        this.STOP_DATE =  ClinicalValueUtil.defaultWithNA(STOP_DATE);
     }
 
     public String getEVENT_TYPE() {
@@ -190,7 +191,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setEVENT_TYPE(String EVENT_TYPE) {
-        this.EVENT_TYPE =  StringUtils.isNotEmpty(EVENT_TYPE)  ? EVENT_TYPE : "NA" ;
+        this.EVENT_TYPE =  ClinicalValueUtil.defaultWithNA(EVENT_TYPE);
     }
 
     public String getTREATMENT_TYPE() {
@@ -198,7 +199,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setTREATMENT_TYPE(String TREATMENT_TYPE) {
-        this.TREATMENT_TYPE =  StringUtils.isNotEmpty(TREATMENT_TYPE)  ? TREATMENT_TYPE : "NA" ;
+        this.TREATMENT_TYPE =  ClinicalValueUtil.defaultWithNA(TREATMENT_TYPE);
     }
 
     public String getSUBTYPE() {
@@ -206,7 +207,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setSUBTYPE(String SUBTYPE) {
-        this.SUBTYPE =  StringUtils.isNotEmpty(SUBTYPE)  ? SUBTYPE : "NA" ;
+        this.SUBTYPE =  ClinicalValueUtil.defaultWithNA(SUBTYPE);
     }
 
     public String getAGENT() {
@@ -214,7 +215,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setAGENT(String AGENT) {
-        this.AGENT =  StringUtils.isNotEmpty(AGENT)  ? AGENT : "NA" ;
+        this.AGENT =  ClinicalValueUtil.defaultWithNA(AGENT);
     }
 
     public String getSPECIMEN_REFERENCE_NUMBER() {
@@ -222,7 +223,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setSPECIMEN_REFERENCE_NUMBER(String SPECIMEN_REFERENCE_NUMBER) {
-        this.SPECIMEN_REFERENCE_NUMBER =  StringUtils.isNotEmpty(SPECIMEN_REFERENCE_NUMBER)  ? SPECIMEN_REFERENCE_NUMBER : "NA" ;
+        this.SPECIMEN_REFERENCE_NUMBER =  ClinicalValueUtil.defaultWithNA(SPECIMEN_REFERENCE_NUMBER);
     }
 
     public String getSPECIMEN_SITE() {
@@ -230,7 +231,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setSPECIMEN_SITE(String SPECIMEN_SITE) {
-        this.SPECIMEN_SITE =  StringUtils.isNotEmpty(SPECIMEN_SITE)  ? SPECIMEN_SITE : "NA" ;
+        this.SPECIMEN_SITE =  ClinicalValueUtil.defaultWithNA(SPECIMEN_SITE);
     }
 
     public String getSPECIMEN_TYPE() {
@@ -238,7 +239,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setSPECIMEN_TYPE(String SPECIMEN_TYPE) {
-        this.SPECIMEN_TYPE =  StringUtils.isNotEmpty(SPECIMEN_TYPE)  ? SPECIMEN_TYPE : "NA" ;
+        this.SPECIMEN_TYPE =  ClinicalValueUtil.defaultWithNA(SPECIMEN_TYPE);
     }
 
     public String getSTATUS() {
@@ -246,7 +247,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setSTATUS(String STATUS) {
-        this.STATUS =  StringUtils.isNotEmpty(STATUS)  ? STATUS : "NA" ;
+        this.STATUS =  ClinicalValueUtil.defaultWithNA(STATUS);
     }
 
     public String getKARNOFSKY_PERFORMANCE_SCORE() {
@@ -254,7 +255,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setKARNOFSKY_PERFORMANCE_SCORE(String KARNOFSKY_PERFORMANCE_SCORE) {
-        this.KARNOFSKY_PERFORMANCE_SCORE =  StringUtils.isNotEmpty(KARNOFSKY_PERFORMANCE_SCORE)  ? KARNOFSKY_PERFORMANCE_SCORE : "NA" ;
+        this.KARNOFSKY_PERFORMANCE_SCORE =  ClinicalValueUtil.defaultWithNA(KARNOFSKY_PERFORMANCE_SCORE);
     }
 
     public String getSURGERY_DETAILS() {
@@ -262,7 +263,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setSURGERY_DETAILS(String SURGERY_DETAILS) {
-        this.SURGERY_DETAILS =  StringUtils.isNotEmpty(SURGERY_DETAILS)  ? SURGERY_DETAILS : "NA" ;
+        this.SURGERY_DETAILS =  ClinicalValueUtil.defaultWithNA(SURGERY_DETAILS);
     }
 
     public String getEVENT_TYPE_DETAILED() {
@@ -270,7 +271,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setEVENT_TYPE_DETAILED(String EVENT_TYPE_DETAILED) {
-        this.EVENT_TYPE_DETAILED =  StringUtils.isNotEmpty(EVENT_TYPE_DETAILED)  ? EVENT_TYPE_DETAILED : "NA" ;
+        this.EVENT_TYPE_DETAILED =  ClinicalValueUtil.defaultWithNA(EVENT_TYPE_DETAILED);
     }
 
     public String getHISTOLOGY() {
@@ -278,7 +279,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setHISTOLOGY(String HISTOLOGY) {
-        this.HISTOLOGY =  StringUtils.isNotEmpty(HISTOLOGY)  ? HISTOLOGY : "NA" ;
+        this.HISTOLOGY =  ClinicalValueUtil.defaultWithNA(HISTOLOGY);
     }
 
     public String getWHO_GRADE() {
@@ -286,7 +287,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setWHO_GRADE(String WHO_GRADE) {
-        this.WHO_GRADE =  StringUtils.isNotEmpty(WHO_GRADE)  ? WHO_GRADE : "NA" ;
+        this.WHO_GRADE =  ClinicalValueUtil.defaultWithNA(WHO_GRADE);
     }
 
     public String getMGMT_STATUS() {
@@ -294,7 +295,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setMGMT_STATUS(String MGMT_STATUS) {
-        this.MGMT_STATUS =  StringUtils.isNotEmpty(MGMT_STATUS)  ? MGMT_STATUS : "NA" ;
+        this.MGMT_STATUS =  ClinicalValueUtil.defaultWithNA(MGMT_STATUS);
     }
 
     public String getSOURCE_PATHOLOGY() {
@@ -302,7 +303,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setSOURCE_PATHOLOGY(String SOURCE_PATHOLOGY) {
-        this.SOURCE_PATHOLOGY =  StringUtils.isNotEmpty(SOURCE_PATHOLOGY)  ? SOURCE_PATHOLOGY : "NA" ;
+        this.SOURCE_PATHOLOGY =  ClinicalValueUtil.defaultWithNA(SOURCE_PATHOLOGY);
     }
 
     public String getNOTE() {
@@ -310,7 +311,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setNOTE(String NOTE) {
-        this.NOTE =  StringUtils.isNotEmpty(NOTE)  ? NOTE : "NA" ;
+        this.NOTE =  ClinicalValueUtil.defaultWithNA(NOTE);
     }
 
     public String getDIAGNOSTIC_TYPE() {
@@ -318,7 +319,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setDIAGNOSTIC_TYPE(String DIAGNOSTIC_TYPE) {
-        this.DIAGNOSTIC_TYPE =  StringUtils.isNotEmpty(DIAGNOSTIC_TYPE)  ? DIAGNOSTIC_TYPE : "NA" ;
+        this.DIAGNOSTIC_TYPE =  ClinicalValueUtil.defaultWithNA(DIAGNOSTIC_TYPE);
     }
 
     public String getDIAGNOSTIC_TYPE_DETAILED() {
@@ -326,7 +327,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setDIAGNOSTIC_TYPE_DETAILED(String DIAGNOSTIC_TYPE_DETAILED) {
-        this.DIAGNOSTIC_TYPE_DETAILED =  StringUtils.isNotEmpty(DIAGNOSTIC_TYPE_DETAILED)  ? DIAGNOSTIC_TYPE_DETAILED : "NA" ;
+        this.DIAGNOSTIC_TYPE_DETAILED =  ClinicalValueUtil.defaultWithNA(DIAGNOSTIC_TYPE_DETAILED);
     }
 
     public String getSOURCE() {
@@ -334,7 +335,7 @@ public class MskimpactBrainSpineTimeline {
     }
 
     public void setSOURCE(String SOURCE) {
-        this.SOURCE =  StringUtils.isNotEmpty(SOURCE)  ? SOURCE : "NA" ;
+        this.SOURCE =  ClinicalValueUtil.defaultWithNA(SOURCE);
     }
 
     public Map<String, Object> getAditionalProperties() {

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactMedicalTherapy.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactMedicalTherapy.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,10 +29,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 /**

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactNAACCRClinical.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactNAACCRClinical.java
@@ -1,12 +1,39 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2017, 2023 Memorial Sloan Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
+ * Center has been advised of the possibility of such damage.
  */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 2of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.*;
-import org.codehaus.plexus.util.StringUtils;
+import org.cbioportal.cmo.pipelines.common.util.ClinicalValueUtil;
 
 /**
  *
@@ -20,78 +47,78 @@ public class MskimpactNAACCRClinical {
     private String PT_NAACCR_RACE_CODE_TERTIARY;
     private String PT_NAACCR_ETHNICITY_CODE;
     private String PT_BIRTH_YEAR;
-    
+
     public MskimpactNAACCRClinical() {}
-    
+
     public MskimpactNAACCRClinical(String DMP_ID_DEMO, String PT_NAACCR_SEX_CODE, String PT_NAACCR_RACE_CODE_PRIMARY,
             String PT_NAACCR_RACE_CODE_SECONDARY, String PT_NAACCR_RACE_CODE_TERTIARY, String PT_NAACCR_ETHNICITY_CODE,
             String PT_BIRTH_YEAR) {
-        this.DMP_ID_DEMO = StringUtils.isNotEmpty(DMP_ID_DEMO) ? DMP_ID_DEMO : "NA";
-        this.PT_NAACCR_SEX_CODE = StringUtils.isNotEmpty(PT_NAACCR_SEX_CODE) ? PT_NAACCR_SEX_CODE : "NA";
-        this.PT_NAACCR_RACE_CODE_PRIMARY = StringUtils.isNotEmpty(PT_NAACCR_RACE_CODE_PRIMARY) ? PT_NAACCR_RACE_CODE_PRIMARY : "NA";
-        this.PT_NAACCR_RACE_CODE_SECONDARY = StringUtils.isNotEmpty(PT_NAACCR_RACE_CODE_SECONDARY) ? PT_NAACCR_RACE_CODE_SECONDARY : "NA";
-        this.PT_NAACCR_RACE_CODE_TERTIARY = StringUtils.isNotEmpty(PT_NAACCR_RACE_CODE_TERTIARY) ? PT_NAACCR_RACE_CODE_TERTIARY : "NA";
-        this.PT_NAACCR_ETHNICITY_CODE = StringUtils.isNotEmpty(PT_NAACCR_ETHNICITY_CODE) ? PT_NAACCR_ETHNICITY_CODE : "NA";
-        this.PT_BIRTH_YEAR = StringUtils.isNotEmpty(PT_BIRTH_YEAR) ? PT_BIRTH_YEAR : "NA";
+        this.DMP_ID_DEMO = ClinicalValueUtil.defaultWithNA(DMP_ID_DEMO);
+        this.PT_NAACCR_SEX_CODE = ClinicalValueUtil.defaultWithNA(PT_NAACCR_SEX_CODE);
+        this.PT_NAACCR_RACE_CODE_PRIMARY = ClinicalValueUtil.defaultWithNA(PT_NAACCR_RACE_CODE_PRIMARY);
+        this.PT_NAACCR_RACE_CODE_SECONDARY = ClinicalValueUtil.defaultWithNA(PT_NAACCR_RACE_CODE_SECONDARY);
+        this.PT_NAACCR_RACE_CODE_TERTIARY = ClinicalValueUtil.defaultWithNA(PT_NAACCR_RACE_CODE_TERTIARY);
+        this.PT_NAACCR_ETHNICITY_CODE = ClinicalValueUtil.defaultWithNA(PT_NAACCR_ETHNICITY_CODE);
+        this.PT_BIRTH_YEAR = ClinicalValueUtil.defaultWithNA(PT_BIRTH_YEAR);
     }
-    
-    
+
+
     public String getDMP_ID_DEMO() {
         return DMP_ID_DEMO;
     }
-    
+
     public void setDMP_ID_DEMO(String DMP_ID_DEMO) {
-        this.DMP_ID_DEMO = StringUtils.isNotEmpty(DMP_ID_DEMO) ? DMP_ID_DEMO : "NA";
+        this.DMP_ID_DEMO = ClinicalValueUtil.defaultWithNA(DMP_ID_DEMO);
     }
-    
+
     public String getPT_NAACCR_SEX_CODE() {
         return PT_NAACCR_SEX_CODE;
     }
-    
+
     public void setPT_NAACCR_SEX_CODE(String PT_NAACCR_SEX_CODE) {
-        this.PT_NAACCR_SEX_CODE = StringUtils.isNotEmpty(PT_NAACCR_SEX_CODE) ? PT_NAACCR_SEX_CODE : "NA";
+        this.PT_NAACCR_SEX_CODE = ClinicalValueUtil.defaultWithNA(PT_NAACCR_SEX_CODE);
     }
 
     public String getPT_NAACCR_RACE_CODE_PRIMARY() {
         return PT_NAACCR_RACE_CODE_PRIMARY;
     }
-    
+
     public void setPT_NAACCR_RACE_CODE_PRIMARY(String PT_NAACCR_RACE_CODE_PRIMARY) {
-        this.PT_NAACCR_RACE_CODE_PRIMARY = StringUtils.isNotEmpty(PT_NAACCR_RACE_CODE_PRIMARY) ? PT_NAACCR_RACE_CODE_PRIMARY : "NA";
+        this.PT_NAACCR_RACE_CODE_PRIMARY = ClinicalValueUtil.defaultWithNA(PT_NAACCR_RACE_CODE_PRIMARY);
     }
 
     public String getPT_NAACCR_RACE_CODE_SECONDARY() {
         return PT_NAACCR_RACE_CODE_SECONDARY;
     }
-    
+
     public void setPT_NAACCR_RACE_CODE_SECONDARY(String PT_NAACCR_RACE_CODE_SECONDARY) {
-        this.PT_NAACCR_RACE_CODE_SECONDARY = StringUtils.isNotEmpty(PT_NAACCR_RACE_CODE_SECONDARY) ? PT_NAACCR_RACE_CODE_SECONDARY : "NA";
+        this.PT_NAACCR_RACE_CODE_SECONDARY = ClinicalValueUtil.defaultWithNA(PT_NAACCR_RACE_CODE_SECONDARY);
     }
 
     public String getPT_NAACCR_RACE_CODE_TERTIARY() {
         return PT_NAACCR_RACE_CODE_TERTIARY;
     }
-    
+
     public void setPT_NAACCR_RACE_CODE_TERTIARY(String PT_NAACCR_RACE_CODE_TERTIARY) {
-        this.PT_NAACCR_RACE_CODE_TERTIARY = StringUtils.isNotEmpty(PT_NAACCR_RACE_CODE_TERTIARY) ? PT_NAACCR_RACE_CODE_TERTIARY : "NA";
+        this.PT_NAACCR_RACE_CODE_TERTIARY = ClinicalValueUtil.defaultWithNA(PT_NAACCR_RACE_CODE_TERTIARY);
     }
-    
+
     public String getPT_NAACCR_ETHNICITY_CODE() {
         return PT_NAACCR_ETHNICITY_CODE;
     }
-    
+
     public void setPT_NAACCR_ETHNICITY_CODE(String PT_NAACCR_ETHNICITY_CODE) {
-        this.PT_NAACCR_ETHNICITY_CODE = StringUtils.isNotEmpty(PT_NAACCR_ETHNICITY_CODE) ? PT_NAACCR_ETHNICITY_CODE : "NA";
+        this.PT_NAACCR_ETHNICITY_CODE = ClinicalValueUtil.defaultWithNA(PT_NAACCR_ETHNICITY_CODE);
     }
-    
+
     public String getPT_BIRTH_YEAR() {
         return PT_BIRTH_YEAR;
     }
-    
+
     public void setPT_BIRTH_YEAR(String PT_BIRTH_YEAR) {
-        this.PT_BIRTH_YEAR = StringUtils.isNotEmpty(PT_BIRTH_YEAR) ? PT_BIRTH_YEAR : "NA";
+        this.PT_BIRTH_YEAR = ClinicalValueUtil.defaultWithNA(PT_BIRTH_YEAR);
     }
-    
+
     public List<String> getFieldNames() {
         List<String> fieldNames = new ArrayList<>();
         fieldNames.add("DMP_ID_DEMO");
@@ -103,7 +130,7 @@ public class MskimpactNAACCRClinical {
         fieldNames.add("PT_BIRTH_YEAR");
         return fieldNames;
     }
-    
+
     public List<String> getHeaders() {
         List<String> headerNames = new ArrayList<>();
         headerNames.add("PATIENT_ID");

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientDemographics.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientDemographics.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,11 +29,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
-import org.apache.commons.lang.StringUtils;
 import java.util.*;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.cbioportal.cmo.pipelines.common.util.ClinicalValueUtil;
 
 /**
  *
@@ -76,12 +77,12 @@ public class MskimpactPatientDemographics {
     public MskimpactPatientDemographics() {}
 
     public MskimpactPatientDemographics(String DMP_ID_DEMO, String PT_NAACCR_SEX_CODE, String PT_NAACCR_RACE_CODE_PRIMARY, String PT_NAACCR_ETHNICITY_CODE, String RELIGION, String PT_VITAL_STATUS, Integer PT_BIRTH_YEAR, Integer PT_DEATH_YEAR, Integer TM_DX_YEAR, Integer AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS, Integer AGE_AT_TM_DX_DATE_IN_DAYS, Integer AGE_AT_DATE_OF_DEATH_IN_DAYS, String PED_IND, String SAMPLE_ID_PATH_DMP, Integer LAST_CONTACT_YEAR, Integer AGE_AT_LAST_CONTACT_YEAR_IN_DAYS){
-        this.DMP_ID_DEMO =  StringUtils.isNotEmpty(DMP_ID_DEMO) ? DMP_ID_DEMO : "NA";
-        this.PT_NAACCR_SEX_CODE =  StringUtils.isNotEmpty(PT_NAACCR_SEX_CODE) ? PT_NAACCR_SEX_CODE : "-1";
-        this.PT_NAACCR_RACE_CODE_PRIMARY =  StringUtils.isNotEmpty(PT_NAACCR_RACE_CODE_PRIMARY) ? PT_NAACCR_RACE_CODE_PRIMARY : "-1";
-        this.PT_NAACCR_ETHNICITY_CODE =  StringUtils.isNotEmpty(PT_NAACCR_ETHNICITY_CODE) ? PT_NAACCR_ETHNICITY_CODE : "-1";
-        this.RELIGION =  StringUtils.isNotEmpty(RELIGION) ? RELIGION : "NA";
-        this.PT_VITAL_STATUS =  StringUtils.isNotEmpty(PT_VITAL_STATUS) ? PT_VITAL_STATUS : "NA";
+        this.DMP_ID_DEMO = ClinicalValueUtil.defaultWithNA(DMP_ID_DEMO);
+        this.PT_NAACCR_SEX_CODE = ClinicalValueUtil.defaultWithNegativeOne(PT_NAACCR_SEX_CODE);
+        this.PT_NAACCR_RACE_CODE_PRIMARY = ClinicalValueUtil.defaultWithNegativeOne(PT_NAACCR_RACE_CODE_PRIMARY);
+        this.PT_NAACCR_ETHNICITY_CODE = ClinicalValueUtil.defaultWithNegativeOne(PT_NAACCR_ETHNICITY_CODE);
+        this.RELIGION = ClinicalValueUtil.defaultWithNA(RELIGION);
+        this.PT_VITAL_STATUS = ClinicalValueUtil.defaultWithNA(PT_VITAL_STATUS);
         this.TM_DX_YEAR = TM_DX_YEAR != null ? TM_DX_YEAR : -1;
         this.PT_BIRTH_YEAR = PT_BIRTH_YEAR != null ? PT_BIRTH_YEAR : -1;
         this.PT_DEATH_YEAR = PT_DEATH_YEAR != null ? PT_DEATH_YEAR : -1;
@@ -96,7 +97,7 @@ public class MskimpactPatientDemographics {
     }
 
     public MskimpactPatientDemographics(String DMP_ID_DEMO, Integer PT_BIRTH_YEAR, Integer PT_DEATH_YEAR) {
-        this.DMP_ID_DEMO = StringUtils.isNotEmpty(DMP_ID_DEMO) ? DMP_ID_DEMO : "NA";
+        this.DMP_ID_DEMO = ClinicalValueUtil.defaultWithNA(DMP_ID_DEMO);
         this.PT_BIRTH_YEAR = PT_BIRTH_YEAR != null ? PT_BIRTH_YEAR : -1;
         this.PT_DEATH_YEAR = PT_DEATH_YEAR != null ? PT_DEATH_YEAR : -1;
     }
@@ -130,7 +131,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setPT_ID_DEMO(String PT_ID_DEMO) {
-        this.PT_ID_DEMO =  StringUtils.isNotEmpty(PT_ID_DEMO) ? PT_ID_DEMO : "NA";
+        this.PT_ID_DEMO = ClinicalValueUtil.defaultWithNA(PT_ID_DEMO);
     }
 
     public String getDMP_ID_DEMO() {
@@ -138,7 +139,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setDMP_ID_DEMO(String DMP_ID_DEMO) {
-        this.DMP_ID_DEMO =  StringUtils.isNotEmpty(DMP_ID_DEMO) ? DMP_ID_DEMO : "NA";
+        this.DMP_ID_DEMO = ClinicalValueUtil.defaultWithNA(DMP_ID_DEMO);
     }
 
     public String getGENDER() {
@@ -146,7 +147,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setGENDER(String GENDER) {
-        this.GENDER =  StringUtils.isNotEmpty(GENDER) ? GENDER : "NA";
+        this.GENDER = ClinicalValueUtil.defaultWithNA(GENDER);
     }
 
     public String getRACE() {
@@ -154,7 +155,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setRACE(String RACE) {
-        this.RACE =  StringUtils.isNotEmpty(RACE) ? RACE : "NA";
+        this.RACE = ClinicalValueUtil.defaultWithNA(RACE);
     }
 
     public String getRELIGION() {
@@ -162,7 +163,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setRELIGION(String RELIGION) {
-        this.RELIGION =  StringUtils.isNotEmpty(RELIGION) ? RELIGION : "NA";
+        this.RELIGION = ClinicalValueUtil.defaultWithNA(RELIGION);
     }
 
     public Integer getAGE_AT_DATE_OF_DEATH_IN_DAYS() {
@@ -194,7 +195,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setDEATH_SOURCE_DESCRIPTION(String DEATH_SOURCE_DESCRIPTION) {
-        this.DEATH_SOURCE_DESCRIPTION =  StringUtils.isNotEmpty(DEATH_SOURCE_DESCRIPTION) ? DEATH_SOURCE_DESCRIPTION : "NA";
+        this.DEATH_SOURCE_DESCRIPTION = ClinicalValueUtil.defaultWithNA(DEATH_SOURCE_DESCRIPTION);
     }
 
     public String getPT_COUNTRY() {
@@ -202,7 +203,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setPT_COUNTRY(String PT_COUNTRY) {
-        this.PT_COUNTRY =  StringUtils.isNotEmpty(PT_COUNTRY) ? PT_COUNTRY : "NA";
+        this.PT_COUNTRY = ClinicalValueUtil.defaultWithNA(PT_COUNTRY);
     }
 
     public String getPT_STATE() {
@@ -210,7 +211,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setPT_STATE(String PT_STATE) {
-        this.PT_STATE =  StringUtils.isNotEmpty(PT_STATE) ? PT_STATE : "NA";
+        this.PT_STATE = ClinicalValueUtil.defaultWithNA(PT_STATE);
     }
 
     public String getPT_ZIP3_CD() {
@@ -218,7 +219,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setPT_ZIP3_CD(String PT_ZIP3_CD) {
-        this.PT_ZIP3_CD =  StringUtils.isNotEmpty(PT_ZIP3_CD) ? PT_ZIP3_CD : "NA";
+        this.PT_ZIP3_CD = ClinicalValueUtil.defaultWithNA(PT_ZIP3_CD);
     }
 
     public Integer getPT_BIRTH_YEAR() {
@@ -234,7 +235,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setPT_SEX_DESC(String PT_SEX_DESC) {
-        this.PT_SEX_DESC =  StringUtils.isNotEmpty(PT_SEX_DESC) ? PT_SEX_DESC : "NA";
+        this.PT_SEX_DESC = ClinicalValueUtil.defaultWithNA(PT_SEX_DESC);
     }
 
     public String getPT_VITAL_STATUS() {
@@ -242,7 +243,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setPT_VITAL_STATUS(String PT_VITAL_STATUS) {
-        this.PT_VITAL_STATUS =  StringUtils.isNotEmpty(PT_VITAL_STATUS) ? PT_VITAL_STATUS : "NA";
+        this.PT_VITAL_STATUS = ClinicalValueUtil.defaultWithNA(PT_VITAL_STATUS);
     }
 
     public String getPT_MARITAL_STS_DESC() {
@@ -250,7 +251,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setPT_MARITAL_STS_DESC(String PT_MARITAL_STS_DESC) {
-        this.PT_MARITAL_STS_DESC =  StringUtils.isNotEmpty(PT_MARITAL_STS_DESC) ? PT_MARITAL_STS_DESC : "NA";
+        this.PT_MARITAL_STS_DESC = ClinicalValueUtil.defaultWithNA(PT_MARITAL_STS_DESC);
     }
 
     public Integer getPT_DEATH_YEAR() {
@@ -266,7 +267,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setPT_MRN_CREATE_YEAR(String PT_MRN_CREATE_YEAR) {
-        this.PT_MRN_CREATE_YEAR =  StringUtils.isNotEmpty(PT_MRN_CREATE_YEAR) ? PT_MRN_CREATE_YEAR : "NA";
+        this.PT_MRN_CREATE_YEAR = ClinicalValueUtil.defaultWithNA(PT_MRN_CREATE_YEAR);
     }
 
     public String getOS_STATUS(){
@@ -274,7 +275,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setOS_STATUS(String OS_STATUS) {
-        this.OS_STATUS = StringUtils.isNotEmpty(OS_STATUS) ? OS_STATUS.trim() : "NA";
+        this.OS_STATUS = ClinicalValueUtil.defaultWithNA(OS_STATUS);
     }
 
     public String getOS_MONTHS() {
@@ -296,7 +297,7 @@ public class MskimpactPatientDemographics {
     }
 
     public void setOS_MONTHS() {
-        this.OS_MONTHS = StringUtils.isNotEmpty(OS_MONTHS) ? OS_MONTHS : "NA";
+        this.OS_MONTHS = ClinicalValueUtil.defaultWithNA(OS_MONTHS);
     }
 
     public String getDARWIN_PATIENT_AGE(){

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientIcdoRecord.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/MskimpactPatientIcdoRecord.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,11 +29,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.cbioportal.cmo.pipelines.common.util.ClinicalValueUtil;
+
 /**
  *
  * @author jake
@@ -137,91 +139,91 @@ public class MskimpactPatientIcdoRecord {
     private String REASON_NO_SURG_DESC;
     private String TM_PRIM_SURGEON;
     private String TM_PRIM_SURGEON_NAME;
-    private String TM_ATN_DR_NO; 
-    private String TM_ATN_DR_NAME; 
-    private String TM_REASON_NO_RAD; 
-    private String TM_REASON_NO_RAD_DESC; 
-    private String TM_RAD_STRT_YEAR; 
-    private String AGE_AT_TM_RAD_STRT_DATE_IN_DAYS; 
-    private String TM_RAD_END_YEAR; 
-    private String AGE_AT_TM_RAD_END_DATE_IN_DAYS; 
-    private String TM_RAD_TX_MOD; 
-    private String TM_RAD_TX_MOD_DESC; 
-    private String TM_BOOST_RAD_MOD; 
-    private String TM_BOOST_RAD_MOD_DESC; 
-    private String TM_LOC_RAD_TX; 
-    private String TM_LOC_RAD_TX_DESC; 
-    private String TM_RAD_TX_VOL; 
-    private String TM_RAD_TX_VOL_DESC; 
-    private String TM_NUM_TX_THIS_VOL; 
-    private String TM_NUM_TX_THIS_VOL_DESC; 
-    private String TM_REG_RAD_DOSE; 
-    private String TM_REG_RAD_DOSE_DESC; 
-    private String TM_BOOST_RAD_DOSE; 
-    private String TM_BOOST_RAD_DOSE_DESC; 
-    private String TM_RAD_SURG_SEQ; 
-    private String TM_RAD_SURG_SEQ_DESC; 
-    private String TM_RAD_MD; 
-    private String TM_RAD_MD_NAME; 
-    private String TM_SYST_STRT_YEAR; 
-    private String AGE_AT_TM_SYST_STRT_DATE_IN_DAYS; 
-    private String TM_OTH_STRT_YEAR; 
-    private String AGE_AT_TM_OTH_STRT_DATE_IN_DAYS; 
-    private String TM_CHEM_SUM; 
-    private String TM_CHEM_SUM_DESC; 
-    private String TM_CHEM_SUM_MSK; 
-    private String TM_CHEM_SUM_MSK_DESC; 
-    private String TM_TUMOR_SEQ; 
-    private String TM_HORM_SUM; 
-    private String TM_HORM_SUM_DESC; 
-    private String TM_HORM_SUM_MSK; 
-    private String TM_HORM_SUM_MSK_DESC; 
-    private String TM_BRM_SUM; 
-    private String TM_BRM_SUM_DESC; 
-    private String TM_BRM_SUM_MSK; 
-    private String TM_BRM_SUM_MSK_DESC; 
-    private String TM_OTH_SUM; 
-    private String TM_OTH_SUM_DESC; 
-    private String TM_OTH_SUM_MSK; 
-    private String TM_OTH_SUM_MSK_DESC; 
-    private String TM_PALLIA_PROC; 
-    private String TM_PALLIA_PROC_DESC; 
-    private String TM_PALLIA_PROC_MSK; 
-    private String TM_PALLIA_PROC_MSK_DESC; 
-    private String TM_ONCOLOGY_MD; 
-    private String TM_ONCOLOGY_MD_NAME; 
-    private String TM_PRCS_YEAR; 
-    private String AGE_AT_TM_PRCS_DATE_IN_DAYS; 
-    private String TM_PATH_TEXT; 
-    private String TM_SURG_TEXT; 
-    private String TM_OVERRIDE_COM; 
-    private String TM_CSSIZE; 
-    private String TM_CSEXT; 
-    private String TM_CSEXTEV; 
-    private String TM_CSLMND; 
-    private String TM_CSRGNEV; 
-    private String TM_CSMETDX; 
-    private String TM_CSMETEV; 
-    private String TM_TSTAGE; 
-    private String TM_TSTAGE_DESC; 
-    private String TM_NSTAGE; 
-    private String TM_NSTAGE_DESC; 
-    private String TM_MSTAGE; 
-    private String TM_MSTAGE_DESC; 
-    private String TM_TBASIS; 
-    private String TM_TBASIS_DESC; 
-    private String TM_NBASIS; 
-    private String TM_NBASIS_DESC; 
-    private String TM_MBASIS; 
-    private String TM_MBASIS_DESC; 
-    private String TM_AJCC; 
+    private String TM_ATN_DR_NO;
+    private String TM_ATN_DR_NAME;
+    private String TM_REASON_NO_RAD;
+    private String TM_REASON_NO_RAD_DESC;
+    private String TM_RAD_STRT_YEAR;
+    private String AGE_AT_TM_RAD_STRT_DATE_IN_DAYS;
+    private String TM_RAD_END_YEAR;
+    private String AGE_AT_TM_RAD_END_DATE_IN_DAYS;
+    private String TM_RAD_TX_MOD;
+    private String TM_RAD_TX_MOD_DESC;
+    private String TM_BOOST_RAD_MOD;
+    private String TM_BOOST_RAD_MOD_DESC;
+    private String TM_LOC_RAD_TX;
+    private String TM_LOC_RAD_TX_DESC;
+    private String TM_RAD_TX_VOL;
+    private String TM_RAD_TX_VOL_DESC;
+    private String TM_NUM_TX_THIS_VOL;
+    private String TM_NUM_TX_THIS_VOL_DESC;
+    private String TM_REG_RAD_DOSE;
+    private String TM_REG_RAD_DOSE_DESC;
+    private String TM_BOOST_RAD_DOSE;
+    private String TM_BOOST_RAD_DOSE_DESC;
+    private String TM_RAD_SURG_SEQ;
+    private String TM_RAD_SURG_SEQ_DESC;
+    private String TM_RAD_MD;
+    private String TM_RAD_MD_NAME;
+    private String TM_SYST_STRT_YEAR;
+    private String AGE_AT_TM_SYST_STRT_DATE_IN_DAYS;
+    private String TM_OTH_STRT_YEAR;
+    private String AGE_AT_TM_OTH_STRT_DATE_IN_DAYS;
+    private String TM_CHEM_SUM;
+    private String TM_CHEM_SUM_DESC;
+    private String TM_CHEM_SUM_MSK;
+    private String TM_CHEM_SUM_MSK_DESC;
+    private String TM_TUMOR_SEQ;
+    private String TM_HORM_SUM;
+    private String TM_HORM_SUM_DESC;
+    private String TM_HORM_SUM_MSK;
+    private String TM_HORM_SUM_MSK_DESC;
+    private String TM_BRM_SUM;
+    private String TM_BRM_SUM_DESC;
+    private String TM_BRM_SUM_MSK;
+    private String TM_BRM_SUM_MSK_DESC;
+    private String TM_OTH_SUM;
+    private String TM_OTH_SUM_DESC;
+    private String TM_OTH_SUM_MSK;
+    private String TM_OTH_SUM_MSK_DESC;
+    private String TM_PALLIA_PROC;
+    private String TM_PALLIA_PROC_DESC;
+    private String TM_PALLIA_PROC_MSK;
+    private String TM_PALLIA_PROC_MSK_DESC;
+    private String TM_ONCOLOGY_MD;
+    private String TM_ONCOLOGY_MD_NAME;
+    private String TM_PRCS_YEAR;
+    private String AGE_AT_TM_PRCS_DATE_IN_DAYS;
+    private String TM_PATH_TEXT;
+    private String TM_SURG_TEXT;
+    private String TM_OVERRIDE_COM;
+    private String TM_CSSIZE;
+    private String TM_CSEXT;
+    private String TM_CSEXTEV;
+    private String TM_CSLMND;
+    private String TM_CSRGNEV;
+    private String TM_CSMETDX;
+    private String TM_CSMETEV;
+    private String TM_TSTAGE;
+    private String TM_TSTAGE_DESC;
+    private String TM_NSTAGE;
+    private String TM_NSTAGE_DESC;
+    private String TM_MSTAGE;
+    private String TM_MSTAGE_DESC;
+    private String TM_TBASIS;
+    private String TM_TBASIS_DESC;
+    private String TM_NBASIS;
+    private String TM_NBASIS_DESC;
+    private String TM_MBASIS;
+    private String TM_MBASIS_DESC;
+    private String TM_AJCC;
     private String TM_AJCC_DESC;
     private String TM_MSK_STG;
     private Integer AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS;
     private Integer AGE_AT_DATE_OF_DEATH_IN_DAYS;
-    
+
     public MskimpactPatientIcdoRecord(){}
-    
+
     public MskimpactPatientIcdoRecord(
             Integer TUMOR_YEAR,
             String PT_ID_ICDO,
@@ -402,195 +404,195 @@ public class MskimpactPatientIcdoRecord {
             String TM_AJCC_DESC,
             String TM_MSK_STG){
         this.TUMOR_YEAR = TUMOR_YEAR != null ? TUMOR_YEAR : -1;
-        this.PT_ID_ICDO =  StringUtils.isNotEmpty(PT_ID_ICDO) ? PT_ID_ICDO : "NA";
-        this.DMP_ID_ICDO =  StringUtils.isNotEmpty(DMP_ID_ICDO) ? DMP_ID_ICDO : "NA";
-        this.TM_TUMOR_SEQ_DESC =  StringUtils.isNotEmpty(TM_TUMOR_SEQ_DESC) ? TM_TUMOR_SEQ_DESC : "NA";
-        this.TM_ACC_YEAR =  StringUtils.isNotEmpty(TM_ACC_YEAR) ? TM_ACC_YEAR : "NA";
-        this.TM_FIRST_MSK_YEAR =  StringUtils.isNotEmpty(TM_FIRST_MSK_YEAR) ? TM_FIRST_MSK_YEAR : "NA";
-        this.AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS) ? AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS : "NA";
-        this.TM_CASE_STS =  StringUtils.isNotEmpty(TM_CASE_STS) ? TM_CASE_STS : "NA";
-        this.TM_CASE_STS_DESC =  StringUtils.isNotEmpty(TM_CASE_STS_DESC) ? TM_CASE_STS_DESC : "NA";
-        this.TM_CASE_EFF_YEAR =  StringUtils.isNotEmpty(TM_CASE_EFF_YEAR) ? TM_CASE_EFF_YEAR : "NA";
-        this.AGE_AT_TM_CASE_EFF_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_CASE_EFF_DATE_IN_DAYS) ? AGE_AT_TM_CASE_EFF_DATE_IN_DAYS : "NA";
-        this.TM_STATE_AT_DX =  StringUtils.isNotEmpty(TM_STATE_AT_DX) ? TM_STATE_AT_DX : "NA";
-        this.TM_SMOKING_HX =  StringUtils.isNotEmpty(TM_SMOKING_HX) ? TM_SMOKING_HX : "NA";
-        this.TM_SMOKING_HX_DESC =  StringUtils.isNotEmpty(TM_SMOKING_HX_DESC) ? TM_SMOKING_HX_DESC : "NA";
-        this.TM_OCCUPATION =  StringUtils.isNotEmpty(TM_OCCUPATION) ? TM_OCCUPATION : "NA";
-        this.TM_OCCUPATION_DESC =  StringUtils.isNotEmpty(TM_OCCUPATION_DESC) ? TM_OCCUPATION_DESC : "NA";
-        this.TM_FACILITY_FROM =  StringUtils.isNotEmpty(TM_FACILITY_FROM) ? TM_FACILITY_FROM : "NA";
-        this.FACILITY_FROM_DESC =  StringUtils.isNotEmpty(FACILITY_FROM_DESC) ? FACILITY_FROM_DESC : "NA";
-        this.TM_FACILITY_TO =  StringUtils.isNotEmpty(TM_FACILITY_TO) ? TM_FACILITY_TO : "NA";
-        this.FACILITY_TO_DESC =  StringUtils.isNotEmpty(FACILITY_TO_DESC) ? FACILITY_TO_DESC : "NA";
+        this.PT_ID_ICDO =  ClinicalValueUtil.defaultWithNA(PT_ID_ICDO);
+        this.DMP_ID_ICDO =  ClinicalValueUtil.defaultWithNA(DMP_ID_ICDO);
+        this.TM_TUMOR_SEQ_DESC =  ClinicalValueUtil.defaultWithNA(TM_TUMOR_SEQ_DESC);
+        this.TM_ACC_YEAR =  ClinicalValueUtil.defaultWithNA(TM_ACC_YEAR);
+        this.TM_FIRST_MSK_YEAR =  ClinicalValueUtil.defaultWithNA(TM_FIRST_MSK_YEAR);
+        this.AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS);
+        this.TM_CASE_STS =  ClinicalValueUtil.defaultWithNA(TM_CASE_STS);
+        this.TM_CASE_STS_DESC =  ClinicalValueUtil.defaultWithNA(TM_CASE_STS_DESC);
+        this.TM_CASE_EFF_YEAR =  ClinicalValueUtil.defaultWithNA(TM_CASE_EFF_YEAR);
+        this.AGE_AT_TM_CASE_EFF_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_CASE_EFF_DATE_IN_DAYS);
+        this.TM_STATE_AT_DX =  ClinicalValueUtil.defaultWithNA(TM_STATE_AT_DX);
+        this.TM_SMOKING_HX =  ClinicalValueUtil.defaultWithNA(TM_SMOKING_HX);
+        this.TM_SMOKING_HX_DESC =  ClinicalValueUtil.defaultWithNA(TM_SMOKING_HX_DESC);
+        this.TM_OCCUPATION =  ClinicalValueUtil.defaultWithNA(TM_OCCUPATION);
+        this.TM_OCCUPATION_DESC =  ClinicalValueUtil.defaultWithNA(TM_OCCUPATION_DESC);
+        this.TM_FACILITY_FROM =  ClinicalValueUtil.defaultWithNA(TM_FACILITY_FROM);
+        this.FACILITY_FROM_DESC =  ClinicalValueUtil.defaultWithNA(FACILITY_FROM_DESC);
+        this.TM_FACILITY_TO =  ClinicalValueUtil.defaultWithNA(TM_FACILITY_TO);
+        this.FACILITY_TO_DESC =  ClinicalValueUtil.defaultWithNA(FACILITY_TO_DESC);
         this.TM_DX_YEAR = TM_DX_YEAR != null ? TM_DX_YEAR : 0;
         this.AGE_AT_TM_DX_DATE_IN_DAYS =  AGE_AT_TM_DX_DATE_IN_DAYS != null ? AGE_AT_TM_DX_DATE_IN_DAYS : -1;
-        this.TM_SITE_CD =  StringUtils.isNotEmpty(TM_SITE_CD) ? TM_SITE_CD : "NA";
-        this.TM_SITE_DESC =  StringUtils.isNotEmpty(TM_SITE_DESC) ? TM_SITE_DESC : "NA";
-        this.TM_LATERALITY_CD =  StringUtils.isNotEmpty(TM_LATERALITY_CD) ? TM_LATERALITY_CD : "NA";
-        this.TM_LATERALITY_DESC =  StringUtils.isNotEmpty(TM_LATERALITY_DESC) ? TM_LATERALITY_DESC : "NA";
-        this.TM_HIST_CD =  StringUtils.isNotEmpty(TM_HIST_CD) ? TM_HIST_CD : "NA";
-        this.TM_HIST_DESC =  StringUtils.isNotEmpty(TM_HIST_DESC) ? TM_HIST_DESC : "NA";
-        this.TM_DX_CONFRM_CD =  StringUtils.isNotEmpty(TM_DX_CONFRM_CD) ? TM_DX_CONFRM_CD : "NA";
-        this.TM_DX_CONFRM_DESC =  StringUtils.isNotEmpty(TM_DX_CONFRM_DESC) ? TM_DX_CONFRM_DESC : "NA";
-        this.TM_REGNODE_EXM_NO =  StringUtils.isNotEmpty(TM_REGNODE_EXM_NO) ? TM_REGNODE_EXM_NO : "NA";
-        this.TM_REGNODE_POS_NO =  StringUtils.isNotEmpty(TM_REGNODE_POS_NO) ? TM_REGNODE_POS_NO : "NA";
-        this.TM_TUMOR_SIZE =  StringUtils.isNotEmpty(TM_TUMOR_SIZE) ? TM_TUMOR_SIZE : "NA";
-        this.TM_RESID_TUMOR_CD =  StringUtils.isNotEmpty(TM_RESID_TUMOR_CD) ? TM_RESID_TUMOR_CD : "NA";
-        this.TM_RESID_TUMOR_DESC =  StringUtils.isNotEmpty(TM_RESID_TUMOR_DESC) ? TM_RESID_TUMOR_DESC : "NA";
-        this.TM_GENERAL_STG =  StringUtils.isNotEmpty(TM_GENERAL_STG) ? TM_GENERAL_STG : "NA";
-        this.TM_GENERAL_STG_DESC =  StringUtils.isNotEmpty(TM_GENERAL_STG_DESC) ? TM_GENERAL_STG_DESC : "NA";
-        this.TM_TNM_EDITION =  StringUtils.isNotEmpty(TM_TNM_EDITION) ? TM_TNM_EDITION : "NA";
-        this.TM_TNM_EDITION_DESC =  StringUtils.isNotEmpty(TM_TNM_EDITION_DESC) ? TM_TNM_EDITION_DESC : "NA";
-        this.TM_CLIN_TNM_T =  StringUtils.isNotEmpty(TM_CLIN_TNM_T) ? TM_CLIN_TNM_T : "NA";
-        this.TM_CLIN_TNM_T_DESC =  StringUtils.isNotEmpty(TM_CLIN_TNM_T_DESC) ? TM_CLIN_TNM_T_DESC : "NA";
-        this.TM_CLIN_TNM_N =  StringUtils.isNotEmpty(TM_CLIN_TNM_N) ? TM_CLIN_TNM_N : "NA";
-        this.TM_CLIN_TNM_N_DESC =  StringUtils.isNotEmpty(TM_CLIN_TNM_N_DESC) ? TM_CLIN_TNM_N_DESC : "NA";
-        this.TM_CLIN_TNM_M =  StringUtils.isNotEmpty(TM_CLIN_TNM_M) ? TM_CLIN_TNM_M : "NA";
-        this.TM_CLIN_TNM_M_DESC =  StringUtils.isNotEmpty(TM_CLIN_TNM_M_DESC) ? TM_CLIN_TNM_M_DESC : "NA";
-        this.TM_CLIN_STG_GRP =  StringUtils.isNotEmpty(TM_CLIN_STG_GRP) ? TM_CLIN_STG_GRP : "NA";
-        this.TM_PATH_TNM_T =  StringUtils.isNotEmpty(TM_PATH_TNM_T) ? TM_PATH_TNM_T : "NA";
-        this.TM_PATH_TNM_T_DESC =  StringUtils.isNotEmpty(TM_PATH_TNM_T_DESC) ? TM_PATH_TNM_T_DESC : "NA";
-        this.TM_PATH_TNM_N =  StringUtils.isNotEmpty(TM_PATH_TNM_N) ? TM_PATH_TNM_N : "NA";
-        this.TM_PATH_TNM_N_DESC =  StringUtils.isNotEmpty(TM_PATH_TNM_N_DESC) ? TM_PATH_TNM_N_DESC : "NA";
-        this.TM_PATH_TNM_M =  StringUtils.isNotEmpty(TM_PATH_TNM_M) ? TM_PATH_TNM_M : "NA";
-        this.TM_PATH_TNM_M_DESC =  StringUtils.isNotEmpty(TM_PATH_TNM_M_DESC) ? TM_PATH_TNM_M_DESC : "NA";
-        this.TM_PATH_STG_GRP =  StringUtils.isNotEmpty(TM_PATH_STG_GRP) ? TM_PATH_STG_GRP : "NA";
-        this.TM_PATH_RPT_AV =  StringUtils.isNotEmpty(TM_PATH_RPT_AV) ? TM_PATH_RPT_AV : "NA";
-        this.TM_CA_STS_AT_ACC =  StringUtils.isNotEmpty(TM_CA_STS_AT_ACC) ? TM_CA_STS_AT_ACC : "NA";
-        this.TM_FIRST_RECUR_YEAR =  StringUtils.isNotEmpty(TM_FIRST_RECUR_YEAR) ? TM_FIRST_RECUR_YEAR : "NA";
-        this.AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS) ? AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS : "NA";
-        this.TM_FIRST_RECUR_TYP =  StringUtils.isNotEmpty(TM_FIRST_RECUR_TYP) ? TM_FIRST_RECUR_TYP : "NA";
-        this.TM_ADM_YEAR =  StringUtils.isNotEmpty(TM_ADM_YEAR) ? TM_ADM_YEAR : "NA";
-        this.AGE_AT_TM_ADM_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_ADM_DATE_IN_DAYS) ? AGE_AT_TM_ADM_DATE_IN_DAYS : "NA";
-        this.TM_DSCH_YEAR =  StringUtils.isNotEmpty(TM_DSCH_YEAR) ? TM_DSCH_YEAR : "NA";
-        this.AGE_AT_TM_DSCH_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_DSCH_DATE_IN_DAYS) ? AGE_AT_TM_DSCH_DATE_IN_DAYS : "NA";
-        this.TM_SURG_DSCH_YEAR =  StringUtils.isNotEmpty(TM_SURG_DSCH_YEAR) ? TM_SURG_DSCH_YEAR : "NA";
-        this.AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS) ? AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS : "NA";
-        this.TM_READM_WTHN_30D =  StringUtils.isNotEmpty(TM_READM_WTHN_30D) ? TM_READM_WTHN_30D : "NA";
-        this.TM_FIRST_TX_YEAR =  StringUtils.isNotEmpty(TM_FIRST_TX_YEAR) ? TM_FIRST_TX_YEAR : "NA";
-        this.AGE_AT_TM_FIRST_TX_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_FIRST_TX_DATE_IN_DAYS) ? AGE_AT_TM_FIRST_TX_DATE_IN_DAYS : "NA";
-        this.TM_NON_CA_SURG_SUM =  StringUtils.isNotEmpty(TM_NON_CA_SURG_SUM) ? TM_NON_CA_SURG_SUM : "NA";
-        this.TM_NON_CA_SURG_SUM_DESC =  StringUtils.isNotEmpty(TM_NON_CA_SURG_SUM_DESC) ? TM_NON_CA_SURG_SUM_DESC : "NA";
-        this.TM_NON_CA_SURG_MSK =  StringUtils.isNotEmpty(TM_NON_CA_SURG_MSK) ? TM_NON_CA_SURG_MSK : "NA";
-        this.TM_NON_CA_SURG_YEAR =  StringUtils.isNotEmpty(TM_NON_CA_SURG_YEAR) ? TM_NON_CA_SURG_YEAR : "NA";
-        this.AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS) ? AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS : "NA";
-        this.TM_CA_SURG_98 =  StringUtils.isNotEmpty(TM_CA_SURG_98) ? TM_CA_SURG_98 : "NA";
-        this.TM_CA_SURG_98_MSK =  StringUtils.isNotEmpty(TM_CA_SURG_98_MSK) ? TM_CA_SURG_98_MSK : "NA";
-        this.TM_CA_SURG_03 =  StringUtils.isNotEmpty(TM_CA_SURG_03) ? TM_CA_SURG_03 : "NA";
-        this.TM_CA_SURG_03_MSK =  StringUtils.isNotEmpty(TM_CA_SURG_03_MSK) ? TM_CA_SURG_03_MSK : "NA";
-        this.TM_OTH_SURG_98 =  StringUtils.isNotEmpty(TM_OTH_SURG_98) ? TM_OTH_SURG_98 : "NA";
-        this.TM_OTH_SURG_98_MSK =  StringUtils.isNotEmpty(TM_OTH_SURG_98_MSK) ? TM_OTH_SURG_98_MSK : "NA";
-        this.TM_OTH_SURG_03 =  StringUtils.isNotEmpty(TM_OTH_SURG_03) ? TM_OTH_SURG_03 : "NA";
-        this.TM_OTH_SURG_03_MSK =  StringUtils.isNotEmpty(TM_OTH_SURG_03_MSK) ? TM_OTH_SURG_03_MSK : "NA";
-        this.TM_OTH_SURG_CD =  StringUtils.isNotEmpty(TM_OTH_SURG_CD) ? TM_OTH_SURG_CD : "NA";
-        this.TM_OTH_SURG_CD_DESC =  StringUtils.isNotEmpty(TM_OTH_SURG_CD_DESC) ? TM_OTH_SURG_CD_DESC : "NA";
-        this.TM_RGN_SCOP_98 =  StringUtils.isNotEmpty(TM_RGN_SCOP_98) ? TM_RGN_SCOP_98 : "NA";
-        this.TM_RGN_SCOP_98_MSK =  StringUtils.isNotEmpty(TM_RGN_SCOP_98_MSK) ? TM_RGN_SCOP_98_MSK : "NA";
-        this.TM_RGN_SCOP_03 =  StringUtils.isNotEmpty(TM_RGN_SCOP_03) ? TM_RGN_SCOP_03 : "NA";
-        this.TM_RGN_SCOP_03_MSK =  StringUtils.isNotEmpty(TM_RGN_SCOP_03_MSK) ? TM_RGN_SCOP_03_MSK : "NA";
-        this.TM_REGNODE_SCOP_CD =  StringUtils.isNotEmpty(TM_REGNODE_SCOP_CD) ? TM_REGNODE_SCOP_CD : "NA";
-        this.TM_REGNODE_SCOP_DESC =  StringUtils.isNotEmpty(TM_REGNODE_SCOP_DESC) ? TM_REGNODE_SCOP_DESC : "NA";
-        this.TM_RECON_SURG =  StringUtils.isNotEmpty(TM_RECON_SURG) ? TM_RECON_SURG : "NA";
-        this.TM_RECON_SURG_DESC =  StringUtils.isNotEmpty(TM_RECON_SURG_DESC) ? TM_RECON_SURG_DESC : "NA";
-        this.TM_CA_SURG_YEAR =  StringUtils.isNotEmpty(TM_CA_SURG_YEAR) ? TM_CA_SURG_YEAR : "NA";
-        this.AGE_AT_TM_CA_SURG_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_CA_SURG_DATE_IN_DAYS) ? AGE_AT_TM_CA_SURG_DATE_IN_DAYS : "NA";
-        this.TM_SURG_DEF_YEAR =  StringUtils.isNotEmpty(TM_SURG_DEF_YEAR) ? TM_SURG_DEF_YEAR : "NA";
-        this.AGE_AT_TM_SURG_DEF_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_SURG_DEF_DATE_IN_DAYS) ? AGE_AT_TM_SURG_DEF_DATE_IN_DAYS : "NA";
-        this.TM_REASON_NO_SURG =  StringUtils.isNotEmpty(TM_REASON_NO_SURG) ? TM_REASON_NO_SURG : "NA";
-        this.REASON_NO_SURG_DESC =  StringUtils.isNotEmpty(REASON_NO_SURG_DESC) ? REASON_NO_SURG_DESC : "NA";
-        this.TM_PRIM_SURGEON =  StringUtils.isNotEmpty(TM_PRIM_SURGEON) ? TM_PRIM_SURGEON : "NA";
-        this.TM_PRIM_SURGEON_NAME =  StringUtils.isNotEmpty(TM_PRIM_SURGEON_NAME) ? TM_PRIM_SURGEON_NAME : "NA";
-        this.TM_ATN_DR_NO =  StringUtils.isNotEmpty(TM_ATN_DR_NO) ? TM_ATN_DR_NO : "NA";
-        this.TM_ATN_DR_NAME =  StringUtils.isNotEmpty(TM_ATN_DR_NAME) ? TM_ATN_DR_NAME : "NA";
-        this.TM_REASON_NO_RAD =  StringUtils.isNotEmpty(TM_REASON_NO_RAD) ? TM_REASON_NO_RAD : "NA";
-        this.TM_REASON_NO_RAD_DESC =  StringUtils.isNotEmpty(TM_REASON_NO_RAD_DESC) ? TM_REASON_NO_RAD_DESC : "NA";
-        this.TM_RAD_STRT_YEAR =  StringUtils.isNotEmpty(TM_RAD_STRT_YEAR) ? TM_RAD_STRT_YEAR : "NA";
-        this.AGE_AT_TM_RAD_STRT_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_RAD_STRT_DATE_IN_DAYS) ? AGE_AT_TM_RAD_STRT_DATE_IN_DAYS : "NA";
-        this.TM_RAD_END_YEAR =  StringUtils.isNotEmpty(TM_RAD_END_YEAR) ? TM_RAD_END_YEAR : "NA";
-        this.AGE_AT_TM_RAD_END_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_RAD_END_DATE_IN_DAYS) ? AGE_AT_TM_RAD_END_DATE_IN_DAYS : "NA";
-        this.TM_RAD_TX_MOD =  StringUtils.isNotEmpty(TM_RAD_TX_MOD) ? TM_RAD_TX_MOD : "NA";
-        this.TM_RAD_TX_MOD_DESC =  StringUtils.isNotEmpty(TM_RAD_TX_MOD_DESC) ? TM_RAD_TX_MOD_DESC : "NA";
-        this.TM_BOOST_RAD_MOD =  StringUtils.isNotEmpty(TM_BOOST_RAD_MOD) ? TM_BOOST_RAD_MOD : "NA";
-        this.TM_BOOST_RAD_MOD_DESC =  StringUtils.isNotEmpty(TM_BOOST_RAD_MOD_DESC) ? TM_BOOST_RAD_MOD_DESC : "NA";
-        this.TM_LOC_RAD_TX =  StringUtils.isNotEmpty(TM_LOC_RAD_TX) ? TM_LOC_RAD_TX : "NA";
-        this.TM_LOC_RAD_TX_DESC =  StringUtils.isNotEmpty(TM_LOC_RAD_TX_DESC) ? TM_LOC_RAD_TX_DESC : "NA";
-        this.TM_RAD_TX_VOL =  StringUtils.isNotEmpty(TM_RAD_TX_VOL) ? TM_RAD_TX_VOL : "NA";
-        this.TM_RAD_TX_VOL_DESC =  StringUtils.isNotEmpty(TM_RAD_TX_VOL_DESC) ? TM_RAD_TX_VOL_DESC : "NA";
-        this.TM_NUM_TX_THIS_VOL =  StringUtils.isNotEmpty(TM_NUM_TX_THIS_VOL) ? TM_NUM_TX_THIS_VOL : "NA";
-        this.TM_NUM_TX_THIS_VOL_DESC =  StringUtils.isNotEmpty(TM_NUM_TX_THIS_VOL_DESC) ? TM_NUM_TX_THIS_VOL_DESC : "NA";
-        this.TM_REG_RAD_DOSE =  StringUtils.isNotEmpty(TM_REG_RAD_DOSE) ? TM_REG_RAD_DOSE : "NA";
-        this.TM_REG_RAD_DOSE_DESC =  StringUtils.isNotEmpty(TM_REG_RAD_DOSE_DESC) ? TM_REG_RAD_DOSE_DESC : "NA";
-        this.TM_BOOST_RAD_DOSE =  StringUtils.isNotEmpty(TM_BOOST_RAD_DOSE) ? TM_BOOST_RAD_DOSE : "NA";
-        this.TM_BOOST_RAD_DOSE_DESC =  StringUtils.isNotEmpty(TM_BOOST_RAD_DOSE_DESC) ? TM_BOOST_RAD_DOSE_DESC : "NA";
-        this.TM_RAD_SURG_SEQ =  StringUtils.isNotEmpty(TM_RAD_SURG_SEQ) ? TM_RAD_SURG_SEQ : "NA";
-        this.TM_RAD_SURG_SEQ_DESC =  StringUtils.isNotEmpty(TM_RAD_SURG_SEQ_DESC) ? TM_RAD_SURG_SEQ_DESC : "NA";
-        this.TM_RAD_MD =  StringUtils.isNotEmpty(TM_RAD_MD) ? TM_RAD_MD : "NA";
-        this.TM_RAD_MD_NAME =  StringUtils.isNotEmpty(TM_RAD_MD_NAME) ? TM_RAD_MD_NAME : "NA";
-        this.TM_SYST_STRT_YEAR =  StringUtils.isNotEmpty(TM_SYST_STRT_YEAR) ? TM_SYST_STRT_YEAR : "NA";
-        this.AGE_AT_TM_SYST_STRT_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_SYST_STRT_DATE_IN_DAYS) ? AGE_AT_TM_SYST_STRT_DATE_IN_DAYS : "NA";
-        this.TM_OTH_STRT_YEAR =  StringUtils.isNotEmpty(TM_OTH_STRT_YEAR) ? TM_OTH_STRT_YEAR : "NA";
-        this.AGE_AT_TM_OTH_STRT_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_OTH_STRT_DATE_IN_DAYS) ? AGE_AT_TM_OTH_STRT_DATE_IN_DAYS : "NA";
-        this.TM_CHEM_SUM =  StringUtils.isNotEmpty(TM_CHEM_SUM) ? TM_CHEM_SUM : "NA";
-        this.TM_CHEM_SUM_DESC =  StringUtils.isNotEmpty(TM_CHEM_SUM_DESC) ? TM_CHEM_SUM_DESC : "NA";
-        this.TM_CHEM_SUM_MSK =  StringUtils.isNotEmpty(TM_CHEM_SUM_MSK) ? TM_CHEM_SUM_MSK : "NA";
-        this.TM_CHEM_SUM_MSK_DESC =  StringUtils.isNotEmpty(TM_CHEM_SUM_MSK_DESC) ? TM_CHEM_SUM_MSK_DESC : "NA";
-        this.TM_TUMOR_SEQ =  StringUtils.isNotEmpty(TM_TUMOR_SEQ) ? TM_TUMOR_SEQ : "NA";
-        this.TM_HORM_SUM =  StringUtils.isNotEmpty(TM_HORM_SUM) ? TM_HORM_SUM : "NA";
-        this.TM_HORM_SUM_DESC =  StringUtils.isNotEmpty(TM_HORM_SUM_DESC) ? TM_HORM_SUM_DESC : "NA";
-        this.TM_HORM_SUM_MSK =  StringUtils.isNotEmpty(TM_HORM_SUM_MSK) ? TM_HORM_SUM_MSK : "NA";
-        this.TM_HORM_SUM_MSK_DESC =  StringUtils.isNotEmpty(TM_HORM_SUM_MSK_DESC) ? TM_HORM_SUM_MSK_DESC : "NA";
-        this.TM_BRM_SUM =  StringUtils.isNotEmpty(TM_BRM_SUM) ? TM_BRM_SUM : "NA";
-        this.TM_BRM_SUM_DESC =  StringUtils.isNotEmpty(TM_BRM_SUM_DESC) ? TM_BRM_SUM_DESC : "NA";
-        this.TM_BRM_SUM_MSK =  StringUtils.isNotEmpty(TM_BRM_SUM_MSK) ? TM_BRM_SUM_MSK : "NA";
-        this.TM_BRM_SUM_MSK_DESC =  StringUtils.isNotEmpty(TM_BRM_SUM_MSK_DESC) ? TM_BRM_SUM_MSK_DESC : "NA";
-        this.TM_OTH_SUM =  StringUtils.isNotEmpty(TM_OTH_SUM) ? TM_OTH_SUM : "NA";
-        this.TM_OTH_SUM_DESC =  StringUtils.isNotEmpty(TM_OTH_SUM_DESC) ? TM_OTH_SUM_DESC : "NA";
-        this.TM_OTH_SUM_MSK =  StringUtils.isNotEmpty(TM_OTH_SUM_MSK) ? TM_OTH_SUM_MSK : "NA";
-        this.TM_OTH_SUM_MSK_DESC =  StringUtils.isNotEmpty(TM_OTH_SUM_MSK_DESC) ? TM_OTH_SUM_MSK_DESC : "NA";
-        this.TM_PALLIA_PROC =  StringUtils.isNotEmpty(TM_PALLIA_PROC) ? TM_PALLIA_PROC : "NA";
-        this.TM_PALLIA_PROC_DESC =  StringUtils.isNotEmpty(TM_PALLIA_PROC_DESC) ? TM_PALLIA_PROC_DESC : "NA";
-        this.TM_PALLIA_PROC_MSK =  StringUtils.isNotEmpty(TM_PALLIA_PROC_MSK) ? TM_PALLIA_PROC_MSK : "NA";
-        this.TM_PALLIA_PROC_MSK_DESC =  StringUtils.isNotEmpty(TM_PALLIA_PROC_MSK_DESC) ? TM_PALLIA_PROC_MSK_DESC : "NA";
-        this.TM_ONCOLOGY_MD =  StringUtils.isNotEmpty(TM_ONCOLOGY_MD) ? TM_ONCOLOGY_MD : "NA";
-        this.TM_ONCOLOGY_MD_NAME =  StringUtils.isNotEmpty(TM_ONCOLOGY_MD_NAME) ? TM_ONCOLOGY_MD_NAME : "NA";
-        this.TM_PRCS_YEAR =  StringUtils.isNotEmpty(TM_PRCS_YEAR) ? TM_PRCS_YEAR : "NA";
-        this.AGE_AT_TM_PRCS_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_PRCS_DATE_IN_DAYS) ? AGE_AT_TM_PRCS_DATE_IN_DAYS : "NA";
-        this.TM_PATH_TEXT =  StringUtils.isNotEmpty(TM_PATH_TEXT) ? TM_PATH_TEXT : "NA";
-        this.TM_SURG_TEXT =  StringUtils.isNotEmpty(TM_SURG_TEXT) ? TM_SURG_TEXT : "NA";
-        this.TM_OVERRIDE_COM =  StringUtils.isNotEmpty(TM_OVERRIDE_COM) ? TM_OVERRIDE_COM : "NA";
-        this.TM_CSSIZE =  StringUtils.isNotEmpty(TM_CSSIZE) ? TM_CSSIZE : "NA";
-        this.TM_CSEXT =  StringUtils.isNotEmpty(TM_CSEXT) ? TM_CSEXT : "NA";
-        this.TM_CSEXTEV =  StringUtils.isNotEmpty(TM_CSEXTEV) ? TM_CSEXTEV : "NA";
-        this.TM_CSLMND =  StringUtils.isNotEmpty(TM_CSLMND) ? TM_CSLMND : "NA";
-        this.TM_CSRGNEV =  StringUtils.isNotEmpty(TM_CSRGNEV) ? TM_CSRGNEV : "NA";
-        this.TM_CSMETDX =  StringUtils.isNotEmpty(TM_CSMETDX) ? TM_CSMETDX : "NA";
-        this.TM_CSMETEV =  StringUtils.isNotEmpty(TM_CSMETEV) ? TM_CSMETEV : "NA";
-        this.TM_TSTAGE =  StringUtils.isNotEmpty(TM_TSTAGE) ? TM_TSTAGE : "NA";
-        this.TM_TSTAGE_DESC =  StringUtils.isNotEmpty(TM_TSTAGE_DESC) ? TM_TSTAGE_DESC : "NA";
-        this.TM_NSTAGE =  StringUtils.isNotEmpty(TM_NSTAGE) ? TM_NSTAGE : "NA";
-        this.TM_NSTAGE_DESC =  StringUtils.isNotEmpty(TM_NSTAGE_DESC) ? TM_NSTAGE_DESC : "NA";
-        this.TM_MSTAGE =  StringUtils.isNotEmpty(TM_MSTAGE) ? TM_MSTAGE : "NA";
-        this.TM_MSTAGE_DESC =  StringUtils.isNotEmpty(TM_MSTAGE_DESC) ? TM_MSTAGE_DESC : "NA";
-        this.TM_TBASIS =  StringUtils.isNotEmpty(TM_TBASIS) ? TM_TBASIS : "NA";
-        this.TM_TBASIS_DESC =  StringUtils.isNotEmpty(TM_TBASIS_DESC) ? TM_TBASIS_DESC : "NA";
-        this.TM_NBASIS =  StringUtils.isNotEmpty(TM_NBASIS) ? TM_NBASIS : "NA";
-        this.TM_NBASIS_DESC =  StringUtils.isNotEmpty(TM_NBASIS_DESC) ? TM_NBASIS_DESC : "NA";
-        this.TM_MBASIS =  StringUtils.isNotEmpty(TM_MBASIS) ? TM_MBASIS : "NA";
-        this.TM_MBASIS_DESC =  StringUtils.isNotEmpty(TM_MBASIS_DESC) ? TM_MBASIS_DESC : "NA";
-        this.TM_AJCC =  StringUtils.isNotEmpty(TM_AJCC) ? TM_AJCC : "NA";
-        this.TM_AJCC_DESC =  StringUtils.isNotEmpty(TM_AJCC_DESC) ? TM_AJCC_DESC : "NA";
-        this.TM_MSK_STG =  StringUtils.isNotEmpty(TM_MSK_STG) ? TM_MSK_STG : "NA";
+        this.TM_SITE_CD =  ClinicalValueUtil.defaultWithNA(TM_SITE_CD);
+        this.TM_SITE_DESC =  ClinicalValueUtil.defaultWithNA(TM_SITE_DESC);
+        this.TM_LATERALITY_CD =  ClinicalValueUtil.defaultWithNA(TM_LATERALITY_CD);
+        this.TM_LATERALITY_DESC =  ClinicalValueUtil.defaultWithNA(TM_LATERALITY_DESC);
+        this.TM_HIST_CD =  ClinicalValueUtil.defaultWithNA(TM_HIST_CD);
+        this.TM_HIST_DESC =  ClinicalValueUtil.defaultWithNA(TM_HIST_DESC);
+        this.TM_DX_CONFRM_CD =  ClinicalValueUtil.defaultWithNA(TM_DX_CONFRM_CD);
+        this.TM_DX_CONFRM_DESC =  ClinicalValueUtil.defaultWithNA(TM_DX_CONFRM_DESC);
+        this.TM_REGNODE_EXM_NO =  ClinicalValueUtil.defaultWithNA(TM_REGNODE_EXM_NO);
+        this.TM_REGNODE_POS_NO =  ClinicalValueUtil.defaultWithNA(TM_REGNODE_POS_NO);
+        this.TM_TUMOR_SIZE =  ClinicalValueUtil.defaultWithNA(TM_TUMOR_SIZE);
+        this.TM_RESID_TUMOR_CD =  ClinicalValueUtil.defaultWithNA(TM_RESID_TUMOR_CD);
+        this.TM_RESID_TUMOR_DESC =  ClinicalValueUtil.defaultWithNA(TM_RESID_TUMOR_DESC);
+        this.TM_GENERAL_STG =  ClinicalValueUtil.defaultWithNA(TM_GENERAL_STG);
+        this.TM_GENERAL_STG_DESC =  ClinicalValueUtil.defaultWithNA(TM_GENERAL_STG_DESC);
+        this.TM_TNM_EDITION =  ClinicalValueUtil.defaultWithNA(TM_TNM_EDITION);
+        this.TM_TNM_EDITION_DESC =  ClinicalValueUtil.defaultWithNA(TM_TNM_EDITION_DESC);
+        this.TM_CLIN_TNM_T =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_T);
+        this.TM_CLIN_TNM_T_DESC =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_T_DESC);
+        this.TM_CLIN_TNM_N =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_N);
+        this.TM_CLIN_TNM_N_DESC =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_N_DESC);
+        this.TM_CLIN_TNM_M =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_M);
+        this.TM_CLIN_TNM_M_DESC =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_M_DESC);
+        this.TM_CLIN_STG_GRP =  ClinicalValueUtil.defaultWithNA(TM_CLIN_STG_GRP);
+        this.TM_PATH_TNM_T =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_T);
+        this.TM_PATH_TNM_T_DESC =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_T_DESC);
+        this.TM_PATH_TNM_N =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_N);
+        this.TM_PATH_TNM_N_DESC =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_N_DESC);
+        this.TM_PATH_TNM_M =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_M);
+        this.TM_PATH_TNM_M_DESC =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_M_DESC);
+        this.TM_PATH_STG_GRP =  ClinicalValueUtil.defaultWithNA(TM_PATH_STG_GRP);
+        this.TM_PATH_RPT_AV =  ClinicalValueUtil.defaultWithNA(TM_PATH_RPT_AV);
+        this.TM_CA_STS_AT_ACC =  ClinicalValueUtil.defaultWithNA(TM_CA_STS_AT_ACC);
+        this.TM_FIRST_RECUR_YEAR =  ClinicalValueUtil.defaultWithNA(TM_FIRST_RECUR_YEAR);
+        this.AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS);
+        this.TM_FIRST_RECUR_TYP =  ClinicalValueUtil.defaultWithNA(TM_FIRST_RECUR_TYP);
+        this.TM_ADM_YEAR =  ClinicalValueUtil.defaultWithNA(TM_ADM_YEAR);
+        this.AGE_AT_TM_ADM_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_ADM_DATE_IN_DAYS);
+        this.TM_DSCH_YEAR =  ClinicalValueUtil.defaultWithNA(TM_DSCH_YEAR);
+        this.AGE_AT_TM_DSCH_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_DSCH_DATE_IN_DAYS);
+        this.TM_SURG_DSCH_YEAR =  ClinicalValueUtil.defaultWithNA(TM_SURG_DSCH_YEAR);
+        this.AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS);
+        this.TM_READM_WTHN_30D =  ClinicalValueUtil.defaultWithNA(TM_READM_WTHN_30D);
+        this.TM_FIRST_TX_YEAR =  ClinicalValueUtil.defaultWithNA(TM_FIRST_TX_YEAR);
+        this.AGE_AT_TM_FIRST_TX_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_FIRST_TX_DATE_IN_DAYS);
+        this.TM_NON_CA_SURG_SUM =  ClinicalValueUtil.defaultWithNA(TM_NON_CA_SURG_SUM);
+        this.TM_NON_CA_SURG_SUM_DESC =  ClinicalValueUtil.defaultWithNA(TM_NON_CA_SURG_SUM_DESC);
+        this.TM_NON_CA_SURG_MSK =  ClinicalValueUtil.defaultWithNA(TM_NON_CA_SURG_MSK);
+        this.TM_NON_CA_SURG_YEAR =  ClinicalValueUtil.defaultWithNA(TM_NON_CA_SURG_YEAR);
+        this.AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS);
+        this.TM_CA_SURG_98 =  ClinicalValueUtil.defaultWithNA(TM_CA_SURG_98);
+        this.TM_CA_SURG_98_MSK =  ClinicalValueUtil.defaultWithNA(TM_CA_SURG_98_MSK);
+        this.TM_CA_SURG_03 =  ClinicalValueUtil.defaultWithNA(TM_CA_SURG_03);
+        this.TM_CA_SURG_03_MSK =  ClinicalValueUtil.defaultWithNA(TM_CA_SURG_03_MSK);
+        this.TM_OTH_SURG_98 =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_98);
+        this.TM_OTH_SURG_98_MSK =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_98_MSK);
+        this.TM_OTH_SURG_03 =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_03);
+        this.TM_OTH_SURG_03_MSK =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_03_MSK);
+        this.TM_OTH_SURG_CD =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_CD);
+        this.TM_OTH_SURG_CD_DESC =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_CD_DESC);
+        this.TM_RGN_SCOP_98 =  ClinicalValueUtil.defaultWithNA(TM_RGN_SCOP_98);
+        this.TM_RGN_SCOP_98_MSK =  ClinicalValueUtil.defaultWithNA(TM_RGN_SCOP_98_MSK);
+        this.TM_RGN_SCOP_03 =  ClinicalValueUtil.defaultWithNA(TM_RGN_SCOP_03);
+        this.TM_RGN_SCOP_03_MSK =  ClinicalValueUtil.defaultWithNA(TM_RGN_SCOP_03_MSK);
+        this.TM_REGNODE_SCOP_CD =  ClinicalValueUtil.defaultWithNA(TM_REGNODE_SCOP_CD);
+        this.TM_REGNODE_SCOP_DESC =  ClinicalValueUtil.defaultWithNA(TM_REGNODE_SCOP_DESC);
+        this.TM_RECON_SURG =  ClinicalValueUtil.defaultWithNA(TM_RECON_SURG);
+        this.TM_RECON_SURG_DESC =  ClinicalValueUtil.defaultWithNA(TM_RECON_SURG_DESC);
+        this.TM_CA_SURG_YEAR =  ClinicalValueUtil.defaultWithNA(TM_CA_SURG_YEAR);
+        this.AGE_AT_TM_CA_SURG_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_CA_SURG_DATE_IN_DAYS);
+        this.TM_SURG_DEF_YEAR =  ClinicalValueUtil.defaultWithNA(TM_SURG_DEF_YEAR);
+        this.AGE_AT_TM_SURG_DEF_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_SURG_DEF_DATE_IN_DAYS);
+        this.TM_REASON_NO_SURG =  ClinicalValueUtil.defaultWithNA(TM_REASON_NO_SURG);
+        this.REASON_NO_SURG_DESC =  ClinicalValueUtil.defaultWithNA(REASON_NO_SURG_DESC);
+        this.TM_PRIM_SURGEON =  ClinicalValueUtil.defaultWithNA(TM_PRIM_SURGEON);
+        this.TM_PRIM_SURGEON_NAME =  ClinicalValueUtil.defaultWithNA(TM_PRIM_SURGEON_NAME);
+        this.TM_ATN_DR_NO =  ClinicalValueUtil.defaultWithNA(TM_ATN_DR_NO);
+        this.TM_ATN_DR_NAME =  ClinicalValueUtil.defaultWithNA(TM_ATN_DR_NAME);
+        this.TM_REASON_NO_RAD =  ClinicalValueUtil.defaultWithNA(TM_REASON_NO_RAD);
+        this.TM_REASON_NO_RAD_DESC =  ClinicalValueUtil.defaultWithNA(TM_REASON_NO_RAD_DESC);
+        this.TM_RAD_STRT_YEAR =  ClinicalValueUtil.defaultWithNA(TM_RAD_STRT_YEAR);
+        this.AGE_AT_TM_RAD_STRT_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_RAD_STRT_DATE_IN_DAYS);
+        this.TM_RAD_END_YEAR =  ClinicalValueUtil.defaultWithNA(TM_RAD_END_YEAR);
+        this.AGE_AT_TM_RAD_END_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_RAD_END_DATE_IN_DAYS);
+        this.TM_RAD_TX_MOD =  ClinicalValueUtil.defaultWithNA(TM_RAD_TX_MOD);
+        this.TM_RAD_TX_MOD_DESC =  ClinicalValueUtil.defaultWithNA(TM_RAD_TX_MOD_DESC);
+        this.TM_BOOST_RAD_MOD =  ClinicalValueUtil.defaultWithNA(TM_BOOST_RAD_MOD);
+        this.TM_BOOST_RAD_MOD_DESC =  ClinicalValueUtil.defaultWithNA(TM_BOOST_RAD_MOD_DESC);
+        this.TM_LOC_RAD_TX =  ClinicalValueUtil.defaultWithNA(TM_LOC_RAD_TX);
+        this.TM_LOC_RAD_TX_DESC =  ClinicalValueUtil.defaultWithNA(TM_LOC_RAD_TX_DESC);
+        this.TM_RAD_TX_VOL =  ClinicalValueUtil.defaultWithNA(TM_RAD_TX_VOL);
+        this.TM_RAD_TX_VOL_DESC =  ClinicalValueUtil.defaultWithNA(TM_RAD_TX_VOL_DESC);
+        this.TM_NUM_TX_THIS_VOL =  ClinicalValueUtil.defaultWithNA(TM_NUM_TX_THIS_VOL);
+        this.TM_NUM_TX_THIS_VOL_DESC =  ClinicalValueUtil.defaultWithNA(TM_NUM_TX_THIS_VOL_DESC);
+        this.TM_REG_RAD_DOSE =  ClinicalValueUtil.defaultWithNA(TM_REG_RAD_DOSE);
+        this.TM_REG_RAD_DOSE_DESC =  ClinicalValueUtil.defaultWithNA(TM_REG_RAD_DOSE_DESC);
+        this.TM_BOOST_RAD_DOSE =  ClinicalValueUtil.defaultWithNA(TM_BOOST_RAD_DOSE);
+        this.TM_BOOST_RAD_DOSE_DESC =  ClinicalValueUtil.defaultWithNA(TM_BOOST_RAD_DOSE_DESC);
+        this.TM_RAD_SURG_SEQ =  ClinicalValueUtil.defaultWithNA(TM_RAD_SURG_SEQ);
+        this.TM_RAD_SURG_SEQ_DESC =  ClinicalValueUtil.defaultWithNA(TM_RAD_SURG_SEQ_DESC);
+        this.TM_RAD_MD =  ClinicalValueUtil.defaultWithNA(TM_RAD_MD);
+        this.TM_RAD_MD_NAME =  ClinicalValueUtil.defaultWithNA(TM_RAD_MD_NAME);
+        this.TM_SYST_STRT_YEAR =  ClinicalValueUtil.defaultWithNA(TM_SYST_STRT_YEAR);
+        this.AGE_AT_TM_SYST_STRT_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_SYST_STRT_DATE_IN_DAYS);
+        this.TM_OTH_STRT_YEAR =  ClinicalValueUtil.defaultWithNA(TM_OTH_STRT_YEAR);
+        this.AGE_AT_TM_OTH_STRT_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_OTH_STRT_DATE_IN_DAYS);
+        this.TM_CHEM_SUM =  ClinicalValueUtil.defaultWithNA(TM_CHEM_SUM);
+        this.TM_CHEM_SUM_DESC =  ClinicalValueUtil.defaultWithNA(TM_CHEM_SUM_DESC);
+        this.TM_CHEM_SUM_MSK =  ClinicalValueUtil.defaultWithNA(TM_CHEM_SUM_MSK);
+        this.TM_CHEM_SUM_MSK_DESC =  ClinicalValueUtil.defaultWithNA(TM_CHEM_SUM_MSK_DESC);
+        this.TM_TUMOR_SEQ =  ClinicalValueUtil.defaultWithNA(TM_TUMOR_SEQ);
+        this.TM_HORM_SUM =  ClinicalValueUtil.defaultWithNA(TM_HORM_SUM);
+        this.TM_HORM_SUM_DESC =  ClinicalValueUtil.defaultWithNA(TM_HORM_SUM_DESC);
+        this.TM_HORM_SUM_MSK =  ClinicalValueUtil.defaultWithNA(TM_HORM_SUM_MSK);
+        this.TM_HORM_SUM_MSK_DESC =  ClinicalValueUtil.defaultWithNA(TM_HORM_SUM_MSK_DESC);
+        this.TM_BRM_SUM =  ClinicalValueUtil.defaultWithNA(TM_BRM_SUM);
+        this.TM_BRM_SUM_DESC =  ClinicalValueUtil.defaultWithNA(TM_BRM_SUM_DESC);
+        this.TM_BRM_SUM_MSK =  ClinicalValueUtil.defaultWithNA(TM_BRM_SUM_MSK);
+        this.TM_BRM_SUM_MSK_DESC =  ClinicalValueUtil.defaultWithNA(TM_BRM_SUM_MSK_DESC);
+        this.TM_OTH_SUM =  ClinicalValueUtil.defaultWithNA(TM_OTH_SUM);
+        this.TM_OTH_SUM_DESC =  ClinicalValueUtil.defaultWithNA(TM_OTH_SUM_DESC);
+        this.TM_OTH_SUM_MSK =  ClinicalValueUtil.defaultWithNA(TM_OTH_SUM_MSK);
+        this.TM_OTH_SUM_MSK_DESC =  ClinicalValueUtil.defaultWithNA(TM_OTH_SUM_MSK_DESC);
+        this.TM_PALLIA_PROC =  ClinicalValueUtil.defaultWithNA(TM_PALLIA_PROC);
+        this.TM_PALLIA_PROC_DESC =  ClinicalValueUtil.defaultWithNA(TM_PALLIA_PROC_DESC);
+        this.TM_PALLIA_PROC_MSK =  ClinicalValueUtil.defaultWithNA(TM_PALLIA_PROC_MSK);
+        this.TM_PALLIA_PROC_MSK_DESC =  ClinicalValueUtil.defaultWithNA(TM_PALLIA_PROC_MSK_DESC);
+        this.TM_ONCOLOGY_MD =  ClinicalValueUtil.defaultWithNA(TM_ONCOLOGY_MD);
+        this.TM_ONCOLOGY_MD_NAME =  ClinicalValueUtil.defaultWithNA(TM_ONCOLOGY_MD_NAME);
+        this.TM_PRCS_YEAR =  ClinicalValueUtil.defaultWithNA(TM_PRCS_YEAR);
+        this.AGE_AT_TM_PRCS_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_PRCS_DATE_IN_DAYS);
+        this.TM_PATH_TEXT =  ClinicalValueUtil.defaultWithNA(TM_PATH_TEXT);
+        this.TM_SURG_TEXT =  ClinicalValueUtil.defaultWithNA(TM_SURG_TEXT);
+        this.TM_OVERRIDE_COM =  ClinicalValueUtil.defaultWithNA(TM_OVERRIDE_COM);
+        this.TM_CSSIZE =  ClinicalValueUtil.defaultWithNA(TM_CSSIZE);
+        this.TM_CSEXT =  ClinicalValueUtil.defaultWithNA(TM_CSEXT);
+        this.TM_CSEXTEV =  ClinicalValueUtil.defaultWithNA(TM_CSEXTEV);
+        this.TM_CSLMND =  ClinicalValueUtil.defaultWithNA(TM_CSLMND);
+        this.TM_CSRGNEV =  ClinicalValueUtil.defaultWithNA(TM_CSRGNEV);
+        this.TM_CSMETDX =  ClinicalValueUtil.defaultWithNA(TM_CSMETDX);
+        this.TM_CSMETEV =  ClinicalValueUtil.defaultWithNA(TM_CSMETEV);
+        this.TM_TSTAGE =  ClinicalValueUtil.defaultWithNA(TM_TSTAGE);
+        this.TM_TSTAGE_DESC =  ClinicalValueUtil.defaultWithNA(TM_TSTAGE_DESC);
+        this.TM_NSTAGE =  ClinicalValueUtil.defaultWithNA(TM_NSTAGE);
+        this.TM_NSTAGE_DESC =  ClinicalValueUtil.defaultWithNA(TM_NSTAGE_DESC);
+        this.TM_MSTAGE =  ClinicalValueUtil.defaultWithNA(TM_MSTAGE);
+        this.TM_MSTAGE_DESC =  ClinicalValueUtil.defaultWithNA(TM_MSTAGE_DESC);
+        this.TM_TBASIS =  ClinicalValueUtil.defaultWithNA(TM_TBASIS);
+        this.TM_TBASIS_DESC =  ClinicalValueUtil.defaultWithNA(TM_TBASIS_DESC);
+        this.TM_NBASIS =  ClinicalValueUtil.defaultWithNA(TM_NBASIS);
+        this.TM_NBASIS_DESC =  ClinicalValueUtil.defaultWithNA(TM_NBASIS_DESC);
+        this.TM_MBASIS =  ClinicalValueUtil.defaultWithNA(TM_MBASIS);
+        this.TM_MBASIS_DESC =  ClinicalValueUtil.defaultWithNA(TM_MBASIS_DESC);
+        this.TM_AJCC =  ClinicalValueUtil.defaultWithNA(TM_AJCC);
+        this.TM_AJCC_DESC =  ClinicalValueUtil.defaultWithNA(TM_AJCC_DESC);
+        this.TM_MSK_STG =  ClinicalValueUtil.defaultWithNA(TM_MSK_STG);
     }
-    
+
     public String getPT_ID_ICDO(){
-	return PT_ID_ICDO;
+        return PT_ID_ICDO;
     }
 
     public void setPT_ID_ICDO(String PT_ID_ICDO) {
-        this.PT_ID_ICDO =  StringUtils.isNotEmpty(PT_ID_ICDO) ? PT_ID_ICDO : "NA";
+        this.PT_ID_ICDO =  ClinicalValueUtil.defaultWithNA(PT_ID_ICDO);
     }
-    
+
     public Integer getTUMOR_YEAR(){
-	return TUMOR_YEAR;
+        return TUMOR_YEAR;
     }
 
     public void setTUMOR_YEAR(Integer TUMOR_YEAR) {
@@ -602,7 +604,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setDMP_ID_ICDO(String DMP_ID_ICDO) {
-        this.DMP_ID_ICDO =  StringUtils.isNotEmpty(DMP_ID_ICDO) ? DMP_ID_ICDO : "NA";
+        this.DMP_ID_ICDO =  ClinicalValueUtil.defaultWithNA(DMP_ID_ICDO);
     }
 
     public String getTM_TUMOR_SEQ_DESC() {
@@ -610,7 +612,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_TUMOR_SEQ_DESC(String TM_TUMOR_SEQ_DESC) {
-        this.TM_TUMOR_SEQ_DESC =  StringUtils.isNotEmpty(TM_TUMOR_SEQ_DESC) ? TM_TUMOR_SEQ_DESC : "NA";
+        this.TM_TUMOR_SEQ_DESC =  ClinicalValueUtil.defaultWithNA(TM_TUMOR_SEQ_DESC);
     }
 
     public String getTM_ACC_YEAR() {
@@ -618,7 +620,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_ACC_YEAR(String TM_ACC_YEAR) {
-        this.TM_ACC_YEAR =  StringUtils.isNotEmpty(TM_ACC_YEAR) ? TM_ACC_YEAR : "NA";
+        this.TM_ACC_YEAR =  ClinicalValueUtil.defaultWithNA(TM_ACC_YEAR);
     }
 
     public String getTM_FIRST_MSK_YEAR() {
@@ -626,7 +628,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_FIRST_MSK_YEAR(String TM_FIRST_MSK_YEAR) {
-        this.TM_FIRST_MSK_YEAR =  StringUtils.isNotEmpty(TM_FIRST_MSK_YEAR) ? TM_FIRST_MSK_YEAR : "NA";
+        this.TM_FIRST_MSK_YEAR =  ClinicalValueUtil.defaultWithNA(TM_FIRST_MSK_YEAR);
     }
 
     public String getAGE_AT_TM_FIRST_MSK_DATE_IN_DAYS() {
@@ -634,7 +636,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_FIRST_MSK_DATE_IN_DAYS(String AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS) {
-        this.AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS) ? AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_FIRST_MSK_DATE_IN_DAYS);
     }
 
     public String getTM_CASE_STS() {
@@ -642,7 +644,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CASE_STS(String TM_CASE_STS) {
-        this.TM_CASE_STS =  StringUtils.isNotEmpty(TM_CASE_STS) ? TM_CASE_STS : "NA";
+        this.TM_CASE_STS =  ClinicalValueUtil.defaultWithNA(TM_CASE_STS);
     }
 
     public String getTM_CASE_STS_DESC() {
@@ -650,7 +652,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CASE_STS_DESC(String TM_CASE_STS_DESC) {
-        this.TM_CASE_STS_DESC =  StringUtils.isNotEmpty(TM_CASE_STS_DESC) ? TM_CASE_STS_DESC : "NA";
+        this.TM_CASE_STS_DESC =  ClinicalValueUtil.defaultWithNA(TM_CASE_STS_DESC);
     }
 
     public String getTM_CASE_EFF_YEAR() {
@@ -658,7 +660,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CASE_EFF_YEAR(String TM_CASE_EFF_YEAR) {
-        this.TM_CASE_EFF_YEAR =  StringUtils.isNotEmpty(TM_CASE_EFF_YEAR) ? TM_CASE_EFF_YEAR : "NA";
+        this.TM_CASE_EFF_YEAR =  ClinicalValueUtil.defaultWithNA(TM_CASE_EFF_YEAR);
     }
 
     public String getAGE_AT_TM_CASE_EFF_DATE_IN_DAYS() {
@@ -666,7 +668,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_CASE_EFF_DATE_IN_DAYS(String AGE_AT_TM_CASE_EFF_DATE_IN_DAYS) {
-        this.AGE_AT_TM_CASE_EFF_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_CASE_EFF_DATE_IN_DAYS) ? AGE_AT_TM_CASE_EFF_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_CASE_EFF_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_CASE_EFF_DATE_IN_DAYS);
     }
 
     public String getTM_STATE_AT_DX() {
@@ -674,7 +676,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_STATE_AT_DX(String TM_STATE_AT_DX) {
-        this.TM_STATE_AT_DX =  StringUtils.isNotEmpty(TM_STATE_AT_DX) ? TM_STATE_AT_DX : "NA";
+        this.TM_STATE_AT_DX =  ClinicalValueUtil.defaultWithNA(TM_STATE_AT_DX);
     }
 
     public String getTM_SMOKING_HX() {
@@ -682,7 +684,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_SMOKING_HX(String TM_SMOKING_HX) {
-        this.TM_SMOKING_HX =  StringUtils.isNotEmpty(TM_SMOKING_HX) ? TM_SMOKING_HX : "NA";
+        this.TM_SMOKING_HX =  ClinicalValueUtil.defaultWithNA(TM_SMOKING_HX);
     }
 
     public String getTM_SMOKING_HX_DESC() {
@@ -690,7 +692,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_SMOKING_HX_DESC(String TM_SMOKING_HX_DESC) {
-        this.TM_SMOKING_HX_DESC =  StringUtils.isNotEmpty(TM_SMOKING_HX_DESC) ? TM_SMOKING_HX_DESC : "NA";
+        this.TM_SMOKING_HX_DESC =  ClinicalValueUtil.defaultWithNA(TM_SMOKING_HX_DESC);
     }
 
     public String getTM_OCCUPATION() {
@@ -698,7 +700,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OCCUPATION(String TM_OCCUPATION) {
-        this.TM_OCCUPATION =  StringUtils.isNotEmpty(TM_OCCUPATION) ? TM_OCCUPATION : "NA";
+        this.TM_OCCUPATION =  ClinicalValueUtil.defaultWithNA(TM_OCCUPATION);
     }
 
     public String getTM_OCCUPATION_DESC() {
@@ -706,7 +708,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OCCUPATION_DESC(String TM_OCCUPATION_DESC) {
-        this.TM_OCCUPATION_DESC =  StringUtils.isNotEmpty(TM_OCCUPATION_DESC) ? TM_OCCUPATION_DESC : "NA";
+        this.TM_OCCUPATION_DESC =  ClinicalValueUtil.defaultWithNA(TM_OCCUPATION_DESC);
     }
 
     public String getTM_FACILITY_FROM() {
@@ -714,7 +716,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_FACILITY_FROM(String TM_FACILITY_FROM) {
-        this.TM_FACILITY_FROM =  StringUtils.isNotEmpty(TM_FACILITY_FROM) ? TM_FACILITY_FROM : "NA";
+        this.TM_FACILITY_FROM =  ClinicalValueUtil.defaultWithNA(TM_FACILITY_FROM);
     }
 
     public String getFACILITY_FROM_DESC() {
@@ -722,7 +724,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setFACILITY_FROM_DESC(String FACILITY_FROM_DESC) {
-        this.FACILITY_FROM_DESC =  StringUtils.isNotEmpty(FACILITY_FROM_DESC) ? FACILITY_FROM_DESC : "NA";
+        this.FACILITY_FROM_DESC =  ClinicalValueUtil.defaultWithNA(FACILITY_FROM_DESC);
     }
 
     public String getTM_FACILITY_TO() {
@@ -730,7 +732,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_FACILITY_TO(String TM_FACILITY_TO) {
-        this.TM_FACILITY_TO =  StringUtils.isNotEmpty(TM_FACILITY_TO) ? TM_FACILITY_TO : "NA";
+        this.TM_FACILITY_TO =  ClinicalValueUtil.defaultWithNA(TM_FACILITY_TO);
     }
 
     public String getFACILITY_TO_DESC() {
@@ -738,7 +740,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setFACILITY_TO_DESC(String FACILITY_TO_DESC) {
-        this.FACILITY_TO_DESC =  StringUtils.isNotEmpty(FACILITY_TO_DESC) ? FACILITY_TO_DESC : "NA";
+        this.FACILITY_TO_DESC =  ClinicalValueUtil.defaultWithNA(FACILITY_TO_DESC);
     }
 
     public Integer getTM_DX_YEAR() {
@@ -762,7 +764,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_SITE_CD(String TM_SITE_CD) {
-        this.TM_SITE_CD =  StringUtils.isNotEmpty(TM_SITE_CD) ? TM_SITE_CD : "NA";
+        this.TM_SITE_CD =  ClinicalValueUtil.defaultWithNA(TM_SITE_CD);
     }
 
     public String getTM_SITE_DESC() {
@@ -770,7 +772,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_SITE_DESC(String TM_SITE_DESC) {
-        this.TM_SITE_DESC =  StringUtils.isNotEmpty(TM_SITE_DESC) ? TM_SITE_DESC : "NA";
+        this.TM_SITE_DESC =  ClinicalValueUtil.defaultWithNA(TM_SITE_DESC);
     }
 
     public String getTM_LATERALITY_CD() {
@@ -778,7 +780,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_LATERALITY_CD(String TM_LATERALITY_CD) {
-        this.TM_LATERALITY_CD =  StringUtils.isNotEmpty(TM_LATERALITY_CD) ? TM_LATERALITY_CD : "NA";
+        this.TM_LATERALITY_CD =  ClinicalValueUtil.defaultWithNA(TM_LATERALITY_CD);
     }
 
     public String getTM_LATERALITY_DESC() {
@@ -786,7 +788,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_LATERALITY_DESC(String TM_LATERALITY_DESC) {
-        this.TM_LATERALITY_DESC =  StringUtils.isNotEmpty(TM_LATERALITY_DESC) ? TM_LATERALITY_DESC : "NA";
+        this.TM_LATERALITY_DESC =  ClinicalValueUtil.defaultWithNA(TM_LATERALITY_DESC);
     }
 
     public String getTM_HIST_CD() {
@@ -794,7 +796,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_HIST_CD(String TM_HIST_CD) {
-        this.TM_HIST_CD =  StringUtils.isNotEmpty(TM_HIST_CD) ? TM_HIST_CD : "NA";
+        this.TM_HIST_CD =  ClinicalValueUtil.defaultWithNA(TM_HIST_CD);
     }
 
     public String getTM_HIST_DESC() {
@@ -802,7 +804,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_HIST_DESC(String TM_HIST_DESC) {
-        this.TM_HIST_DESC =  StringUtils.isNotEmpty(TM_HIST_DESC) ? TM_HIST_DESC : "NA";
+        this.TM_HIST_DESC =  ClinicalValueUtil.defaultWithNA(TM_HIST_DESC);
     }
 
     public String getTM_DX_CONFRM_CD() {
@@ -810,7 +812,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_DX_CONFRM_CD(String TM_DX_CONFRM_CD) {
-        this.TM_DX_CONFRM_CD =  StringUtils.isNotEmpty(TM_DX_CONFRM_CD) ? TM_DX_CONFRM_CD : "NA";
+        this.TM_DX_CONFRM_CD =  ClinicalValueUtil.defaultWithNA(TM_DX_CONFRM_CD);
     }
 
     public String getTM_DX_CONFRM_DESC() {
@@ -818,7 +820,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_DX_CONFRM_DESC(String TM_DX_CONFRM_DESC) {
-        this.TM_DX_CONFRM_DESC =  StringUtils.isNotEmpty(TM_DX_CONFRM_DESC) ? TM_DX_CONFRM_DESC : "NA";
+        this.TM_DX_CONFRM_DESC =  ClinicalValueUtil.defaultWithNA(TM_DX_CONFRM_DESC);
     }
 
     public String getTM_REGNODE_EXM_NO() {
@@ -826,7 +828,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_REGNODE_EXM_NO(String TM_REGNODE_EXM_NO) {
-        this.TM_REGNODE_EXM_NO =  StringUtils.isNotEmpty(TM_REGNODE_EXM_NO) ? TM_REGNODE_EXM_NO : "NA";
+        this.TM_REGNODE_EXM_NO =  ClinicalValueUtil.defaultWithNA(TM_REGNODE_EXM_NO);
     }
 
     public String getTM_REGNODE_POS_NO() {
@@ -834,7 +836,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_REGNODE_POS_NO(String TM_REGNODE_POS_NO) {
-        this.TM_REGNODE_POS_NO =  StringUtils.isNotEmpty(TM_REGNODE_POS_NO) ? TM_REGNODE_POS_NO : "NA";
+        this.TM_REGNODE_POS_NO =  ClinicalValueUtil.defaultWithNA(TM_REGNODE_POS_NO);
     }
 
     public String getTM_TUMOR_SIZE() {
@@ -842,7 +844,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_TUMOR_SIZE(String TM_TUMOR_SIZE) {
-        this.TM_TUMOR_SIZE =  StringUtils.isNotEmpty(TM_TUMOR_SIZE) ? TM_TUMOR_SIZE : "NA";
+        this.TM_TUMOR_SIZE =  ClinicalValueUtil.defaultWithNA(TM_TUMOR_SIZE);
     }
 
     public String getTM_RESID_TUMOR_CD() {
@@ -850,7 +852,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RESID_TUMOR_CD(String TM_RESID_TUMOR_CD) {
-        this.TM_RESID_TUMOR_CD =  StringUtils.isNotEmpty(TM_RESID_TUMOR_CD) ? TM_RESID_TUMOR_CD : "NA";
+        this.TM_RESID_TUMOR_CD =  ClinicalValueUtil.defaultWithNA(TM_RESID_TUMOR_CD);
     }
 
     public String getTM_RESID_TUMOR_DESC() {
@@ -858,7 +860,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RESID_TUMOR_DESC(String TM_RESID_TUMOR_DESC) {
-        this.TM_RESID_TUMOR_DESC =  StringUtils.isNotEmpty(TM_RESID_TUMOR_DESC) ? TM_RESID_TUMOR_DESC : "NA";
+        this.TM_RESID_TUMOR_DESC =  ClinicalValueUtil.defaultWithNA(TM_RESID_TUMOR_DESC);
     }
 
     public String getTM_GENERAL_STG() {
@@ -866,7 +868,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_GENERAL_STG(String TM_GENERAL_STG) {
-        this.TM_GENERAL_STG =  StringUtils.isNotEmpty(TM_GENERAL_STG) ? TM_GENERAL_STG : "NA";
+        this.TM_GENERAL_STG =  ClinicalValueUtil.defaultWithNA(TM_GENERAL_STG);
     }
 
     public String getTM_GENERAL_STG_DESC() {
@@ -874,7 +876,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_GENERAL_STG_DESC(String TM_GENERAL_STG_DESC) {
-        this.TM_GENERAL_STG_DESC =  StringUtils.isNotEmpty(TM_GENERAL_STG_DESC) ? TM_GENERAL_STG_DESC : "NA";
+        this.TM_GENERAL_STG_DESC =  ClinicalValueUtil.defaultWithNA(TM_GENERAL_STG_DESC);
     }
 
     public String getTM_TNM_EDITION() {
@@ -882,7 +884,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_TNM_EDITION(String TM_TNM_EDITION) {
-        this.TM_TNM_EDITION =  StringUtils.isNotEmpty(TM_TNM_EDITION) ? TM_TNM_EDITION : "NA";
+        this.TM_TNM_EDITION =  ClinicalValueUtil.defaultWithNA(TM_TNM_EDITION);
     }
 
     public String getTM_TNM_EDITION_DESC() {
@@ -890,7 +892,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_TNM_EDITION_DESC(String TM_TNM_EDITION_DESC) {
-        this.TM_TNM_EDITION_DESC =  StringUtils.isNotEmpty(TM_TNM_EDITION_DESC) ? TM_TNM_EDITION_DESC : "NA";
+        this.TM_TNM_EDITION_DESC =  ClinicalValueUtil.defaultWithNA(TM_TNM_EDITION_DESC);
     }
 
     public String getTM_CLIN_TNM_T() {
@@ -898,7 +900,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CLIN_TNM_T(String TM_CLIN_TNM_T) {
-        this.TM_CLIN_TNM_T =  StringUtils.isNotEmpty(TM_CLIN_TNM_T) ? TM_CLIN_TNM_T : "NA";
+        this.TM_CLIN_TNM_T =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_T);
     }
 
     public String getTM_CLIN_TNM_T_DESC() {
@@ -906,7 +908,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CLIN_TNM_T_DESC(String TM_CLIN_TNM_T_DESC) {
-        this.TM_CLIN_TNM_T_DESC =  StringUtils.isNotEmpty(TM_CLIN_TNM_T_DESC) ? TM_CLIN_TNM_T_DESC : "NA";
+        this.TM_CLIN_TNM_T_DESC =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_T_DESC);
     }
 
     public String getTM_CLIN_TNM_N() {
@@ -914,7 +916,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CLIN_TNM_N(String TM_CLIN_TNM_N) {
-        this.TM_CLIN_TNM_N =  StringUtils.isNotEmpty(TM_CLIN_TNM_N) ? TM_CLIN_TNM_N : "NA";
+        this.TM_CLIN_TNM_N =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_N);
     }
 
     public String getTM_CLIN_TNM_N_DESC() {
@@ -922,7 +924,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CLIN_TNM_N_DESC(String TM_CLIN_TNM_N_DESC) {
-        this.TM_CLIN_TNM_N_DESC =  StringUtils.isNotEmpty(TM_CLIN_TNM_N_DESC) ? TM_CLIN_TNM_N_DESC : "NA";
+        this.TM_CLIN_TNM_N_DESC =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_N_DESC);
     }
 
     public String getTM_CLIN_TNM_M() {
@@ -930,7 +932,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CLIN_TNM_M(String TM_CLIN_TNM_M) {
-        this.TM_CLIN_TNM_M =  StringUtils.isNotEmpty(TM_CLIN_TNM_M) ? TM_CLIN_TNM_M : "NA";
+        this.TM_CLIN_TNM_M =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_M);
     }
 
     public String getTM_CLIN_TNM_M_DESC() {
@@ -938,7 +940,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CLIN_TNM_M_DESC(String TM_CLIN_TNM_M_DESC) {
-        this.TM_CLIN_TNM_M_DESC =  StringUtils.isNotEmpty(TM_CLIN_TNM_M_DESC) ? TM_CLIN_TNM_M_DESC : "NA";
+        this.TM_CLIN_TNM_M_DESC =  ClinicalValueUtil.defaultWithNA(TM_CLIN_TNM_M_DESC);
     }
 
     public String getTM_CLIN_STG_GRP() {
@@ -946,7 +948,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CLIN_STG_GRP(String TM_CLIN_STG_GRP) {
-        this.TM_CLIN_STG_GRP =  StringUtils.isNotEmpty(TM_CLIN_STG_GRP) ? TM_CLIN_STG_GRP : "NA";
+        this.TM_CLIN_STG_GRP =  ClinicalValueUtil.defaultWithNA(TM_CLIN_STG_GRP);
     }
 
     public String getTM_PATH_TNM_T() {
@@ -954,7 +956,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PATH_TNM_T(String TM_PATH_TNM_T) {
-        this.TM_PATH_TNM_T =  StringUtils.isNotEmpty(TM_PATH_TNM_T) ? TM_PATH_TNM_T : "NA";
+        this.TM_PATH_TNM_T =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_T);
     }
 
     public String getTM_PATH_TNM_T_DESC() {
@@ -962,7 +964,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PATH_TNM_T_DESC(String TM_PATH_TNM_T_DESC) {
-        this.TM_PATH_TNM_T_DESC =  StringUtils.isNotEmpty(TM_PATH_TNM_T_DESC) ? TM_PATH_TNM_T_DESC : "NA";
+        this.TM_PATH_TNM_T_DESC =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_T_DESC);
     }
 
     public String getTM_PATH_TNM_N() {
@@ -970,7 +972,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PATH_TNM_N(String TM_PATH_TNM_N) {
-        this.TM_PATH_TNM_N =  StringUtils.isNotEmpty(TM_PATH_TNM_N) ? TM_PATH_TNM_N : "NA";
+        this.TM_PATH_TNM_N =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_N);
     }
 
     public String getTM_PATH_TNM_N_DESC() {
@@ -978,7 +980,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PATH_TNM_N_DESC(String TM_PATH_TNM_N_DESC) {
-        this.TM_PATH_TNM_N_DESC =  StringUtils.isNotEmpty(TM_PATH_TNM_N_DESC) ? TM_PATH_TNM_N_DESC : "NA";
+        this.TM_PATH_TNM_N_DESC =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_N_DESC);
     }
 
     public String getTM_PATH_TNM_M() {
@@ -986,7 +988,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PATH_TNM_M(String TM_PATH_TNM_M) {
-        this.TM_PATH_TNM_M =  StringUtils.isNotEmpty(TM_PATH_TNM_M) ? TM_PATH_TNM_M : "NA";
+        this.TM_PATH_TNM_M =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_M);
     }
 
     public String getTM_PATH_TNM_M_DESC() {
@@ -994,7 +996,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PATH_TNM_M_DESC(String TM_PATH_TNM_M_DESC) {
-        this.TM_PATH_TNM_M_DESC =  StringUtils.isNotEmpty(TM_PATH_TNM_M_DESC) ? TM_PATH_TNM_M_DESC : "NA";
+        this.TM_PATH_TNM_M_DESC =  ClinicalValueUtil.defaultWithNA(TM_PATH_TNM_M_DESC);
     }
 
     public String getTM_PATH_STG_GRP() {
@@ -1002,7 +1004,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PATH_STG_GRP(String TM_PATH_STG_GRP) {
-        this.TM_PATH_STG_GRP =  StringUtils.isNotEmpty(TM_PATH_STG_GRP) ? TM_PATH_STG_GRP : "NA";
+        this.TM_PATH_STG_GRP =  ClinicalValueUtil.defaultWithNA(TM_PATH_STG_GRP);
     }
 
     public String getTM_PATH_RPT_AV() {
@@ -1010,7 +1012,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PATH_RPT_AV(String TM_PATH_RPT_AV) {
-        this.TM_PATH_RPT_AV =  StringUtils.isNotEmpty(TM_PATH_RPT_AV) ? TM_PATH_RPT_AV : "NA";
+        this.TM_PATH_RPT_AV =  ClinicalValueUtil.defaultWithNA(TM_PATH_RPT_AV);
     }
 
     public String getTM_CA_STS_AT_ACC() {
@@ -1018,7 +1020,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CA_STS_AT_ACC(String TM_CA_STS_AT_ACC) {
-        this.TM_CA_STS_AT_ACC =  StringUtils.isNotEmpty(TM_CA_STS_AT_ACC) ? TM_CA_STS_AT_ACC : "NA";
+        this.TM_CA_STS_AT_ACC =  ClinicalValueUtil.defaultWithNA(TM_CA_STS_AT_ACC);
     }
 
     public String getTM_FIRST_RECUR_YEAR() {
@@ -1026,7 +1028,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_FIRST_RECUR_YEAR(String TM_FIRST_RECUR_YEAR) {
-        this.TM_FIRST_RECUR_YEAR =  StringUtils.isNotEmpty(TM_FIRST_RECUR_YEAR) ? TM_FIRST_RECUR_YEAR : "NA";
+        this.TM_FIRST_RECUR_YEAR =  ClinicalValueUtil.defaultWithNA(TM_FIRST_RECUR_YEAR);
     }
 
     public String getAGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS() {
@@ -1034,7 +1036,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS(String AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS) {
-        this.AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS) ? AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_FIRST_RECUR_DATE_IN_DAYS);
     }
 
     public String getTM_FIRST_RECUR_TYP() {
@@ -1042,7 +1044,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_FIRST_RECUR_TYP(String TM_FIRST_RECUR_TYP) {
-        this.TM_FIRST_RECUR_TYP =  StringUtils.isNotEmpty(TM_FIRST_RECUR_TYP) ? TM_FIRST_RECUR_TYP : "NA";
+        this.TM_FIRST_RECUR_TYP =  ClinicalValueUtil.defaultWithNA(TM_FIRST_RECUR_TYP);
     }
 
     public String getTM_ADM_YEAR() {
@@ -1050,7 +1052,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_ADM_YEAR(String TM_ADM_YEAR) {
-        this.TM_ADM_YEAR =  StringUtils.isNotEmpty(TM_ADM_YEAR) ? TM_ADM_YEAR : "NA";
+        this.TM_ADM_YEAR =  ClinicalValueUtil.defaultWithNA(TM_ADM_YEAR);
     }
 
     public String getAGE_AT_TM_ADM_DATE_IN_DAYS() {
@@ -1058,7 +1060,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_ADM_DATE_IN_DAYS(String AGE_AT_TM_ADM_DATE_IN_DAYS) {
-        this.AGE_AT_TM_ADM_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_ADM_DATE_IN_DAYS) ? AGE_AT_TM_ADM_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_ADM_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_ADM_DATE_IN_DAYS);
     }
 
     public String getTM_DSCH_YEAR() {
@@ -1066,7 +1068,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_DSCH_YEAR(String TM_DSCH_YEAR) {
-        this.TM_DSCH_YEAR =  StringUtils.isNotEmpty(TM_DSCH_YEAR) ? TM_DSCH_YEAR : "NA";
+        this.TM_DSCH_YEAR =  ClinicalValueUtil.defaultWithNA(TM_DSCH_YEAR);
     }
 
     public String getAGE_AT_TM_DSCH_DATE_IN_DAYS() {
@@ -1074,7 +1076,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_DSCH_DATE_IN_DAYS(String AGE_AT_TM_DSCH_DATE_IN_DAYS) {
-        this.AGE_AT_TM_DSCH_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_DSCH_DATE_IN_DAYS) ? AGE_AT_TM_DSCH_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_DSCH_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_DSCH_DATE_IN_DAYS);
     }
 
     public String getTM_SURG_DSCH_YEAR() {
@@ -1082,7 +1084,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_SURG_DSCH_YEAR(String TM_SURG_DSCH_YEAR) {
-        this.TM_SURG_DSCH_YEAR =  StringUtils.isNotEmpty(TM_SURG_DSCH_YEAR) ? TM_SURG_DSCH_YEAR : "NA";
+        this.TM_SURG_DSCH_YEAR =  ClinicalValueUtil.defaultWithNA(TM_SURG_DSCH_YEAR);
     }
 
     public String getAGE_AT_TM_SURG_DSCH_DATE_IN_DAYS() {
@@ -1090,7 +1092,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_SURG_DSCH_DATE_IN_DAYS(String AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS) {
-        this.AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS) ? AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_SURG_DSCH_DATE_IN_DAYS);
     }
 
     public String getTM_READM_WTHN_30D() {
@@ -1098,7 +1100,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_READM_WTHN_30D(String TM_READM_WTHN_30D) {
-        this.TM_READM_WTHN_30D =  StringUtils.isNotEmpty(TM_READM_WTHN_30D) ? TM_READM_WTHN_30D : "NA";
+        this.TM_READM_WTHN_30D =  ClinicalValueUtil.defaultWithNA(TM_READM_WTHN_30D);
     }
 
     public String getTM_FIRST_TX_YEAR() {
@@ -1106,7 +1108,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_FIRST_TX_YEAR(String TM_FIRST_TX_YEAR) {
-        this.TM_FIRST_TX_YEAR =  StringUtils.isNotEmpty(TM_FIRST_TX_YEAR) ? TM_FIRST_TX_YEAR : "NA";
+        this.TM_FIRST_TX_YEAR =  ClinicalValueUtil.defaultWithNA(TM_FIRST_TX_YEAR);
     }
 
     public String getAGE_AT_TM_FIRST_TX_DATE_IN_DAYS() {
@@ -1114,7 +1116,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_FIRST_TX_DATE_IN_DAYS(String AGE_AT_TM_FIRST_TX_DATE_IN_DAYS) {
-        this.AGE_AT_TM_FIRST_TX_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_FIRST_TX_DATE_IN_DAYS) ? AGE_AT_TM_FIRST_TX_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_FIRST_TX_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_FIRST_TX_DATE_IN_DAYS);
     }
 
     public String getTM_NON_CA_SURG_SUM() {
@@ -1122,7 +1124,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_NON_CA_SURG_SUM(String TM_NON_CA_SURG_SUM) {
-        this.TM_NON_CA_SURG_SUM =  StringUtils.isNotEmpty(TM_NON_CA_SURG_SUM) ? TM_NON_CA_SURG_SUM : "NA";
+        this.TM_NON_CA_SURG_SUM =  ClinicalValueUtil.defaultWithNA(TM_NON_CA_SURG_SUM);
     }
 
     public String getTM_NON_CA_SURG_SUM_DESC() {
@@ -1130,7 +1132,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_NON_CA_SURG_SUM_DESC(String TM_NON_CA_SURG_SUM_DESC) {
-        this.TM_NON_CA_SURG_SUM_DESC =  StringUtils.isNotEmpty(TM_NON_CA_SURG_SUM_DESC) ? TM_NON_CA_SURG_SUM_DESC : "NA";
+        this.TM_NON_CA_SURG_SUM_DESC =  ClinicalValueUtil.defaultWithNA(TM_NON_CA_SURG_SUM_DESC);
     }
 
     public String getTM_NON_CA_SURG_MSK() {
@@ -1138,7 +1140,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_NON_CA_SURG_MSK(String TM_NON_CA_SURG_MSK) {
-        this.TM_NON_CA_SURG_MSK =  StringUtils.isNotEmpty(TM_NON_CA_SURG_MSK) ? TM_NON_CA_SURG_MSK : "NA";
+        this.TM_NON_CA_SURG_MSK =  ClinicalValueUtil.defaultWithNA(TM_NON_CA_SURG_MSK);
     }
 
     public String getTM_NON_CA_SURG_YEAR() {
@@ -1146,7 +1148,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_NON_CA_SURG_YEAR(String TM_NON_CA_SURG_YEAR) {
-        this.TM_NON_CA_SURG_YEAR =  StringUtils.isNotEmpty(TM_NON_CA_SURG_YEAR) ? TM_NON_CA_SURG_YEAR : "NA";
+        this.TM_NON_CA_SURG_YEAR =  ClinicalValueUtil.defaultWithNA(TM_NON_CA_SURG_YEAR);
     }
 
     public String getAGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS() {
@@ -1154,7 +1156,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS(String AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS) {
-        this.AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS) ? AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_NON_CA_SURG_DATE_IN_DAYS);
     }
 
     public String getTM_CA_SURG_98() {
@@ -1162,7 +1164,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CA_SURG_98(String TM_CA_SURG_98) {
-        this.TM_CA_SURG_98 =  StringUtils.isNotEmpty(TM_CA_SURG_98) ? TM_CA_SURG_98 : "NA";
+        this.TM_CA_SURG_98 =  ClinicalValueUtil.defaultWithNA(TM_CA_SURG_98);
     }
 
     public String getTM_CA_SURG_98_MSK() {
@@ -1170,7 +1172,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CA_SURG_98_MSK(String TM_CA_SURG_98_MSK) {
-        this.TM_CA_SURG_98_MSK =  StringUtils.isNotEmpty(TM_CA_SURG_98_MSK) ? TM_CA_SURG_98_MSK : "NA";
+        this.TM_CA_SURG_98_MSK =  ClinicalValueUtil.defaultWithNA(TM_CA_SURG_98_MSK);
     }
 
     public String getTM_CA_SURG_03() {
@@ -1178,7 +1180,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CA_SURG_03(String TM_CA_SURG_03) {
-        this.TM_CA_SURG_03 =  StringUtils.isNotEmpty(TM_CA_SURG_03) ? TM_CA_SURG_03 : "NA";
+        this.TM_CA_SURG_03 =  ClinicalValueUtil.defaultWithNA(TM_CA_SURG_03);
     }
 
     public String getTM_CA_SURG_03_MSK() {
@@ -1186,7 +1188,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CA_SURG_03_MSK(String TM_CA_SURG_03_MSK) {
-        this.TM_CA_SURG_03_MSK =  StringUtils.isNotEmpty(TM_CA_SURG_03_MSK) ? TM_CA_SURG_03_MSK : "NA";
+        this.TM_CA_SURG_03_MSK =  ClinicalValueUtil.defaultWithNA(TM_CA_SURG_03_MSK);
     }
 
     public String getTM_OTH_SURG_98() {
@@ -1194,7 +1196,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_SURG_98(String TM_OTH_SURG_98) {
-        this.TM_OTH_SURG_98 =  StringUtils.isNotEmpty(TM_OTH_SURG_98) ? TM_OTH_SURG_98 : "NA";
+        this.TM_OTH_SURG_98 =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_98);
     }
 
     public String getTM_OTH_SURG_98_MSK() {
@@ -1202,7 +1204,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_SURG_98_MSK(String TM_OTH_SURG_98_MSK) {
-        this.TM_OTH_SURG_98_MSK =  StringUtils.isNotEmpty(TM_OTH_SURG_98_MSK) ? TM_OTH_SURG_98_MSK : "NA";
+        this.TM_OTH_SURG_98_MSK =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_98_MSK);
     }
 
     public String getTM_OTH_SURG_03() {
@@ -1210,7 +1212,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_SURG_03(String TM_OTH_SURG_03) {
-        this.TM_OTH_SURG_03 =  StringUtils.isNotEmpty(TM_OTH_SURG_03) ? TM_OTH_SURG_03 : "NA";
+        this.TM_OTH_SURG_03 =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_03);
     }
 
     public String getTM_OTH_SURG_03_MSK() {
@@ -1218,7 +1220,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_SURG_03_MSK(String TM_OTH_SURG_03_MSK) {
-        this.TM_OTH_SURG_03_MSK =  StringUtils.isNotEmpty(TM_OTH_SURG_03_MSK) ? TM_OTH_SURG_03_MSK : "NA";
+        this.TM_OTH_SURG_03_MSK =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_03_MSK);
     }
 
     public String getTM_OTH_SURG_CD() {
@@ -1226,7 +1228,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_SURG_CD(String TM_OTH_SURG_CD) {
-        this.TM_OTH_SURG_CD =  StringUtils.isNotEmpty(TM_OTH_SURG_CD) ? TM_OTH_SURG_CD : "NA";
+        this.TM_OTH_SURG_CD =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_CD);
     }
 
     public String getTM_OTH_SURG_CD_DESC() {
@@ -1234,7 +1236,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_SURG_CD_DESC(String TM_OTH_SURG_CD_DESC) {
-        this.TM_OTH_SURG_CD_DESC =  StringUtils.isNotEmpty(TM_OTH_SURG_CD_DESC) ? TM_OTH_SURG_CD_DESC : "NA";
+        this.TM_OTH_SURG_CD_DESC =  ClinicalValueUtil.defaultWithNA(TM_OTH_SURG_CD_DESC);
     }
 
     public String getTM_RGN_SCOP_98() {
@@ -1242,7 +1244,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RGN_SCOP_98(String TM_RGN_SCOP_98) {
-        this.TM_RGN_SCOP_98 =  StringUtils.isNotEmpty(TM_RGN_SCOP_98) ? TM_RGN_SCOP_98 : "NA";
+        this.TM_RGN_SCOP_98 =  ClinicalValueUtil.defaultWithNA(TM_RGN_SCOP_98);
     }
 
     public String getTM_RGN_SCOP_98_MSK() {
@@ -1250,7 +1252,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RGN_SCOP_98_MSK(String TM_RGN_SCOP_98_MSK) {
-        this.TM_RGN_SCOP_98_MSK =  StringUtils.isNotEmpty(TM_RGN_SCOP_98_MSK) ? TM_RGN_SCOP_98_MSK : "NA";
+        this.TM_RGN_SCOP_98_MSK =  ClinicalValueUtil.defaultWithNA(TM_RGN_SCOP_98_MSK);
     }
 
     public String getTM_RGN_SCOP_03() {
@@ -1258,7 +1260,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RGN_SCOP_03(String TM_RGN_SCOP_03) {
-        this.TM_RGN_SCOP_03 =  StringUtils.isNotEmpty(TM_RGN_SCOP_03) ? TM_RGN_SCOP_03 : "NA";
+        this.TM_RGN_SCOP_03 =  ClinicalValueUtil.defaultWithNA(TM_RGN_SCOP_03);
     }
 
     public String getTM_RGN_SCOP_03_MSK() {
@@ -1266,7 +1268,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RGN_SCOP_03_MSK(String TM_RGN_SCOP_03_MSK) {
-        this.TM_RGN_SCOP_03_MSK =  StringUtils.isNotEmpty(TM_RGN_SCOP_03_MSK) ? TM_RGN_SCOP_03_MSK : "NA";
+        this.TM_RGN_SCOP_03_MSK =  ClinicalValueUtil.defaultWithNA(TM_RGN_SCOP_03_MSK);
     }
 
     public String getTM_REGNODE_SCOP_CD() {
@@ -1274,7 +1276,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_REGNODE_SCOP_CD(String TM_REGNODE_SCOP_CD) {
-        this.TM_REGNODE_SCOP_CD =  StringUtils.isNotEmpty(TM_REGNODE_SCOP_CD) ? TM_REGNODE_SCOP_CD : "NA";
+        this.TM_REGNODE_SCOP_CD =  ClinicalValueUtil.defaultWithNA(TM_REGNODE_SCOP_CD);
     }
 
     public String getTM_REGNODE_SCOP_DESC() {
@@ -1282,7 +1284,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_REGNODE_SCOP_DESC(String TM_REGNODE_SCOP_DESC) {
-        this.TM_REGNODE_SCOP_DESC =  StringUtils.isNotEmpty(TM_REGNODE_SCOP_DESC) ? TM_REGNODE_SCOP_DESC : "NA";
+        this.TM_REGNODE_SCOP_DESC =  ClinicalValueUtil.defaultWithNA(TM_REGNODE_SCOP_DESC);
     }
 
     public String getTM_RECON_SURG() {
@@ -1290,7 +1292,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RECON_SURG(String TM_RECON_SURG) {
-        this.TM_RECON_SURG =  StringUtils.isNotEmpty(TM_RECON_SURG) ? TM_RECON_SURG : "NA";
+        this.TM_RECON_SURG =  ClinicalValueUtil.defaultWithNA(TM_RECON_SURG);
     }
 
     public String getTM_RECON_SURG_DESC() {
@@ -1298,7 +1300,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RECON_SURG_DESC(String TM_RECON_SURG_DESC) {
-        this.TM_RECON_SURG_DESC =  StringUtils.isNotEmpty(TM_RECON_SURG_DESC) ? TM_RECON_SURG_DESC : "NA";
+        this.TM_RECON_SURG_DESC =  ClinicalValueUtil.defaultWithNA(TM_RECON_SURG_DESC);
     }
 
     public String getTM_CA_SURG_YEAR() {
@@ -1306,7 +1308,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CA_SURG_YEAR(String TM_CA_SURG_YEAR) {
-        this.TM_CA_SURG_YEAR =  StringUtils.isNotEmpty(TM_CA_SURG_YEAR) ? TM_CA_SURG_YEAR : "NA";
+        this.TM_CA_SURG_YEAR =  ClinicalValueUtil.defaultWithNA(TM_CA_SURG_YEAR);
     }
 
     public String getAGE_AT_TM_CA_SURG_DATE_IN_DAYS() {
@@ -1314,7 +1316,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_CA_SURG_DATE_IN_DAYS(String AGE_AT_TM_CA_SURG_DATE_IN_DAYS) {
-        this.AGE_AT_TM_CA_SURG_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_CA_SURG_DATE_IN_DAYS) ? AGE_AT_TM_CA_SURG_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_CA_SURG_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_CA_SURG_DATE_IN_DAYS);
     }
 
     public String getTM_SURG_DEF_YEAR() {
@@ -1322,7 +1324,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_SURG_DEF_YEAR(String TM_SURG_DEF_YEAR) {
-        this.TM_SURG_DEF_YEAR =  StringUtils.isNotEmpty(TM_SURG_DEF_YEAR) ? TM_SURG_DEF_YEAR : "NA";
+        this.TM_SURG_DEF_YEAR =  ClinicalValueUtil.defaultWithNA(TM_SURG_DEF_YEAR);
     }
 
     public String getAGE_AT_TM_SURG_DEF_DATE_IN_DAYS() {
@@ -1330,7 +1332,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_SURG_DEF_DATE_IN_DAYS(String AGE_AT_TM_SURG_DEF_DATE_IN_DAYS) {
-        this.AGE_AT_TM_SURG_DEF_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_SURG_DEF_DATE_IN_DAYS) ? AGE_AT_TM_SURG_DEF_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_SURG_DEF_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_SURG_DEF_DATE_IN_DAYS);
     }
 
     public String getTM_REASON_NO_SURG() {
@@ -1338,7 +1340,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_REASON_NO_SURG(String TM_REASON_NO_SURG) {
-        this.TM_REASON_NO_SURG =  StringUtils.isNotEmpty(TM_REASON_NO_SURG) ? TM_REASON_NO_SURG : "NA";
+        this.TM_REASON_NO_SURG =  ClinicalValueUtil.defaultWithNA(TM_REASON_NO_SURG);
     }
 
     public String getREASON_NO_SURG_DESC() {
@@ -1346,7 +1348,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setREASON_NO_SURG_DESC(String REASON_NO_SURG_DESC) {
-        this.REASON_NO_SURG_DESC =  StringUtils.isNotEmpty(REASON_NO_SURG_DESC) ? REASON_NO_SURG_DESC : "NA";
+        this.REASON_NO_SURG_DESC =  ClinicalValueUtil.defaultWithNA(REASON_NO_SURG_DESC);
     }
 
     public String getTM_PRIM_SURGEON() {
@@ -1354,7 +1356,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PRIM_SURGEON(String TM_PRIM_SURGEON) {
-        this.TM_PRIM_SURGEON =  StringUtils.isNotEmpty(TM_PRIM_SURGEON) ? TM_PRIM_SURGEON : "NA";
+        this.TM_PRIM_SURGEON =  ClinicalValueUtil.defaultWithNA(TM_PRIM_SURGEON);
     }
 
     public String getTM_PRIM_SURGEON_NAME() {
@@ -1362,7 +1364,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PRIM_SURGEON_NAME(String TM_PRIM_SURGEON_NAME) {
-        this.TM_PRIM_SURGEON_NAME =  StringUtils.isNotEmpty(TM_PRIM_SURGEON_NAME) ? TM_PRIM_SURGEON_NAME : "NA";
+        this.TM_PRIM_SURGEON_NAME =  ClinicalValueUtil.defaultWithNA(TM_PRIM_SURGEON_NAME);
     }
 
     public String getTM_ATN_DR_NO() {
@@ -1370,7 +1372,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_ATN_DR_NO(String TM_ATN_DR_NO) {
-        this.TM_ATN_DR_NO =  StringUtils.isNotEmpty(TM_ATN_DR_NO) ? TM_ATN_DR_NO : "NA";
+        this.TM_ATN_DR_NO =  ClinicalValueUtil.defaultWithNA(TM_ATN_DR_NO);
     }
 
     public String getTM_ATN_DR_NAME() {
@@ -1378,7 +1380,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_ATN_DR_NAME(String TM_ATN_DR_NAME) {
-        this.TM_ATN_DR_NAME =  StringUtils.isNotEmpty(TM_ATN_DR_NAME) ? TM_ATN_DR_NAME : "NA";
+        this.TM_ATN_DR_NAME =  ClinicalValueUtil.defaultWithNA(TM_ATN_DR_NAME);
     }
 
     public String getTM_REASON_NO_RAD() {
@@ -1386,7 +1388,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_REASON_NO_RAD(String TM_REASON_NO_RAD) {
-        this.TM_REASON_NO_RAD =  StringUtils.isNotEmpty(TM_REASON_NO_RAD) ? TM_REASON_NO_RAD : "NA";
+        this.TM_REASON_NO_RAD =  ClinicalValueUtil.defaultWithNA(TM_REASON_NO_RAD);
     }
 
     public String getTM_REASON_NO_RAD_DESC() {
@@ -1394,7 +1396,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_REASON_NO_RAD_DESC(String TM_REASON_NO_RAD_DESC) {
-        this.TM_REASON_NO_RAD_DESC =  StringUtils.isNotEmpty(TM_REASON_NO_RAD_DESC) ? TM_REASON_NO_RAD_DESC : "NA";
+        this.TM_REASON_NO_RAD_DESC =  ClinicalValueUtil.defaultWithNA(TM_REASON_NO_RAD_DESC);
     }
 
     public String getTM_RAD_STRT_YEAR() {
@@ -1402,7 +1404,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RAD_STRT_YEAR(String TM_RAD_STRT_YEAR) {
-        this.TM_RAD_STRT_YEAR =  StringUtils.isNotEmpty(TM_RAD_STRT_YEAR) ? TM_RAD_STRT_YEAR : "NA";
+        this.TM_RAD_STRT_YEAR =  ClinicalValueUtil.defaultWithNA(TM_RAD_STRT_YEAR);
     }
 
     public String getAGE_AT_TM_RAD_STRT_DATE_IN_DAYS() {
@@ -1410,7 +1412,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_RAD_STRT_DATE_IN_DAYS(String AGE_AT_TM_RAD_STRT_DATE_IN_DAYS) {
-        this.AGE_AT_TM_RAD_STRT_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_RAD_STRT_DATE_IN_DAYS) ? AGE_AT_TM_RAD_STRT_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_RAD_STRT_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_RAD_STRT_DATE_IN_DAYS);
     }
 
     public String getTM_RAD_END_YEAR() {
@@ -1418,7 +1420,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RAD_END_YEAR(String TM_RAD_END_YEAR) {
-        this.TM_RAD_END_YEAR =  StringUtils.isNotEmpty(TM_RAD_END_YEAR) ? TM_RAD_END_YEAR : "NA";
+        this.TM_RAD_END_YEAR =  ClinicalValueUtil.defaultWithNA(TM_RAD_END_YEAR);
     }
 
     public String getAGE_AT_TM_RAD_END_DATE_IN_DAYS() {
@@ -1426,7 +1428,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_RAD_END_DATE_IN_DAYS(String AGE_AT_TM_RAD_END_DATE_IN_DAYS) {
-        this.AGE_AT_TM_RAD_END_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_RAD_END_DATE_IN_DAYS) ? AGE_AT_TM_RAD_END_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_RAD_END_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_RAD_END_DATE_IN_DAYS);
     }
 
     public String getTM_RAD_TX_MOD() {
@@ -1434,7 +1436,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RAD_TX_MOD(String TM_RAD_TX_MOD) {
-        this.TM_RAD_TX_MOD =  StringUtils.isNotEmpty(TM_RAD_TX_MOD) ? TM_RAD_TX_MOD : "NA";
+        this.TM_RAD_TX_MOD =  ClinicalValueUtil.defaultWithNA(TM_RAD_TX_MOD);
     }
 
     public String getTM_RAD_TX_MOD_DESC() {
@@ -1442,7 +1444,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RAD_TX_MOD_DESC(String TM_RAD_TX_MOD_DESC) {
-        this.TM_RAD_TX_MOD_DESC =  StringUtils.isNotEmpty(TM_RAD_TX_MOD_DESC) ? TM_RAD_TX_MOD_DESC : "NA";
+        this.TM_RAD_TX_MOD_DESC =  ClinicalValueUtil.defaultWithNA(TM_RAD_TX_MOD_DESC);
     }
 
     public String getTM_BOOST_RAD_MOD() {
@@ -1450,7 +1452,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_BOOST_RAD_MOD(String TM_BOOST_RAD_MOD) {
-        this.TM_BOOST_RAD_MOD =  StringUtils.isNotEmpty(TM_BOOST_RAD_MOD) ? TM_BOOST_RAD_MOD : "NA";
+        this.TM_BOOST_RAD_MOD =  ClinicalValueUtil.defaultWithNA(TM_BOOST_RAD_MOD);
     }
 
     public String getTM_BOOST_RAD_MOD_DESC() {
@@ -1458,7 +1460,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_BOOST_RAD_MOD_DESC(String TM_BOOST_RAD_MOD_DESC) {
-        this.TM_BOOST_RAD_MOD_DESC =  StringUtils.isNotEmpty(TM_BOOST_RAD_MOD_DESC) ? TM_BOOST_RAD_MOD_DESC : "NA";
+        this.TM_BOOST_RAD_MOD_DESC =  ClinicalValueUtil.defaultWithNA(TM_BOOST_RAD_MOD_DESC);
     }
 
     public String getTM_LOC_RAD_TX() {
@@ -1466,7 +1468,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_LOC_RAD_TX(String TM_LOC_RAD_TX) {
-        this.TM_LOC_RAD_TX =  StringUtils.isNotEmpty(TM_LOC_RAD_TX) ? TM_LOC_RAD_TX : "NA";
+        this.TM_LOC_RAD_TX =  ClinicalValueUtil.defaultWithNA(TM_LOC_RAD_TX);
     }
 
     public String getTM_LOC_RAD_TX_DESC() {
@@ -1474,7 +1476,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_LOC_RAD_TX_DESC(String TM_LOC_RAD_TX_DESC) {
-        this.TM_LOC_RAD_TX_DESC =  StringUtils.isNotEmpty(TM_LOC_RAD_TX_DESC) ? TM_LOC_RAD_TX_DESC : "NA";
+        this.TM_LOC_RAD_TX_DESC =  ClinicalValueUtil.defaultWithNA(TM_LOC_RAD_TX_DESC);
     }
 
     public String getTM_RAD_TX_VOL() {
@@ -1482,7 +1484,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RAD_TX_VOL(String TM_RAD_TX_VOL) {
-        this.TM_RAD_TX_VOL =  StringUtils.isNotEmpty(TM_RAD_TX_VOL) ? TM_RAD_TX_VOL : "NA";
+        this.TM_RAD_TX_VOL =  ClinicalValueUtil.defaultWithNA(TM_RAD_TX_VOL);
     }
 
     public String getTM_RAD_TX_VOL_DESC() {
@@ -1490,7 +1492,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RAD_TX_VOL_DESC(String TM_RAD_TX_VOL_DESC) {
-        this.TM_RAD_TX_VOL_DESC =  StringUtils.isNotEmpty(TM_RAD_TX_VOL_DESC) ? TM_RAD_TX_VOL_DESC : "NA";
+        this.TM_RAD_TX_VOL_DESC =  ClinicalValueUtil.defaultWithNA(TM_RAD_TX_VOL_DESC);
     }
 
     public String getTM_NUM_TX_THIS_VOL() {
@@ -1498,7 +1500,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_NUM_TX_THIS_VOL(String TM_NUM_TX_THIS_VOL) {
-        this.TM_NUM_TX_THIS_VOL =  StringUtils.isNotEmpty(TM_NUM_TX_THIS_VOL) ? TM_NUM_TX_THIS_VOL : "NA";
+        this.TM_NUM_TX_THIS_VOL =  ClinicalValueUtil.defaultWithNA(TM_NUM_TX_THIS_VOL);
     }
 
     public String getTM_NUM_TX_THIS_VOL_DESC() {
@@ -1506,7 +1508,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_NUM_TX_THIS_VOL_DESC(String TM_NUM_TX_THIS_VOL_DESC) {
-        this.TM_NUM_TX_THIS_VOL_DESC =  StringUtils.isNotEmpty(TM_NUM_TX_THIS_VOL_DESC) ? TM_NUM_TX_THIS_VOL_DESC : "NA";
+        this.TM_NUM_TX_THIS_VOL_DESC =  ClinicalValueUtil.defaultWithNA(TM_NUM_TX_THIS_VOL_DESC);
     }
 
     public String getTM_REG_RAD_DOSE() {
@@ -1514,7 +1516,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_REG_RAD_DOSE(String TM_REG_RAD_DOSE) {
-        this.TM_REG_RAD_DOSE =  StringUtils.isNotEmpty(TM_REG_RAD_DOSE) ? TM_REG_RAD_DOSE : "NA";
+        this.TM_REG_RAD_DOSE =  ClinicalValueUtil.defaultWithNA(TM_REG_RAD_DOSE);
     }
 
     public String getTM_REG_RAD_DOSE_DESC() {
@@ -1522,7 +1524,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_REG_RAD_DOSE_DESC(String TM_REG_RAD_DOSE_DESC) {
-        this.TM_REG_RAD_DOSE_DESC =  StringUtils.isNotEmpty(TM_REG_RAD_DOSE_DESC) ? TM_REG_RAD_DOSE_DESC : "NA";
+        this.TM_REG_RAD_DOSE_DESC =  ClinicalValueUtil.defaultWithNA(TM_REG_RAD_DOSE_DESC);
     }
 
     public String getTM_BOOST_RAD_DOSE() {
@@ -1530,7 +1532,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_BOOST_RAD_DOSE(String TM_BOOST_RAD_DOSE) {
-        this.TM_BOOST_RAD_DOSE =  StringUtils.isNotEmpty(TM_BOOST_RAD_DOSE) ? TM_BOOST_RAD_DOSE : "NA";
+        this.TM_BOOST_RAD_DOSE =  ClinicalValueUtil.defaultWithNA(TM_BOOST_RAD_DOSE);
     }
 
     public String getTM_BOOST_RAD_DOSE_DESC() {
@@ -1538,7 +1540,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_BOOST_RAD_DOSE_DESC(String TM_BOOST_RAD_DOSE_DESC) {
-        this.TM_BOOST_RAD_DOSE_DESC =  StringUtils.isNotEmpty(TM_BOOST_RAD_DOSE_DESC) ? TM_BOOST_RAD_DOSE_DESC : "NA";
+        this.TM_BOOST_RAD_DOSE_DESC =  ClinicalValueUtil.defaultWithNA(TM_BOOST_RAD_DOSE_DESC);
     }
 
     public String getTM_RAD_SURG_SEQ() {
@@ -1546,7 +1548,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RAD_SURG_SEQ(String TM_RAD_SURG_SEQ) {
-        this.TM_RAD_SURG_SEQ =  StringUtils.isNotEmpty(TM_RAD_SURG_SEQ) ? TM_RAD_SURG_SEQ : "NA";
+        this.TM_RAD_SURG_SEQ =  ClinicalValueUtil.defaultWithNA(TM_RAD_SURG_SEQ);
     }
 
     public String getTM_RAD_SURG_SEQ_DESC() {
@@ -1554,7 +1556,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RAD_SURG_SEQ_DESC(String TM_RAD_SURG_SEQ_DESC) {
-        this.TM_RAD_SURG_SEQ_DESC =  StringUtils.isNotEmpty(TM_RAD_SURG_SEQ_DESC) ? TM_RAD_SURG_SEQ_DESC : "NA";
+        this.TM_RAD_SURG_SEQ_DESC =  ClinicalValueUtil.defaultWithNA(TM_RAD_SURG_SEQ_DESC);
     }
 
     public String getTM_RAD_MD() {
@@ -1562,7 +1564,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RAD_MD(String TM_RAD_MD) {
-        this.TM_RAD_MD =  StringUtils.isNotEmpty(TM_RAD_MD) ? TM_RAD_MD : "NA";
+        this.TM_RAD_MD =  ClinicalValueUtil.defaultWithNA(TM_RAD_MD);
     }
 
     public String getTM_RAD_MD_NAME() {
@@ -1570,7 +1572,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_RAD_MD_NAME(String TM_RAD_MD_NAME) {
-        this.TM_RAD_MD_NAME =  StringUtils.isNotEmpty(TM_RAD_MD_NAME) ? TM_RAD_MD_NAME : "NA";
+        this.TM_RAD_MD_NAME =  ClinicalValueUtil.defaultWithNA(TM_RAD_MD_NAME);
     }
 
     public String getTM_SYST_STRT_YEAR() {
@@ -1578,7 +1580,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_SYST_STRT_YEAR(String TM_SYST_STRT_YEAR) {
-        this.TM_SYST_STRT_YEAR =  StringUtils.isNotEmpty(TM_SYST_STRT_YEAR) ? TM_SYST_STRT_YEAR : "NA";
+        this.TM_SYST_STRT_YEAR =  ClinicalValueUtil.defaultWithNA(TM_SYST_STRT_YEAR);
     }
 
     public String getAGE_AT_TM_SYST_STRT_DATE_IN_DAYS() {
@@ -1586,7 +1588,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_SYST_STRT_DATE_IN_DAYS(String AGE_AT_TM_SYST_STRT_DATE_IN_DAYS) {
-        this.AGE_AT_TM_SYST_STRT_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_SYST_STRT_DATE_IN_DAYS) ? AGE_AT_TM_SYST_STRT_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_SYST_STRT_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_SYST_STRT_DATE_IN_DAYS);
     }
 
     public String getTM_OTH_STRT_YEAR() {
@@ -1594,7 +1596,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_STRT_YEAR(String TM_OTH_STRT_YEAR) {
-        this.TM_OTH_STRT_YEAR =  StringUtils.isNotEmpty(TM_OTH_STRT_YEAR) ? TM_OTH_STRT_YEAR : "NA";
+        this.TM_OTH_STRT_YEAR =  ClinicalValueUtil.defaultWithNA(TM_OTH_STRT_YEAR);
     }
 
     public String getAGE_AT_TM_OTH_STRT_DATE_IN_DAYS() {
@@ -1602,7 +1604,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_OTH_STRT_DATE_IN_DAYS(String AGE_AT_TM_OTH_STRT_DATE_IN_DAYS) {
-        this.AGE_AT_TM_OTH_STRT_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_OTH_STRT_DATE_IN_DAYS) ? AGE_AT_TM_OTH_STRT_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_OTH_STRT_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_OTH_STRT_DATE_IN_DAYS);
     }
 
     public String getTM_CHEM_SUM() {
@@ -1610,7 +1612,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CHEM_SUM(String TM_CHEM_SUM) {
-        this.TM_CHEM_SUM =  StringUtils.isNotEmpty(TM_CHEM_SUM) ? TM_CHEM_SUM : "NA";
+        this.TM_CHEM_SUM =  ClinicalValueUtil.defaultWithNA(TM_CHEM_SUM);
     }
 
     public String getTM_CHEM_SUM_DESC() {
@@ -1618,7 +1620,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CHEM_SUM_DESC(String TM_CHEM_SUM_DESC) {
-        this.TM_CHEM_SUM_DESC =  StringUtils.isNotEmpty(TM_CHEM_SUM_DESC) ? TM_CHEM_SUM_DESC : "NA";
+        this.TM_CHEM_SUM_DESC =  ClinicalValueUtil.defaultWithNA(TM_CHEM_SUM_DESC);
     }
 
     public String getTM_CHEM_SUM_MSK() {
@@ -1626,7 +1628,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CHEM_SUM_MSK(String TM_CHEM_SUM_MSK) {
-        this.TM_CHEM_SUM_MSK =  StringUtils.isNotEmpty(TM_CHEM_SUM_MSK) ? TM_CHEM_SUM_MSK : "NA";
+        this.TM_CHEM_SUM_MSK =  ClinicalValueUtil.defaultWithNA(TM_CHEM_SUM_MSK);
     }
 
     public String getTM_CHEM_SUM_MSK_DESC() {
@@ -1634,7 +1636,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CHEM_SUM_MSK_DESC(String TM_CHEM_SUM_MSK_DESC) {
-        this.TM_CHEM_SUM_MSK_DESC =  StringUtils.isNotEmpty(TM_CHEM_SUM_MSK_DESC) ? TM_CHEM_SUM_MSK_DESC : "NA";
+        this.TM_CHEM_SUM_MSK_DESC =  ClinicalValueUtil.defaultWithNA(TM_CHEM_SUM_MSK_DESC);
     }
 
     public String getTM_TUMOR_SEQ() {
@@ -1642,7 +1644,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_TUMOR_SEQ(String TM_TUMOR_SEQ) {
-        this.TM_TUMOR_SEQ =  StringUtils.isNotEmpty(TM_TUMOR_SEQ) ? TM_TUMOR_SEQ : "NA";
+        this.TM_TUMOR_SEQ =  ClinicalValueUtil.defaultWithNA(TM_TUMOR_SEQ);
     }
 
     public String getTM_HORM_SUM() {
@@ -1650,7 +1652,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_HORM_SUM(String TM_HORM_SUM) {
-        this.TM_HORM_SUM =  StringUtils.isNotEmpty(TM_HORM_SUM) ? TM_HORM_SUM : "NA";
+        this.TM_HORM_SUM =  ClinicalValueUtil.defaultWithNA(TM_HORM_SUM);
     }
 
     public String getTM_HORM_SUM_DESC() {
@@ -1658,7 +1660,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_HORM_SUM_DESC(String TM_HORM_SUM_DESC) {
-        this.TM_HORM_SUM_DESC =  StringUtils.isNotEmpty(TM_HORM_SUM_DESC) ? TM_HORM_SUM_DESC : "NA";
+        this.TM_HORM_SUM_DESC =  ClinicalValueUtil.defaultWithNA(TM_HORM_SUM_DESC);
     }
 
     public String getTM_HORM_SUM_MSK() {
@@ -1666,7 +1668,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_HORM_SUM_MSK(String TM_HORM_SUM_MSK) {
-        this.TM_HORM_SUM_MSK =  StringUtils.isNotEmpty(TM_HORM_SUM_MSK) ? TM_HORM_SUM_MSK : "NA";
+        this.TM_HORM_SUM_MSK =  ClinicalValueUtil.defaultWithNA(TM_HORM_SUM_MSK);
     }
 
     public String getTM_HORM_SUM_MSK_DESC() {
@@ -1674,7 +1676,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_HORM_SUM_MSK_DESC(String TM_HORM_SUM_MSK_DESC) {
-        this.TM_HORM_SUM_MSK_DESC =  StringUtils.isNotEmpty(TM_HORM_SUM_MSK_DESC) ? TM_HORM_SUM_MSK_DESC : "NA";
+        this.TM_HORM_SUM_MSK_DESC =  ClinicalValueUtil.defaultWithNA(TM_HORM_SUM_MSK_DESC);
     }
 
     public String getTM_BRM_SUM() {
@@ -1682,7 +1684,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_BRM_SUM(String TM_BRM_SUM) {
-        this.TM_BRM_SUM =  StringUtils.isNotEmpty(TM_BRM_SUM) ? TM_BRM_SUM : "NA";
+        this.TM_BRM_SUM =  ClinicalValueUtil.defaultWithNA(TM_BRM_SUM);
     }
 
     public String getTM_BRM_SUM_DESC() {
@@ -1690,7 +1692,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_BRM_SUM_DESC(String TM_BRM_SUM_DESC) {
-        this.TM_BRM_SUM_DESC =  StringUtils.isNotEmpty(TM_BRM_SUM_DESC) ? TM_BRM_SUM_DESC : "NA";
+        this.TM_BRM_SUM_DESC =  ClinicalValueUtil.defaultWithNA(TM_BRM_SUM_DESC);
     }
 
     public String getTM_BRM_SUM_MSK() {
@@ -1698,7 +1700,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_BRM_SUM_MSK(String TM_BRM_SUM_MSK) {
-        this.TM_BRM_SUM_MSK =  StringUtils.isNotEmpty(TM_BRM_SUM_MSK) ? TM_BRM_SUM_MSK : "NA";
+        this.TM_BRM_SUM_MSK =  ClinicalValueUtil.defaultWithNA(TM_BRM_SUM_MSK);
     }
 
     public String getTM_BRM_SUM_MSK_DESC() {
@@ -1706,7 +1708,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_BRM_SUM_MSK_DESC(String TM_BRM_SUM_MSK_DESC) {
-        this.TM_BRM_SUM_MSK_DESC =  StringUtils.isNotEmpty(TM_BRM_SUM_MSK_DESC) ? TM_BRM_SUM_MSK_DESC : "NA";
+        this.TM_BRM_SUM_MSK_DESC =  ClinicalValueUtil.defaultWithNA(TM_BRM_SUM_MSK_DESC);
     }
 
     public String getTM_OTH_SUM() {
@@ -1714,7 +1716,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_SUM(String TM_OTH_SUM) {
-        this.TM_OTH_SUM =  StringUtils.isNotEmpty(TM_OTH_SUM) ? TM_OTH_SUM : "NA";
+        this.TM_OTH_SUM =  ClinicalValueUtil.defaultWithNA(TM_OTH_SUM);
     }
 
     public String getTM_OTH_SUM_DESC() {
@@ -1722,7 +1724,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_SUM_DESC(String TM_OTH_SUM_DESC) {
-        this.TM_OTH_SUM_DESC =  StringUtils.isNotEmpty(TM_OTH_SUM_DESC) ? TM_OTH_SUM_DESC : "NA";
+        this.TM_OTH_SUM_DESC =  ClinicalValueUtil.defaultWithNA(TM_OTH_SUM_DESC);
     }
 
     public String getTM_OTH_SUM_MSK() {
@@ -1730,7 +1732,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_SUM_MSK(String TM_OTH_SUM_MSK) {
-        this.TM_OTH_SUM_MSK =  StringUtils.isNotEmpty(TM_OTH_SUM_MSK) ? TM_OTH_SUM_MSK : "NA";
+        this.TM_OTH_SUM_MSK =  ClinicalValueUtil.defaultWithNA(TM_OTH_SUM_MSK);
     }
 
     public String getTM_OTH_SUM_MSK_DESC() {
@@ -1738,7 +1740,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OTH_SUM_MSK_DESC(String TM_OTH_SUM_MSK_DESC) {
-        this.TM_OTH_SUM_MSK_DESC =  StringUtils.isNotEmpty(TM_OTH_SUM_MSK_DESC) ? TM_OTH_SUM_MSK_DESC : "NA";
+        this.TM_OTH_SUM_MSK_DESC =  ClinicalValueUtil.defaultWithNA(TM_OTH_SUM_MSK_DESC);
     }
 
     public String getTM_PALLIA_PROC() {
@@ -1746,7 +1748,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PALLIA_PROC(String TM_PALLIA_PROC) {
-        this.TM_PALLIA_PROC =  StringUtils.isNotEmpty(TM_PALLIA_PROC) ? TM_PALLIA_PROC : "NA";
+        this.TM_PALLIA_PROC =  ClinicalValueUtil.defaultWithNA(TM_PALLIA_PROC);
     }
 
     public String getTM_PALLIA_PROC_DESC() {
@@ -1754,7 +1756,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PALLIA_PROC_DESC(String TM_PALLIA_PROC_DESC) {
-        this.TM_PALLIA_PROC_DESC =  StringUtils.isNotEmpty(TM_PALLIA_PROC_DESC) ? TM_PALLIA_PROC_DESC : "NA";
+        this.TM_PALLIA_PROC_DESC =  ClinicalValueUtil.defaultWithNA(TM_PALLIA_PROC_DESC);
     }
 
     public String getTM_PALLIA_PROC_MSK() {
@@ -1762,7 +1764,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PALLIA_PROC_MSK(String TM_PALLIA_PROC_MSK) {
-        this.TM_PALLIA_PROC_MSK =  StringUtils.isNotEmpty(TM_PALLIA_PROC_MSK) ? TM_PALLIA_PROC_MSK : "NA";
+        this.TM_PALLIA_PROC_MSK =  ClinicalValueUtil.defaultWithNA(TM_PALLIA_PROC_MSK);
     }
 
     public String getTM_PALLIA_PROC_MSK_DESC() {
@@ -1770,7 +1772,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PALLIA_PROC_MSK_DESC(String TM_PALLIA_PROC_MSK_DESC) {
-        this.TM_PALLIA_PROC_MSK_DESC =  StringUtils.isNotEmpty(TM_PALLIA_PROC_MSK_DESC) ? TM_PALLIA_PROC_MSK_DESC : "NA";
+        this.TM_PALLIA_PROC_MSK_DESC =  ClinicalValueUtil.defaultWithNA(TM_PALLIA_PROC_MSK_DESC);
     }
 
     public String getTM_ONCOLOGY_MD() {
@@ -1778,7 +1780,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_ONCOLOGY_MD(String TM_ONCOLOGY_MD) {
-        this.TM_ONCOLOGY_MD =  StringUtils.isNotEmpty(TM_ONCOLOGY_MD) ? TM_ONCOLOGY_MD : "NA";
+        this.TM_ONCOLOGY_MD =  ClinicalValueUtil.defaultWithNA(TM_ONCOLOGY_MD);
     }
 
     public String getTM_ONCOLOGY_MD_NAME() {
@@ -1786,7 +1788,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_ONCOLOGY_MD_NAME(String TM_ONCOLOGY_MD_NAME) {
-        this.TM_ONCOLOGY_MD_NAME =  StringUtils.isNotEmpty(TM_ONCOLOGY_MD_NAME) ? TM_ONCOLOGY_MD_NAME : "NA";
+        this.TM_ONCOLOGY_MD_NAME =  ClinicalValueUtil.defaultWithNA(TM_ONCOLOGY_MD_NAME);
     }
 
     public String getTM_PRCS_YEAR() {
@@ -1794,7 +1796,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PRCS_YEAR(String TM_PRCS_YEAR) {
-        this.TM_PRCS_YEAR =  StringUtils.isNotEmpty(TM_PRCS_YEAR) ? TM_PRCS_YEAR : "NA";
+        this.TM_PRCS_YEAR =  ClinicalValueUtil.defaultWithNA(TM_PRCS_YEAR);
     }
 
     public String getAGE_AT_TM_PRCS_DATE_IN_DAYS() {
@@ -1802,7 +1804,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setAGE_AT_TM_PRCS_DATE_IN_DAYS(String AGE_AT_TM_PRCS_DATE_IN_DAYS) {
-        this.AGE_AT_TM_PRCS_DATE_IN_DAYS =  StringUtils.isNotEmpty(AGE_AT_TM_PRCS_DATE_IN_DAYS) ? AGE_AT_TM_PRCS_DATE_IN_DAYS : "NA";
+        this.AGE_AT_TM_PRCS_DATE_IN_DAYS =  ClinicalValueUtil.defaultWithNA(AGE_AT_TM_PRCS_DATE_IN_DAYS);
     }
 
     public String getTM_PATH_TEXT() {
@@ -1810,7 +1812,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_PATH_TEXT(String TM_PATH_TEXT) {
-        this.TM_PATH_TEXT =  StringUtils.isNotEmpty(TM_PATH_TEXT) ? TM_PATH_TEXT : "NA";
+        this.TM_PATH_TEXT =  ClinicalValueUtil.defaultWithNA(TM_PATH_TEXT);
     }
 
     public String getTM_SURG_TEXT() {
@@ -1818,7 +1820,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_SURG_TEXT(String TM_SURG_TEXT) {
-        this.TM_SURG_TEXT =  StringUtils.isNotEmpty(TM_SURG_TEXT) ? TM_SURG_TEXT : "NA";
+        this.TM_SURG_TEXT =  ClinicalValueUtil.defaultWithNA(TM_SURG_TEXT);
     }
 
     public String getTM_OVERRIDE_COM() {
@@ -1826,7 +1828,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_OVERRIDE_COM(String TM_OVERRIDE_COM) {
-        this.TM_OVERRIDE_COM =  StringUtils.isNotEmpty(TM_OVERRIDE_COM) ? TM_OVERRIDE_COM : "NA";
+        this.TM_OVERRIDE_COM =  ClinicalValueUtil.defaultWithNA(TM_OVERRIDE_COM);
     }
 
     public String getTM_CSSIZE() {
@@ -1834,7 +1836,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CSSIZE(String TM_CSSIZE) {
-        this.TM_CSSIZE =  StringUtils.isNotEmpty(TM_CSSIZE) ? TM_CSSIZE : "NA";
+        this.TM_CSSIZE =  ClinicalValueUtil.defaultWithNA(TM_CSSIZE);
     }
 
     public String getTM_CSEXT() {
@@ -1842,7 +1844,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CSEXT(String TM_CSEXT) {
-        this.TM_CSEXT =  StringUtils.isNotEmpty(TM_CSEXT) ? TM_CSEXT : "NA";
+        this.TM_CSEXT =  ClinicalValueUtil.defaultWithNA(TM_CSEXT);
     }
 
     public String getTM_CSEXTEV() {
@@ -1850,7 +1852,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CSEXTEV(String TM_CSEXTEV) {
-        this.TM_CSEXTEV =  StringUtils.isNotEmpty(TM_CSEXTEV) ? TM_CSEXTEV : "NA";
+        this.TM_CSEXTEV =  ClinicalValueUtil.defaultWithNA(TM_CSEXTEV);
     }
 
     public String getTM_CSLMND() {
@@ -1858,7 +1860,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CSLMND(String TM_CSLMND) {
-        this.TM_CSLMND =  StringUtils.isNotEmpty(TM_CSLMND) ? TM_CSLMND : "NA";
+        this.TM_CSLMND =  ClinicalValueUtil.defaultWithNA(TM_CSLMND);
     }
 
     public String getTM_CSRGNEV() {
@@ -1866,7 +1868,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CSRGNEV(String TM_CSRGNEV) {
-        this.TM_CSRGNEV =  StringUtils.isNotEmpty(TM_CSRGNEV) ? TM_CSRGNEV : "NA";
+        this.TM_CSRGNEV =  ClinicalValueUtil.defaultWithNA(TM_CSRGNEV);
     }
 
     public String getTM_CSMETDX() {
@@ -1874,7 +1876,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CSMETDX(String TM_CSMETDX) {
-        this.TM_CSMETDX =  StringUtils.isNotEmpty(TM_CSMETDX) ? TM_CSMETDX : "NA";
+        this.TM_CSMETDX =  ClinicalValueUtil.defaultWithNA(TM_CSMETDX);
     }
 
     public String getTM_CSMETEV() {
@@ -1882,7 +1884,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_CSMETEV(String TM_CSMETEV) {
-        this.TM_CSMETEV =  StringUtils.isNotEmpty(TM_CSMETEV) ? TM_CSMETEV : "NA";
+        this.TM_CSMETEV =  ClinicalValueUtil.defaultWithNA(TM_CSMETEV);
     }
 
     public String getTM_TSTAGE() {
@@ -1890,7 +1892,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_TSTAGE(String TM_TSTAGE) {
-        this.TM_TSTAGE =  StringUtils.isNotEmpty(TM_TSTAGE) ? TM_TSTAGE : "NA";
+        this.TM_TSTAGE =  ClinicalValueUtil.defaultWithNA(TM_TSTAGE);
     }
 
     public String getTM_TSTAGE_DESC() {
@@ -1898,7 +1900,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_TSTAGE_DESC(String TM_TSTAGE_DESC) {
-        this.TM_TSTAGE_DESC =  StringUtils.isNotEmpty(TM_TSTAGE_DESC) ? TM_TSTAGE_DESC : "NA";
+        this.TM_TSTAGE_DESC =  ClinicalValueUtil.defaultWithNA(TM_TSTAGE_DESC);
     }
 
     public String getTM_NSTAGE() {
@@ -1906,7 +1908,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_NSTAGE(String TM_NSTAGE) {
-        this.TM_NSTAGE =  StringUtils.isNotEmpty(TM_NSTAGE) ? TM_NSTAGE : "NA";
+        this.TM_NSTAGE =  ClinicalValueUtil.defaultWithNA(TM_NSTAGE);
     }
 
     public String getTM_NSTAGE_DESC() {
@@ -1914,7 +1916,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_NSTAGE_DESC(String TM_NSTAGE_DESC) {
-        this.TM_NSTAGE_DESC =  StringUtils.isNotEmpty(TM_NSTAGE_DESC) ? TM_NSTAGE_DESC : "NA";
+        this.TM_NSTAGE_DESC =  ClinicalValueUtil.defaultWithNA(TM_NSTAGE_DESC);
     }
 
     public String getTM_MSTAGE() {
@@ -1922,7 +1924,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_MSTAGE(String TM_MSTAGE) {
-        this.TM_MSTAGE =  StringUtils.isNotEmpty(TM_MSTAGE) ? TM_MSTAGE : "NA";
+        this.TM_MSTAGE =  ClinicalValueUtil.defaultWithNA(TM_MSTAGE);
     }
 
     public String getTM_MSTAGE_DESC() {
@@ -1930,7 +1932,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_MSTAGE_DESC(String TM_MSTAGE_DESC) {
-        this.TM_MSTAGE_DESC =  StringUtils.isNotEmpty(TM_MSTAGE_DESC) ? TM_MSTAGE_DESC : "NA";
+        this.TM_MSTAGE_DESC =  ClinicalValueUtil.defaultWithNA(TM_MSTAGE_DESC);
     }
 
     public String getTM_TBASIS() {
@@ -1938,7 +1940,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_TBASIS(String TM_TBASIS) {
-        this.TM_TBASIS =  StringUtils.isNotEmpty(TM_TBASIS) ? TM_TBASIS : "NA";
+        this.TM_TBASIS =  ClinicalValueUtil.defaultWithNA(TM_TBASIS);
     }
 
     public String getTM_TBASIS_DESC() {
@@ -1946,7 +1948,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_TBASIS_DESC(String TM_TBASIS_DESC) {
-        this.TM_TBASIS_DESC =  StringUtils.isNotEmpty(TM_TBASIS_DESC) ? TM_TBASIS_DESC : "NA";
+        this.TM_TBASIS_DESC =  ClinicalValueUtil.defaultWithNA(TM_TBASIS_DESC);
     }
 
     public String getTM_NBASIS() {
@@ -1954,7 +1956,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_NBASIS(String TM_NBASIS) {
-        this.TM_NBASIS =  StringUtils.isNotEmpty(TM_NBASIS) ? TM_NBASIS : "NA";
+        this.TM_NBASIS =  ClinicalValueUtil.defaultWithNA(TM_NBASIS);
     }
 
     public String getTM_NBASIS_DESC() {
@@ -1962,7 +1964,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_NBASIS_DESC(String TM_NBASIS_DESC) {
-        this.TM_NBASIS_DESC =  StringUtils.isNotEmpty(TM_NBASIS_DESC) ? TM_NBASIS_DESC : "NA";
+        this.TM_NBASIS_DESC =  ClinicalValueUtil.defaultWithNA(TM_NBASIS_DESC);
     }
 
     public String getTM_MBASIS() {
@@ -1970,7 +1972,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_MBASIS(String TM_MBASIS) {
-        this.TM_MBASIS =  StringUtils.isNotEmpty(TM_MBASIS) ? TM_MBASIS : "NA";
+        this.TM_MBASIS =  ClinicalValueUtil.defaultWithNA(TM_MBASIS);
     }
 
     public String getTM_MBASIS_DESC() {
@@ -1978,7 +1980,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_MBASIS_DESC(String TM_MBASIS_DESC) {
-        this.TM_MBASIS_DESC =  StringUtils.isNotEmpty(TM_MBASIS_DESC) ? TM_MBASIS_DESC : "NA";
+        this.TM_MBASIS_DESC =  ClinicalValueUtil.defaultWithNA(TM_MBASIS_DESC);
     }
 
     public String getTM_AJCC() {
@@ -1986,7 +1988,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_AJCC(String TM_AJCC) {
-        this.TM_AJCC =  StringUtils.isNotEmpty(TM_AJCC) ? TM_AJCC : "NA";
+        this.TM_AJCC =  ClinicalValueUtil.defaultWithNA(TM_AJCC);
     }
 
     public String getTM_AJCC_DESC() {
@@ -1994,7 +1996,7 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_AJCC_DESC(String TM_AJCC_DESC) {
-        this.TM_AJCC_DESC =  StringUtils.isNotEmpty(TM_AJCC_DESC) ? TM_AJCC_DESC : "NA";
+        this.TM_AJCC_DESC =  ClinicalValueUtil.defaultWithNA(TM_AJCC_DESC);
     }
 
     public String getTM_MSK_STG() {
@@ -2002,25 +2004,25 @@ public class MskimpactPatientIcdoRecord {
     }
 
     public void setTM_MSK_STG(String TM_MSK_STG) {
-        this.TM_MSK_STG =  StringUtils.isNotEmpty(TM_MSK_STG) ? TM_MSK_STG : "NA";
+        this.TM_MSK_STG =  ClinicalValueUtil.defaultWithNA(TM_MSK_STG);
     }
-    
+
     public Integer getAGE_AT_LAST_KNOWN_ALIVE_IN_DAYS() {
         return AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS;
     }
-    
+
     public void setAGE_AT_LAST_KNOWN_ALIVE_IN_DAYS(Integer AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS) {
         this.AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS = AGE_AT_LAST_KNOWN_ALIVE_IN_DAYS;
     }
-    
+
     public Integer getAGE_AT_DATE_OF_DEATH_IN_DAYS() {
         return AGE_AT_DATE_OF_DEATH_IN_DAYS;
     }
-    
+
     public void setAGE_AT_DATE_OF_DEATH_IN_DAYS(Integer AGE_AT_DATE_OF_DEATH_IN_DAYS) {
         this.AGE_AT_DATE_OF_DEATH_IN_DAYS = AGE_AT_DATE_OF_DEATH_IN_DAYS;
-    }    
-    
+    }
+
     @Override
     public String toString(){
         return ToStringBuilder.reflectionToString(this);
@@ -2205,10 +2207,7 @@ public class MskimpactPatientIcdoRecord {
         fieldNames.add("TM_AJCC");
         fieldNames.add("TM_AJCC_DESC");
         fieldNames.add("TM_MSK_STG");
-
         return fieldNames;
     }
-    
-    
-    
+
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantClinicalRecord.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantClinicalRecord.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,8 +33,8 @@
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.cbioportal.cmo.pipelines.common.util.ClinicalValueUtil;
 
 /**
  *
@@ -114,12 +114,12 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     private String melmsSiteTypeDesc;
     private String melmsSiteDesc;
     private String melmsSiteYear;
-    
-    private Map<String, Object> additionalProperties;    
-    
+
+    private Map<String, Object> additionalProperties;
+
     public Skcm_mskcc_2015_chantClinicalRecord() {
     }
-    
+
     public Skcm_mskcc_2015_chantClinicalRecord(String melspcPtid,
             String  melspcStageYear,
             String melspcStgGrpName,
@@ -191,79 +191,79 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
             String melmsSiteTypeDesc,
             String melmsSiteDesc,
             String melmsSiteYear) {
-        this.melspcPtid = StringUtils.isNotEmpty(melspcPtid) ? melspcPtid : "NA";
-        this.melspcStageYear = StringUtils.isNotEmpty(melspcStageYear) ? melspcStageYear : "NA";
-        this.melspcStgGrpName = StringUtils.isNotEmpty(melspcStgGrpName) ? melspcStgGrpName : "NA";
-        this.melgPtid = StringUtils.isNotEmpty(melgPtid) ? melgPtid : "NA";
-        this.melgStsDesc = StringUtils.isNotEmpty(melgStsDesc) ? melgStsDesc : "NA";
-        this.melgStsSrcDesc = StringUtils.isNotEmpty(melgStsSrcDesc) ? melgStsSrcDesc : "NA";
-        this.melgActvStsDesc = StringUtils.isNotEmpty(melgActvStsDesc) ? melgActvStsDesc : "NA";
-        this.melgDermagrphxDesc = StringUtils.isNotEmpty(melgDermagrphxDesc) ? melgDermagrphxDesc : "NA";
-        this.melgPresStgYear = StringUtils.isNotEmpty(melgPresStgYear) ? melgPresStgYear : "NA";
-        this.melgFamilyHxDesc = StringUtils.isNotEmpty(melgFamilyHxDesc) ? melgFamilyHxDesc : "NA";
-        this.melg1stRecurYear = StringUtils.isNotEmpty(melg1stRecurYear) ? melg1stRecurYear : "NA";
-        this.melgLocalDesc = StringUtils.isNotEmpty(melgLocalDesc) ? melgLocalDesc : "NA";
-        this.melgNodalDesc = StringUtils.isNotEmpty(melgNodalDesc) ? melgNodalDesc : "NA";
-        this.melgIntransitDesc = StringUtils.isNotEmpty(melgIntransitDesc) ? melgIntransitDesc : "NA";
-        this.melgSysDesc = StringUtils.isNotEmpty(melgSysDesc) ? melgSysDesc : "NA";
-        this.melgRecurNdszDesc = StringUtils.isNotEmpty(melgRecurNdszDesc) ? melgRecurNdszDesc : "NA";
-        this.melgRecurNodalNo = StringUtils.isNotEmpty(melgRecurNodalNo) ? melgRecurNodalNo : "NA";
-        this.melgLdh = StringUtils.isNotEmpty(melgLdh) ? melgLdh : "NA";
-        this.melgLdhYear = StringUtils.isNotEmpty(melgLdhYear) ? melgLdhYear : "NA";
-        this.melgMetsDesc = StringUtils.isNotEmpty(melgMetsDesc) ? melgMetsDesc : "NA";
-        this.melgAdjvntTxDesc = StringUtils.isNotEmpty(melgAdjvntTxDesc) ? melgAdjvntTxDesc : "NA";
-        this.melgSysTxDesc = StringUtils.isNotEmpty(melgSysTxDesc) ? melgSysTxDesc : "NA";
-        this.melgRadTxDesc = StringUtils.isNotEmpty(melgRadTxDesc) ? melgRadTxDesc : "NA";
-        this.melgSurgDesc = StringUtils.isNotEmpty(melgSurgDesc) ? melgSurgDesc : "NA";
-        this.melgTissueBankAvail = StringUtils.isNotEmpty(melgTissueBankAvail) ? melgTissueBankAvail : "NA";
-        this.melpPtid = StringUtils.isNotEmpty(melpPtid) ? melpPtid : "NA";
-        this.melpPrimSeq = StringUtils.isNotEmpty(melpPrimSeq) ? melpPrimSeq : "NA";
-        this.melpDxYear = StringUtils.isNotEmpty(melpDxYear) ? melpDxYear : "NA";
-        this.melpMskReviewDesc = StringUtils.isNotEmpty(melpMskReviewDesc) ? melpMskReviewDesc : "NA";
-        this.melpThicknessMm = StringUtils.isNotEmpty(melpThicknessMm) ? melpThicknessMm : "NA";
-        this.melpClarkLvlDesc = StringUtils.isNotEmpty(melpClarkLvlDesc) ? melpClarkLvlDesc : "NA";
-        this.melpUlcerationDesc = StringUtils.isNotEmpty(melpUlcerationDesc) ? melpUlcerationDesc : "NA";
-        this.melpSiteDesc = StringUtils.isNotEmpty(melpSiteDesc) ? melpSiteDesc : "NA";
-        this.melpSubSiteDesc = StringUtils.isNotEmpty(melpSubSiteDesc) ? melpSubSiteDesc : "NA";
-        this.melpTilsDesc = StringUtils.isNotEmpty(melpTilsDesc) ? melpTilsDesc : "NA";
-        this.melpRegressionDesc = StringUtils.isNotEmpty(melpRegressionDesc) ? melpRegressionDesc : "NA";
-        this.melpMarginsDesc = StringUtils.isNotEmpty(melpMarginsDesc) ? melpMarginsDesc : "NA";
-        this.melpMitidxUnkDesc = StringUtils.isNotEmpty(melpMitidxUnkDesc) ? melpMitidxUnkDesc : "NA";
-        this.melpHistTypeDesc = StringUtils.isNotEmpty(melpHistTypeDesc) ? melpHistTypeDesc : "NA";
-        this.melpSatellitesDesc = StringUtils.isNotEmpty(melpSatellitesDesc) ? melpSatellitesDesc : "NA";
-        this.melpExtSlidesDesc = StringUtils.isNotEmpty(melpExtSlidesDesc) ? melpExtSlidesDesc : "NA";
-        this.melpLnorgDxDesc = StringUtils.isNotEmpty(melpLnorgDxDesc) ? melpLnorgDxDesc : "NA";
-        this.melpLnclinStsDesc = StringUtils.isNotEmpty(melpLnclinStsDesc) ? melpLnclinStsDesc : "NA";
-        this.melpLnsentinbxDesx = StringUtils.isNotEmpty(melpLnsentinbxDesx) ? melpLnsentinbxDesx : "NA";
-        this.melpLnsentinbxYear = StringUtils.isNotEmpty(melpLnsentinbxYear) ? melpLnsentinbxYear : "NA";
-        this.melpLnprolysctDesc = StringUtils.isNotEmpty(melpLnprolysctDesc) ? melpLnprolysctDesc : "NA";
-        this.melpLnprosuccDesc = StringUtils.isNotEmpty(melpLnprosuccDesc) ? melpLnprosuccDesc : "NA";
-        this.melpLndsctCmpDesc = StringUtils.isNotEmpty(melpLndsctCmpDesc) ? melpLndsctCmpDesc : "NA";
-        this.melpLndsctYear = StringUtils.isNotEmpty(melpLndsctYear) ? melpLndsctYear : "NA";
-        this.melpLnmattedDesc = StringUtils.isNotEmpty(melpLnmattedDesc) ? melpLnmattedDesc : "NA";
-        this.LnextnodstDesc = StringUtils.isNotEmpty(LnextnodstDesc) ? LnextnodstDesc : "NA";
-        this.LnintrmetsDesc = StringUtils.isNotEmpty(LnintrmetsDesc) ? LnintrmetsDesc : "NA";
-        this.melpLnsize = StringUtils.isNotEmpty(melpLnsize) ? melpLnsize : "NA";
-        this.melpLnsizeUnkDesc = StringUtils.isNotEmpty(melpLnsizeUnkDesc) ? melpLnsizeUnkDesc : "NA";
-        this.melpLnslnlargSize = StringUtils.isNotEmpty(melpLnslnlargSize) ? melpLnslnlargSize : "NA";
-        this.melpLnihcDesc = StringUtils.isNotEmpty(melpLnihcDesc) ? melpLnihcDesc : "NA";
-        this.melpLnimmS100Desc = StringUtils.isNotEmpty(melpLnimmS100Desc) ? melpLnimmS100Desc : "NA";
-        this.melpLnimmhmb45Desc = StringUtils.isNotEmpty(melpLnimmhmb45Desc) ? melpLnimmhmb45Desc : "NA";
-        this.melpLnimmMelaDesc = StringUtils.isNotEmpty(melpLnimmMelaDesc) ? melpLnimmMelaDesc : "NA";
-        this.meliPtid = StringUtils.isNotEmpty(meliPtid) ? meliPtid : "NA";
-        this.meliDmpPatientId = StringUtils.isNotEmpty(meliDmpPatientId) ? meliDmpPatientId : "NA";
-        this.meliDmpSampleId = StringUtils.isNotEmpty(meliDmpSampleId) ? meliDmpSampleId : "NA";
-        this.meliReportYear = StringUtils.isNotEmpty(meliReportYear)  ? meliReportYear : "NA";
-        this.meliProcedureYear = StringUtils.isNotEmpty(meliProcedureYear) ? meliProcedureYear : "NA";
-        this.meliTumorType = StringUtils.isNotEmpty(meliTumorType) ? meliTumorType : "NA";
-        this.meliPrimarySite = StringUtils.isNotEmpty(meliPrimarySite) ? meliPrimarySite : "NA";
-        this.meliMetSite = StringUtils.isNotEmpty(meliMetSite) ? meliMetSite : "NA";
-        this.melmsPtid = StringUtils.isNotEmpty(melmsPtid) ? melmsPtid : "NA";
-        this.melmsSiteTypeDesc = StringUtils.isNotEmpty(melmsSiteTypeDesc) ? melmsSiteTypeDesc : "NA";
-        this.melmsSiteDesc = StringUtils.isNotEmpty(melmsSiteDesc) ? melmsSiteDesc : "NA";
-        this.melmsSiteYear = StringUtils.isNotEmpty(melmsSiteYear) ? melmsSiteYear : "NA";
+        this.melspcPtid = ClinicalValueUtil.defaultWithNA(melspcPtid);
+        this.melspcStageYear = ClinicalValueUtil.defaultWithNA(melspcStageYear);
+        this.melspcStgGrpName = ClinicalValueUtil.defaultWithNA(melspcStgGrpName);
+        this.melgPtid = ClinicalValueUtil.defaultWithNA(melgPtid);
+        this.melgStsDesc = ClinicalValueUtil.defaultWithNA(melgStsDesc);
+        this.melgStsSrcDesc = ClinicalValueUtil.defaultWithNA(melgStsSrcDesc);
+        this.melgActvStsDesc = ClinicalValueUtil.defaultWithNA(melgActvStsDesc);
+        this.melgDermagrphxDesc = ClinicalValueUtil.defaultWithNA(melgDermagrphxDesc);
+        this.melgPresStgYear = ClinicalValueUtil.defaultWithNA(melgPresStgYear);
+        this.melgFamilyHxDesc = ClinicalValueUtil.defaultWithNA(melgFamilyHxDesc);
+        this.melg1stRecurYear = ClinicalValueUtil.defaultWithNA(melg1stRecurYear);
+        this.melgLocalDesc = ClinicalValueUtil.defaultWithNA(melgLocalDesc);
+        this.melgNodalDesc = ClinicalValueUtil.defaultWithNA(melgNodalDesc);
+        this.melgIntransitDesc = ClinicalValueUtil.defaultWithNA(melgIntransitDesc);
+        this.melgSysDesc = ClinicalValueUtil.defaultWithNA(melgSysDesc);
+        this.melgRecurNdszDesc = ClinicalValueUtil.defaultWithNA(melgRecurNdszDesc);
+        this.melgRecurNodalNo = ClinicalValueUtil.defaultWithNA(melgRecurNodalNo);
+        this.melgLdh = ClinicalValueUtil.defaultWithNA(melgLdh);
+        this.melgLdhYear = ClinicalValueUtil.defaultWithNA(melgLdhYear);
+        this.melgMetsDesc = ClinicalValueUtil.defaultWithNA(melgMetsDesc);
+        this.melgAdjvntTxDesc = ClinicalValueUtil.defaultWithNA(melgAdjvntTxDesc);
+        this.melgSysTxDesc = ClinicalValueUtil.defaultWithNA(melgSysTxDesc);
+        this.melgRadTxDesc = ClinicalValueUtil.defaultWithNA(melgRadTxDesc);
+        this.melgSurgDesc = ClinicalValueUtil.defaultWithNA(melgSurgDesc);
+        this.melgTissueBankAvail = ClinicalValueUtil.defaultWithNA(melgTissueBankAvail);
+        this.melpPtid = ClinicalValueUtil.defaultWithNA(melpPtid);
+        this.melpPrimSeq = ClinicalValueUtil.defaultWithNA(melpPrimSeq);
+        this.melpDxYear = ClinicalValueUtil.defaultWithNA(melpDxYear);
+        this.melpMskReviewDesc = ClinicalValueUtil.defaultWithNA(melpMskReviewDesc);
+        this.melpThicknessMm = ClinicalValueUtil.defaultWithNA(melpThicknessMm);
+        this.melpClarkLvlDesc = ClinicalValueUtil.defaultWithNA(melpClarkLvlDesc);
+        this.melpUlcerationDesc = ClinicalValueUtil.defaultWithNA(melpUlcerationDesc);
+        this.melpSiteDesc = ClinicalValueUtil.defaultWithNA(melpSiteDesc);
+        this.melpSubSiteDesc = ClinicalValueUtil.defaultWithNA(melpSubSiteDesc);
+        this.melpTilsDesc = ClinicalValueUtil.defaultWithNA(melpTilsDesc);
+        this.melpRegressionDesc = ClinicalValueUtil.defaultWithNA(melpRegressionDesc);
+        this.melpMarginsDesc = ClinicalValueUtil.defaultWithNA(melpMarginsDesc);
+        this.melpMitidxUnkDesc = ClinicalValueUtil.defaultWithNA(melpMitidxUnkDesc);
+        this.melpHistTypeDesc = ClinicalValueUtil.defaultWithNA(melpHistTypeDesc);
+        this.melpSatellitesDesc = ClinicalValueUtil.defaultWithNA(melpSatellitesDesc);
+        this.melpExtSlidesDesc = ClinicalValueUtil.defaultWithNA(melpExtSlidesDesc);
+        this.melpLnorgDxDesc = ClinicalValueUtil.defaultWithNA(melpLnorgDxDesc);
+        this.melpLnclinStsDesc = ClinicalValueUtil.defaultWithNA(melpLnclinStsDesc);
+        this.melpLnsentinbxDesx = ClinicalValueUtil.defaultWithNA(melpLnsentinbxDesx);
+        this.melpLnsentinbxYear = ClinicalValueUtil.defaultWithNA(melpLnsentinbxYear);
+        this.melpLnprolysctDesc = ClinicalValueUtil.defaultWithNA(melpLnprolysctDesc);
+        this.melpLnprosuccDesc = ClinicalValueUtil.defaultWithNA(melpLnprosuccDesc);
+        this.melpLndsctCmpDesc = ClinicalValueUtil.defaultWithNA(melpLndsctCmpDesc);
+        this.melpLndsctYear = ClinicalValueUtil.defaultWithNA(melpLndsctYear);
+        this.melpLnmattedDesc = ClinicalValueUtil.defaultWithNA(melpLnmattedDesc);
+        this.LnextnodstDesc = ClinicalValueUtil.defaultWithNA(LnextnodstDesc);
+        this.LnintrmetsDesc = ClinicalValueUtil.defaultWithNA(LnintrmetsDesc);
+        this.melpLnsize = ClinicalValueUtil.defaultWithNA(melpLnsize);
+        this.melpLnsizeUnkDesc = ClinicalValueUtil.defaultWithNA(melpLnsizeUnkDesc);
+        this.melpLnslnlargSize = ClinicalValueUtil.defaultWithNA(melpLnslnlargSize);
+        this.melpLnihcDesc = ClinicalValueUtil.defaultWithNA(melpLnihcDesc);
+        this.melpLnimmS100Desc = ClinicalValueUtil.defaultWithNA(melpLnimmS100Desc);
+        this.melpLnimmhmb45Desc = ClinicalValueUtil.defaultWithNA(melpLnimmhmb45Desc);
+        this.melpLnimmMelaDesc = ClinicalValueUtil.defaultWithNA(melpLnimmMelaDesc);
+        this.meliPtid = ClinicalValueUtil.defaultWithNA(meliPtid);
+        this.meliDmpPatientId = ClinicalValueUtil.defaultWithNA(meliDmpPatientId);
+        this.meliDmpSampleId = ClinicalValueUtil.defaultWithNA(meliDmpSampleId);
+        this.meliReportYear = ClinicalValueUtil.defaultWithNA(meliReportYear);
+        this.meliProcedureYear = ClinicalValueUtil.defaultWithNA(meliProcedureYear);
+        this.meliTumorType = ClinicalValueUtil.defaultWithNA(meliTumorType);
+        this.meliPrimarySite = ClinicalValueUtil.defaultWithNA(meliPrimarySite);
+        this.meliMetSite = ClinicalValueUtil.defaultWithNA(meliMetSite);
+        this.melmsPtid = ClinicalValueUtil.defaultWithNA(melmsPtid);
+        this.melmsSiteTypeDesc = ClinicalValueUtil.defaultWithNA(melmsSiteTypeDesc);
+        this.melmsSiteDesc = ClinicalValueUtil.defaultWithNA(melmsSiteDesc);
+        this.melmsSiteYear = ClinicalValueUtil.defaultWithNA(melmsSiteYear);
     }
-    
+
     public String getPATIENT_ID() {
         if (patientId != null) {
             return patientId;
@@ -279,21 +279,21 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
         }
         return melmsPtid;
     }
-    
+
     public void setPATIENT_ID(String patientId) {
         this.patientId = patientId;
     }
-    
+
     public String getSAMPLE_ID() {
         if (sampleId != null) {
             return sampleId;
         }
         if (!meliDmpSampleId.equals("NA")) {
             return meliDmpSampleId;
-        }        
+        }
         if (!melpPrimSeq.equals("NA")) {
             return melpPtid + "_" + melpPrimSeq;
-        }        
+        }
         if (!melspcPtid.equals("NA")) {
             return melspcPtid;
         }
@@ -302,151 +302,151 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
         }
         return melmsPtid;
     }
-    
+
     public void setSAMPLE_ID(String sampleId) {
         this.sampleId = sampleId;
     }
-    
+
     public String getMELSPC_PTID() {
         return melspcPtid;
     }
-    
+
     public void setMELSPC_PTID(String melspcPtid) {
         this.melspcPtid = melspcPtid;
-    }    
-    
+    }
+
     public String getMELSPC_STAGE_YEAR() {
         return melspcStageYear;
     }
-    
+
     public void setMELSPC_STAGE_YEAR(String melspcStageYear) {
         this.melspcStageYear = melspcStageYear;
-    }  
-    
+    }
+
     public String getMELSPC_STG_GRP_NAME() {
         return melspcStgGrpName;
     }
-    
+
     public void setMELSPC_STG_GRP_NAME(String melspcStgGrpName) {
         this.melspcStgGrpName = melspcStgGrpName;
-    }      
-    
+    }
+
     public String getMELG_PTID() {
         return melgPtid;
     }
-    
+
     public void setMELG_PTID(String melgPtid) {
         this.melgPtid = melgPtid;
-    }        
-    
+    }
+
     public String getMELG_STS_DESC() {
         return melgStsDesc;
     }
-    
+
     public void setMELG_STS_DESC(String melgStsDesc) {
         this.melgStsDesc = melgStsDesc;
-    }      
-    
+    }
+
     public String getMELG_STS_SRCE_DESC() {
         return melgStsSrcDesc;
     }
-    
+
     public void setMELG_STS_SRCE_DESC(String melgStsSrcDesc) {
         this.melgStsSrcDesc = melgStsSrcDesc;
-    }  
+    }
 
     public String getMELG_ACTV_STS_DESC() {
         return melgActvStsDesc;
     }
-    
+
     public void setMELG_ACTV_STS_DESC(String melgActvStsDesc) {
         this.melgActvStsDesc = melgActvStsDesc;
-    }  
+    }
 
     public String getMELG_DERMAGRPHX_DESC() {
         return melgDermagrphxDesc;
     }
-    
+
     public void setMELG_DERMAGRPHX_DESC(String melgDermagrphxDesc) {
         this.melgDermagrphxDesc = melgDermagrphxDesc;
-    }  
+    }
 
     public String getMELG_PRES_STG_YEAR() {
         return melgPresStgYear;
     }
-    
+
     public void setMELG_PRES_STG_YEAR(String melgPresStgYear) {
         this.melgPresStgYear = melgPresStgYear;
-    }  
+    }
 
     public String getMELG_FAMILY_HX_DESC() {
         return melgFamilyHxDesc;
     }
-    
+
     public void setMELG_FAMILY_HX_DESC(String melgFamilyHxDesc) {
         this.melgFamilyHxDesc = melgFamilyHxDesc;
-    }  
+    }
 
     public String getMELG_1ST_RECUR_YEAR() {
         return melg1stRecurYear;
     }
-    
+
     public void setMELG_1ST_RECUR_YEAR(String melg1stRecurYear) {
         this.melg1stRecurYear = melg1stRecurYear;
-    }  
+    }
 
     public String getMELG_LOCAL_DESC() {
         return melgLocalDesc;
     }
-    
+
     public void setMELG_LOCAL_DESC(String melgLocalDesc) {
         this.melgLocalDesc = melgLocalDesc;
-    }  
+    }
 
     public String getMELG_NODAL_DESC() {
         return melgNodalDesc;
     }
-    
+
     public void setMELG_NODAL_DESC(String melgNodalDesc) {
         this.melgNodalDesc = melgNodalDesc;
-    }  
+    }
 
     public String getMELG_INTRANSIT_DESC() {
         return melgIntransitDesc;
     }
-    
+
     public void setMELG_INTRANSIT_DESC(String melgIntransitDesc) {
         this.melgIntransitDesc = melgIntransitDesc;
-    }  
+    }
 
     public String getMELG_SYS_DESC() {
         return melgSysDesc;
     }
-    
+
     public void setMELG_SYS_DESC(String melgSysDesc) {
         this.melgSysDesc = melgSysDesc;
-    }  
+    }
 
     public String getMELG_RECUR_NDSZ_DESC() {
         return melgRecurNdszDesc;
     }
-    
+
     public void setMELG_RECUR_NDSZ_DESC(String melgRecurNdszDesc) {
         this.melgRecurNdszDesc = melgRecurNdszDesc;
-    }  
+    }
 
     public String getMELG_RECUR_NODAL_NO() {
         return melgRecurNodalNo;
     }
-    
+
     public void setMELG_RECUR_NODAL_NO(String melgRecurNodalNo) {
         this.melgRecurNodalNo = melgRecurNodalNo;
-    }  
+    }
 
     public String getMELG_LDH() {
         return melgLdh;
     }
-    
+
     public void setMELG_LDH(String melgLdh) {
         this.melgLdh = melgLdh;
     }
@@ -454,7 +454,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELG_LDH_YEAR() {
         return melgLdhYear;
     }
-    
+
     public void setMELG_LDH_YEAR(String melgLdhYear) {
         this.melgLdhYear = melgLdhYear;
     }
@@ -462,7 +462,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELG_METS_DESC() {
         return melgMetsDesc;
     }
-    
+
     public void setMELG_METS_DESC(String melgMetsDesc) {
         this.melgMetsDesc = melgMetsDesc;
     }
@@ -470,7 +470,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELG_ADJVNT_TX_DESC() {
         return melgAdjvntTxDesc;
     }
-    
+
     public void setMELG_ADJVNT_TX_DESC(String melgAdjvntTxDesc) {
         this.melgAdjvntTxDesc = melgAdjvntTxDesc;
     }
@@ -478,7 +478,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELG_SYS_TX_DESC() {
         return melgSysTxDesc;
     }
-    
+
     public void setMELG_SYS_TX_DESC(String melgSysTxDesc) {
         this.melgSysTxDesc = melgSysTxDesc;
     }
@@ -486,7 +486,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELG_RAD_TX_DESC() {
         return melgRadTxDesc;
     }
-    
+
     public void setMELG_RAD_TX_DESC(String melgRadTxDesc) {
         this.melgRadTxDesc = melgRadTxDesc;
     }
@@ -494,39 +494,39 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELG_SURG_DESC() {
         return melgSurgDesc;
     }
-    
+
     public void setMELG_SURG_DESC(String melgSurgDesc) {
         this.melgSurgDesc = melgSurgDesc;
-    }    
-    
+    }
+
     public String getMELG_TISSUE_BANK_AVAIL() {
         return melgTissueBankAvail;
     }
-    
+
     public void setMELG_TISSUE_BANK_AVAIL(String melgTissueBankAvail) {
         this.melgTissueBankAvail = melgTissueBankAvail;
     }
-    
+
     public String getMELP_PTID() {
         return melpPtid;
     }
-    
+
     public void setMELP_PTID(String melpPtid) {
         this.melpPtid = melpPtid;
-    }        
-    
+    }
+
     public String getMELP_PRIM_SEQ() {
         return melpPrimSeq;
     }
-    
+
     public void setMELP_PRIM_SEQ(String melpPrimSeq) {
         this.melpPrimSeq = melpPrimSeq;
     }
-    
+
     public String getMELP_DX_YEAR() {
         return melpDxYear;
     }
-    
+
     public void setMELP_DX_YEAR(String melpDxYear) {
         this.melpDxYear = melpDxYear;
     }
@@ -534,7 +534,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_MSK_REVIEW_DESC() {
         return melpMskReviewDesc;
     }
-    
+
     public void setMELP_MSK_REVIEW_DESC(String melpMskReviewDesc) {
         this.melpMskReviewDesc = melpMskReviewDesc;
     }
@@ -542,7 +542,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_THICKNESS_MM() {
         return melpThicknessMm;
     }
-    
+
     public void setMELP_THICKNESS_MM(String melpThicknessMm) {
         this.melpThicknessMm = melpThicknessMm;
     }
@@ -550,7 +550,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_CLARK_LVL_DESC() {
         return melpClarkLvlDesc;
     }
-    
+
     public void setMELP_CLARK_LVL_DESC(String melpClarkLvlDesc) {
         this.melpClarkLvlDesc = melpClarkLvlDesc;
     }
@@ -558,7 +558,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_ULCERATION_DESC() {
         return melpUlcerationDesc;
     }
-    
+
     public void setMELP_ULCERATION_DESC(String melpUlcerationDesc) {
         this.melpUlcerationDesc = melpUlcerationDesc;
     }
@@ -566,7 +566,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_SITE_DESC() {
         return melpSiteDesc;
     }
-    
+
     public void setMELP_SITE_DESC(String melpSiteDesc) {
         this.melpSiteDesc = melpSiteDesc;
     }
@@ -574,7 +574,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_SUB_SITE_DESC() {
         return melpSubSiteDesc;
     }
-    
+
     public void setMELP_SUB_SITE_DESC(String melpSubSiteDesc) {
         this.melpSubSiteDesc = melpSubSiteDesc;
     }
@@ -582,7 +582,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_TILS_DESC() {
         return melpTilsDesc;
     }
-    
+
     public void setMELP_TILS_DESC(String melpTilsDesc) {
         this.melpTilsDesc = melpTilsDesc;
     }
@@ -590,7 +590,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_REGRESSION_DESC() {
         return melpRegressionDesc;
     }
-    
+
     public void setMELP_REGRESSION_DESC(String melpRegressionDesc) {
         this.melpRegressionDesc = melpRegressionDesc;
     }
@@ -598,7 +598,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_MARGINS_DESC() {
         return melpMarginsDesc;
     }
-    
+
     public void setMELP_MARGINS_DESC(String melpMarginsDesc) {
         this.melpMarginsDesc = melpMarginsDesc;
     }
@@ -606,7 +606,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_MITIDX_UNK_DESC() {
         return melpMitidxUnkDesc;
     }
-    
+
     public void setMELP_MITIDX_UNK_DESC(String melpMitidxUnkDesc) {
         this.melpMitidxUnkDesc = melpMitidxUnkDesc;
     }
@@ -614,7 +614,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_HIST_TYPE_DESC() {
         return melpHistTypeDesc;
     }
-    
+
     public void setMELP_HIST_TYPE_DESC(String melpHistTypeDesc) {
         this.melpHistTypeDesc = melpHistTypeDesc;
     }
@@ -622,7 +622,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_SATELLITES_DESC() {
         return melpSatellitesDesc;
     }
-    
+
     public void setMELP_SATELLITES_DESC(String melpSatellitesDesc) {
         this.melpSatellitesDesc = melpSatellitesDesc;
     }
@@ -630,7 +630,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_EXT_SLIDES_DESC() {
         return melpExtSlidesDesc;
     }
-    
+
     public void setMELP_EXT_SLIDES_DESC(String melpExtSlidesDesc) {
         this.melpExtSlidesDesc = melpExtSlidesDesc;
     }
@@ -638,7 +638,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNORG_DX_DESC() {
         return melpLnorgDxDesc;
     }
-    
+
     public void setMELP_LNORG_DX_DESC(String melpLnorgDxDesc) {
         this.melpLnorgDxDesc = melpLnorgDxDesc;
     }
@@ -646,7 +646,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNCLIN_STS_DESC() {
         return melpLnclinStsDesc;
     }
-    
+
     public void setMELP_LNCLIN_STS_DESC(String melpLnclinStsDesc) {
         this.melpLnclinStsDesc = melpLnclinStsDesc;
     }
@@ -654,7 +654,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNSENTINBX_DESC() {
         return melpLnsentinbxDesx;
     }
-    
+
     public void setMELP_LNSENTINBX_DESC(String melpLnsentinbxDesx) {
         this.melpLnsentinbxDesx = melpLnsentinbxDesx;
     }
@@ -662,7 +662,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNSENTINBX_YEAR() {
         return melpLnsentinbxYear;
     }
-    
+
     public void setMELP_LNSENTINBX_YEAR(String melpLnsentinbxYear) {
         this.melpLnsentinbxYear = melpLnsentinbxYear;
     }
@@ -670,7 +670,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNPROLYSCT_DESC() {
         return melpLnprolysctDesc;
     }
-    
+
     public void setMELP_LNPROLYSCT_DESC(String melpLnprolysctDesc) {
         this.melpLnprolysctDesc = melpLnprolysctDesc;
     }
@@ -678,7 +678,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNPROSUCC_DESC() {
         return melpLnprosuccDesc;
     }
-    
+
     public void setMELP_LNPROSUCC_DESC(String melpLnprosuccDesc) {
         this.melpLnprosuccDesc = melpLnprosuccDesc;
     }
@@ -686,7 +686,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNDSCT_CMP_DESC() {
         return melpLndsctCmpDesc;
     }
-    
+
     public void setMELP_LNDSCT_CMP_DESC(String melpLndsctCmpDesc) {
         this.melpLndsctCmpDesc = melpLndsctCmpDesc;
     }
@@ -694,15 +694,15 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNDSCT_YEAR() {
         return melpLndsctYear;
     }
-    
+
     public void setMELP_LNDSCT_YEAR(String melpLndsctYear) {
         this.melpLndsctYear = melpLndsctYear;
-    }    
-    
+    }
+
     public String getMELP_LNMATTED_DESC() {
         return melpLnmattedDesc;
     }
-    
+
     public void setMELP_LNMATTED_DESC(String melpLnmattedDesc) {
         this.melpLnmattedDesc = melpLnmattedDesc;
     }
@@ -710,7 +710,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNEXTNODST_DESC() {
         return LnextnodstDesc;
     }
-    
+
     public void setMELP_LNEXTNODST_DESC(String LnextnodstDesc) {
         this.LnextnodstDesc = LnextnodstDesc;
     }
@@ -718,7 +718,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNINTRMETS_DESC() {
         return LnintrmetsDesc;
     }
-    
+
     public void setMELP_LNINTRMETS_DESC(String LnintrmetsDesc) {
         this.LnintrmetsDesc = LnintrmetsDesc;
     }
@@ -726,7 +726,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNSIZE() {
         return melpLnsize;
     }
-    
+
     public void setMELP_LNSIZE(String melpLnsize) {
         this.melpLnsize = melpLnsize;
     }
@@ -734,7 +734,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNSIZE_UNK_DESC() {
         return melpLnsizeUnkDesc;
     }
-    
+
     public void setMELP_LNSIZE_UNK_DESC(String melpLnsizeUnkDesc) {
         this.melpLnsizeUnkDesc = melpLnsizeUnkDesc;
     }
@@ -742,7 +742,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNSLNLARG_SIZE() {
         return melpLnslnlargSize;
     }
-    
+
     public void setMELP_LNSLNLARG_SIZE(String melpLnslnlargSize) {
         this.melpLnslnlargSize = melpLnslnlargSize;
     }
@@ -750,15 +750,15 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNIHC_DESC() {
         return melpLnihcDesc;
     }
-    
+
     public void setMELP_LNIHC_DESC(String melpLnihcDesc) {
         this.melpLnihcDesc = melpLnihcDesc;
-    }   
-    
+    }
+
     public String getMELP_LNIMM_S100_DESC() {
         return melpLnimmS100Desc;
     }
-    
+
     public void setMELP_LNIMM_S100_DESC(String melpLnimmS100Desc) {
         this.melpLnimmS100Desc = melpLnimmS100Desc;
     }
@@ -766,7 +766,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNIMMHMB45_DESC() {
         return melpLnimmhmb45Desc;
     }
-    
+
     public void setMELP_LNIMMHMB45_DESC(String melpLnimmhmb45Desc) {
         this.melpLnimmhmb45Desc = melpLnimmhmb45Desc;
     }
@@ -774,55 +774,55 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELP_LNIMM_MELA_DESC() {
         return melpLnimmMelaDesc;
     }
-    
+
     public void setMELP_LNIMM_MELA_DESC(String melpLnimmMelaDesc) {
         this.melpLnimmMelaDesc = melpLnimmMelaDesc;
-    }    
-    
+    }
+
     public String getMELI_PTID() {
         return meliPtid;
     }
-    
+
     public void setMELI_PTID(String meliPtid) {
         this.meliPtid = meliPtid;
-    }  
+    }
 
     public String getMELI_DMP_PATIENT_ID() {
         return meliDmpPatientId;
     }
-    
+
     public void setMELI_DMP_PATIENT_ID(String meliDmpPatientId) {
         this.meliDmpPatientId = meliDmpPatientId;
-    }  
+    }
 
     public String getMELI_DMP_SAMPLE_ID() {
         return meliDmpSampleId;
     }
-    
+
     public void setMELI_DMP_SAMPLE_ID(String meliDmpSampleId) {
         this.meliDmpSampleId = meliDmpSampleId;
-    }   
-    
+    }
+
     public String getMELI_REPORT_YEAR() {
         return meliReportYear;
     }
-    
+
     public void setMELI_REPORT_YEAR(String meliReportYear) {
         this.meliReportYear = meliReportYear;
-    }    
+    }
 
     public String getMELI_PROCEDURE_YEAR() {
         return meliProcedureYear;
     }
-    
+
     public void setMELI_PROCEDURE_YEAR(String meliProcedureYear) {
         this.meliProcedureYear = meliProcedureYear;
-    }        
-    
+    }
+
     public String getMELI_TUMOR_TYPE() {
         return meliTumorType;
     }
-    
+
     public void setMELI_TUMOR_TYPE(String meliTumorType) {
         this.meliTumorType = meliTumorType;
     }
@@ -830,7 +830,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELI_PRIMARY_SITE() {
         return meliPrimarySite;
     }
-    
+
     public void setMELI_PRIMARY_SITE(String meliPrimarySite) {
         this.meliPrimarySite = meliPrimarySite;
     }
@@ -838,31 +838,31 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELI_MET_SITE() {
         return meliMetSite;
     }
-    
+
     public void setMELI_MET_SITE(String meliMetSite) {
         this.meliMetSite = meliMetSite;
     }
-    
+
     public String getMELMS_PTID() {
         return melmsPtid;
     }
-    
+
     public void setMELMS_PTID(String melmsPtid) {
         this.melmsPtid = melmsPtid;
     }
-    
+
     public String getMELMS_SITE_TYPE_DESC() {
         return melmsSiteTypeDesc;
     }
-    
+
     public void setMELMS_SITE_TYPE_DESC(String melmsSiteTypeDesc) {
         this.melmsSiteTypeDesc = melmsSiteTypeDesc;
     }
-    
+
     public String getMELMS_SITE_DESC() {
         return melmsSiteDesc;
     }
-    
+
     public void setMELMS_SITE_DESC(String melmsSiteDesc) {
         this.melmsSiteDesc = melmsSiteDesc;
     }
@@ -870,11 +870,11 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
     public String getMELMS_SITE_YEAR() {
         return melmsSiteYear;
     }
-    
+
     public void setMELMS_SITE_YEAR(String melmsSiteYear) {
         this.melmsSiteYear = melmsSiteYear;
-    }    
-    
+    }
+
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
@@ -919,13 +919,13 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
         fieldNames.add("MELP_REGRESSION_DESC");
         fieldNames.add("MELP_MARGINS_DESC");
         fieldNames.add("MELP_MITIDX_UNK_DESC");
-        fieldNames.add("MELP_HIST_TYPE_DESC");        
+        fieldNames.add("MELP_HIST_TYPE_DESC");
         fieldNames.add("MELP_SATELLITES_DESC");
         fieldNames.add("MELP_EXT_SLIDES_DESC");
         fieldNames.add("MELP_LNORG_DX_DESC");
         fieldNames.add("MELP_LNCLIN_STS_DESC");
         fieldNames.add("MELP_LNSENTINBX_DESC");
-        fieldNames.add("MELP_LNSENTINBX_YEAR"); 
+        fieldNames.add("MELP_LNSENTINBX_YEAR");
         fieldNames.add("MELP_LNPROLYSCT_DESC");
         fieldNames.add("MELP_LNPROSUCC_DESC");
         fieldNames.add("MELP_LNDSCT_CMP_DESC");
@@ -951,7 +951,7 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
 
         return fieldNames;
     }
-    
+
     public List<String> getAllVariables() {
         List<String> fieldNames = getFieldNames();
         fieldNames.add("MELSPC_PTID");
@@ -959,16 +959,16 @@ public class Skcm_mskcc_2015_chantClinicalRecord {
         fieldNames.add("MELG_PTID");
         fieldNames.add("MELI_PTID");
         fieldNames.add("MELMS_PTID");
-        
+
         return fieldNames;
     }
-    
+
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
-    }    
-    
+    }
+
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantNormalizedClinicalRecord.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantNormalizedClinicalRecord.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,8 +33,8 @@
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.cbioportal.cmo.pipelines.common.util.ClinicalValueUtil;
 
 public class Skcm_mskcc_2015_chantNormalizedClinicalRecord {
     private String patientId;
@@ -103,12 +103,12 @@ public class Skcm_mskcc_2015_chantNormalizedClinicalRecord {
     private String initialMetDisease;
     private String otherSitesOfMets;
     private String yearMetDiseaseIdentified;
-    
-    private Map<String, Object> additionalProperties;    
-    
+
+    private Map<String, Object> additionalProperties;
+
     public Skcm_mskcc_2015_chantNormalizedClinicalRecord() {
     }
-    
+
     public Skcm_mskcc_2015_chantNormalizedClinicalRecord(
              String patientId,
              String sampleId,
@@ -176,90 +176,90 @@ public class Skcm_mskcc_2015_chantNormalizedClinicalRecord {
              String initialMetDisease,
              String otherSitesOfMets,
              String yearMetDiseaseIdentified) {
-        this.patientId = StringUtils.isNotEmpty(patientId) ? patientId : "NA";
-        this.sampleId = StringUtils.isNotEmpty(sampleId) ? sampleId : "NA";
-        this.stageYear = StringUtils.isNotEmpty(stageYear) ? stageYear : "NA";
-        this.stgGrpName = StringUtils.isNotEmpty(stgGrpName) ? stgGrpName : "NA";
-        this.vitalStatus = StringUtils.isNotEmpty(vitalStatus) ? vitalStatus : "NA";
-        this.stsSrcDesc = StringUtils.isNotEmpty(stsSrcDesc) ? stsSrcDesc : "NA";
-        this.lastStatus = StringUtils.isNotEmpty(lastStatus) ? lastStatus : "NA";
-        this.dermagrphxDes = StringUtils.isNotEmpty(dermagrphxDes) ? dermagrphxDes : "NA";
-        this.presStgYear = StringUtils.isNotEmpty(presStgYear) ? presStgYear : "NA";
-        this.familyHistory = StringUtils.isNotEmpty(familyHistory) ? familyHistory : "NA";
-        this.timeToFirstRecurrence = StringUtils.isNotEmpty(timeToFirstRecurrence) ? timeToFirstRecurrence : "NA";
-        this.localDesc = StringUtils.isNotEmpty(localDesc) ? localDesc : "NA";
-        this.nodalDesc = StringUtils.isNotEmpty(nodalDesc) ? nodalDesc : "NA";
-        this.intransitDesc = StringUtils.isNotEmpty(intransitDesc) ? intransitDesc : "NA";
-        this.sysDesc = StringUtils.isNotEmpty(sysDesc) ? sysDesc : "NA";
-        this.recurNdszDes = StringUtils.isNotEmpty(recurNdszDes) ? recurNdszDes : "NA";
-        this.recurNodalNo = StringUtils.isNotEmpty(recurNodalNo) ? recurNodalNo : "NA";
-        this.ldh = StringUtils.isNotEmpty(ldh) ? ldh : "NA";
-        this.ldhYear = StringUtils.isNotEmpty(ldhYear) ? ldhYear : "NA";
-        this.metastasis = StringUtils.isNotEmpty(metastasis) ? metastasis : "NA";
-        this.adjvntTx = StringUtils.isNotEmpty(adjvntTx) ? adjvntTx : "NA";
-        this.systemicTreatment = StringUtils.isNotEmpty(systemicTreatment) ? systemicTreatment : "NA";
-        this.treatmentRadiation = StringUtils.isNotEmpty(treatmentRadiation) ? treatmentRadiation : "NA";
-        this.surgery = StringUtils.isNotEmpty(surgery) ? surgery : "NA";
-        this.tissueBankAvail = StringUtils.isNotEmpty(tissueBankAvail) ? tissueBankAvail : "NA";
-        this.primSeq = StringUtils.isNotEmpty(primSeq) ? primSeq : "NA";
-        this.yearOfDiagnosis = StringUtils.isNotEmpty(yearOfDiagnosis) ? yearOfDiagnosis : "NA";
-        this.mskReviewDes = StringUtils.isNotEmpty(mskReviewDes) ? mskReviewDes : "NA";
-        this.tumorThicknessMeasurement = StringUtils.isNotEmpty(tumorThicknessMeasurement) ? tumorThicknessMeasurement : "NA";
-        this.clarkLevelAtDiagnosis = StringUtils.isNotEmpty(clarkLevelAtDiagnosis) ? clarkLevelAtDiagnosis : "NA";
-        this.primaryMelanomaTumorUlceration = StringUtils.isNotEmpty(primaryMelanomaTumorUlceration) ? primaryMelanomaTumorUlceration : "NA";
-        this.tumorTissueSite = StringUtils.isNotEmpty(tumorTissueSite) ? tumorTissueSite : "NA";
-        this.detailedPrimarySite = StringUtils.isNotEmpty(detailedPrimarySite) ? detailedPrimarySite : "NA";
-        this.lymphocyteInfiltration = StringUtils.isNotEmpty(lymphocyteInfiltration) ? lymphocyteInfiltration : "NA";
-        this.regressionDes = StringUtils.isNotEmpty(regressionDes) ? regressionDes : "NA";
-        this.marginStatus = StringUtils.isNotEmpty(marginStatus) ? marginStatus : "NA";
-        this.mitoticIndex = StringUtils.isNotEmpty(mitoticIndex) ? mitoticIndex : "NA";
-        this.histologicalType = StringUtils.isNotEmpty(histologicalType) ? histologicalType : "NA";
-        this.satellitesDes = StringUtils.isNotEmpty(satellitesDes) ? satellitesDes : "NA";
-        this.extSlidesDes = StringUtils.isNotEmpty(extSlidesDes) ? extSlidesDes : "NA";
-        this.primaryLymphNodePresentationAssessment = StringUtils.isNotEmpty(primaryLymphNodePresentationAssessment) ? primaryLymphNodePresentationAssessment : "NA";
-        this.lnclinStsDes = StringUtils.isNotEmpty(lnclinStsDes) ? lnclinStsDes : "NA";
-        this.lnsentinbxDes = StringUtils.isNotEmpty(lnsentinbxDes) ? lnsentinbxDes : "NA";
-        this.lnsentinbxYea = StringUtils.isNotEmpty(lnsentinbxYea) ? lnsentinbxYea : "NA";
-        this.lnprolysctDes = StringUtils.isNotEmpty(lnprolysctDes) ? lnprolysctDes : "NA";
-        this.lnprosuccDesc = StringUtils.isNotEmpty(lnprosuccDesc) ? lnprosuccDesc : "NA";
-        this.lndsctCmpDes = StringUtils.isNotEmpty(lndsctCmpDes) ? lndsctCmpDes : "NA";
-        this.lndsctYear = StringUtils.isNotEmpty(lndsctYear) ? lndsctYear : "NA";
-        this.lnmattedDesc = StringUtils.isNotEmpty(lnmattedDesc) ? lnmattedDesc : "NA";
-        this.lnextnodstDes = StringUtils.isNotEmpty(lnextnodstDes) ? lnextnodstDes : "NA";
-        this.lnintrmetsDes = StringUtils.isNotEmpty(lnintrmetsDes) ? lnintrmetsDes : "NA";
-        this.lnsize = StringUtils.isNotEmpty(lnsize) ? lnsize : "NA";
-        this.lnsizeUnkDes = StringUtils.isNotEmpty(lnsizeUnkDes) ? lnsizeUnkDes : "NA";
-        this.lnslnlargSize = StringUtils.isNotEmpty(lnslnlargSize) ? lnslnlargSize : "NA";
-        this.lnihcDesc = StringUtils.isNotEmpty(lnihcDesc) ? lnihcDesc : "NA";
-        this.s100Stain = StringUtils.isNotEmpty(s100Stain) ? s100Stain : "NA";
-        this.lnimmhmb45Des = StringUtils.isNotEmpty(lnimmhmb45Des) ? lnimmhmb45Des : "NA";
-        this.lnimmMelaDes = StringUtils.isNotEmpty(lnimmMelaDes) ? lnimmMelaDes : "NA";
-        this.reportYear = StringUtils.isNotEmpty(reportYear) ? reportYear : "NA";
-        this.procedureYear = StringUtils.isNotEmpty(procedureYear) ? procedureYear : "NA";
-        this.tumorType = StringUtils.isNotEmpty(tumorType) ? tumorType : "NA";
-        this.primarySite = StringUtils.isNotEmpty(primarySite) ? primarySite : "NA";
-        this.metastaticSite = StringUtils.isNotEmpty(metastaticSite) ? metastaticSite : "NA";
-        this.initialMetDisease = StringUtils.isNotEmpty(initialMetDisease) ? initialMetDisease : "NA";
-        this.otherSitesOfMets = StringUtils.isNotEmpty(otherSitesOfMets) ? otherSitesOfMets : "NA";
-        this.yearMetDiseaseIdentified = StringUtils.isNotEmpty(yearMetDiseaseIdentified) ? yearMetDiseaseIdentified : "NA";
+        this.patientId = ClinicalValueUtil.defaultWithNA(patientId);
+        this.sampleId = ClinicalValueUtil.defaultWithNA(sampleId);
+        this.stageYear = ClinicalValueUtil.defaultWithNA(stageYear);
+        this.stgGrpName = ClinicalValueUtil.defaultWithNA(stgGrpName);
+        this.vitalStatus = ClinicalValueUtil.defaultWithNA(vitalStatus);
+        this.stsSrcDesc = ClinicalValueUtil.defaultWithNA(stsSrcDesc);
+        this.lastStatus = ClinicalValueUtil.defaultWithNA(lastStatus);
+        this.dermagrphxDes = ClinicalValueUtil.defaultWithNA(dermagrphxDes);
+        this.presStgYear = ClinicalValueUtil.defaultWithNA(presStgYear);
+        this.familyHistory = ClinicalValueUtil.defaultWithNA(familyHistory);
+        this.timeToFirstRecurrence = ClinicalValueUtil.defaultWithNA(timeToFirstRecurrence);
+        this.localDesc = ClinicalValueUtil.defaultWithNA(localDesc);
+        this.nodalDesc = ClinicalValueUtil.defaultWithNA(nodalDesc);
+        this.intransitDesc = ClinicalValueUtil.defaultWithNA(intransitDesc);
+        this.sysDesc = ClinicalValueUtil.defaultWithNA(sysDesc);
+        this.recurNdszDes = ClinicalValueUtil.defaultWithNA(recurNdszDes);
+        this.recurNodalNo = ClinicalValueUtil.defaultWithNA(recurNodalNo);
+        this.ldh = ClinicalValueUtil.defaultWithNA(ldh);
+        this.ldhYear = ClinicalValueUtil.defaultWithNA(ldhYear);
+        this.metastasis = ClinicalValueUtil.defaultWithNA(metastasis);
+        this.adjvntTx = ClinicalValueUtil.defaultWithNA(adjvntTx);
+        this.systemicTreatment = ClinicalValueUtil.defaultWithNA(systemicTreatment);
+        this.treatmentRadiation = ClinicalValueUtil.defaultWithNA(treatmentRadiation);
+        this.surgery = ClinicalValueUtil.defaultWithNA(surgery);
+        this.tissueBankAvail = ClinicalValueUtil.defaultWithNA(tissueBankAvail);
+        this.primSeq = ClinicalValueUtil.defaultWithNA(primSeq);
+        this.yearOfDiagnosis = ClinicalValueUtil.defaultWithNA(yearOfDiagnosis);
+        this.mskReviewDes = ClinicalValueUtil.defaultWithNA(mskReviewDes);
+        this.tumorThicknessMeasurement = ClinicalValueUtil.defaultWithNA(tumorThicknessMeasurement);
+        this.clarkLevelAtDiagnosis = ClinicalValueUtil.defaultWithNA(clarkLevelAtDiagnosis);
+        this.primaryMelanomaTumorUlceration = ClinicalValueUtil.defaultWithNA(primaryMelanomaTumorUlceration);
+        this.tumorTissueSite = ClinicalValueUtil.defaultWithNA(tumorTissueSite);
+        this.detailedPrimarySite = ClinicalValueUtil.defaultWithNA(detailedPrimarySite);
+        this.lymphocyteInfiltration = ClinicalValueUtil.defaultWithNA(lymphocyteInfiltration);
+        this.regressionDes = ClinicalValueUtil.defaultWithNA(regressionDes);
+        this.marginStatus = ClinicalValueUtil.defaultWithNA(marginStatus);
+        this.mitoticIndex = ClinicalValueUtil.defaultWithNA(mitoticIndex);
+        this.histologicalType = ClinicalValueUtil.defaultWithNA(histologicalType);
+        this.satellitesDes = ClinicalValueUtil.defaultWithNA(satellitesDes);
+        this.extSlidesDes = ClinicalValueUtil.defaultWithNA(extSlidesDes);
+        this.primaryLymphNodePresentationAssessment = ClinicalValueUtil.defaultWithNA(primaryLymphNodePresentationAssessment);
+        this.lnclinStsDes = ClinicalValueUtil.defaultWithNA(lnclinStsDes);
+        this.lnsentinbxDes = ClinicalValueUtil.defaultWithNA(lnsentinbxDes);
+        this.lnsentinbxYea = ClinicalValueUtil.defaultWithNA(lnsentinbxYea);
+        this.lnprolysctDes = ClinicalValueUtil.defaultWithNA(lnprolysctDes);
+        this.lnprosuccDesc = ClinicalValueUtil.defaultWithNA(lnprosuccDesc);
+        this.lndsctCmpDes = ClinicalValueUtil.defaultWithNA(lndsctCmpDes);
+        this.lndsctYear = ClinicalValueUtil.defaultWithNA(lndsctYear);
+        this.lnmattedDesc = ClinicalValueUtil.defaultWithNA(lnmattedDesc);
+        this.lnextnodstDes = ClinicalValueUtil.defaultWithNA(lnextnodstDes);
+        this.lnintrmetsDes = ClinicalValueUtil.defaultWithNA(lnintrmetsDes);
+        this.lnsize = ClinicalValueUtil.defaultWithNA(lnsize);
+        this.lnsizeUnkDes = ClinicalValueUtil.defaultWithNA(lnsizeUnkDes);
+        this.lnslnlargSize = ClinicalValueUtil.defaultWithNA(lnslnlargSize);
+        this.lnihcDesc = ClinicalValueUtil.defaultWithNA(lnihcDesc);
+        this.s100Stain = ClinicalValueUtil.defaultWithNA(s100Stain);
+        this.lnimmhmb45Des = ClinicalValueUtil.defaultWithNA(lnimmhmb45Des);
+        this.lnimmMelaDes = ClinicalValueUtil.defaultWithNA(lnimmMelaDes);
+        this.reportYear = ClinicalValueUtil.defaultWithNA(reportYear);
+        this.procedureYear = ClinicalValueUtil.defaultWithNA(procedureYear);
+        this.tumorType = ClinicalValueUtil.defaultWithNA(tumorType);
+        this.primarySite = ClinicalValueUtil.defaultWithNA(primarySite);
+        this.metastaticSite = ClinicalValueUtil.defaultWithNA(metastaticSite);
+        this.initialMetDisease = ClinicalValueUtil.defaultWithNA(initialMetDisease);
+        this.otherSitesOfMets = ClinicalValueUtil.defaultWithNA(otherSitesOfMets);
+        this.yearMetDiseaseIdentified = ClinicalValueUtil.defaultWithNA(yearMetDiseaseIdentified);
     }
-    
+
     public String getPATIENT_ID() {
         return patientId;
     }
-    
+
     public void setPATIENT_ID(String patientId) {
         this.patientId = patientId;
     }
-    
+
     public String getSAMPLE_ID() {
         return sampleId;
     }
-    
+
     public void setSAMPLE_ID(String sampleId) {
         this.sampleId = sampleId;
     }
-    
+
     public String getSTAGE_YEAR() {
         return this.stageYear;
     }
@@ -847,13 +847,13 @@ public class Skcm_mskcc_2015_chantNormalizedClinicalRecord {
         fieldNames.add("YEAR_MET_DISEASE_IDENTIFIED");
         return fieldNames;
     }
-    
+
     public void setAdditionalProperty(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
-    }    
-    
+    }
+
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantTimelineAdjuvantTx.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantTimelineAdjuvantTx.java
@@ -1,20 +1,47 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
+ * Center has been advised of the possibility of such damage.
  */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.cbioportal.cmo.pipelines.common.util.ClinicalValueUtil;
 
 /**
  *
  * @author heinsz
  */
-public class Skcm_mskcc_2015_chantTimelineAdjuvantTx implements Skcm_mskcc_2015_chantTimelineRecord { 
-    
+public class Skcm_mskcc_2015_chantTimelineAdjuvantTx implements Skcm_mskcc_2015_chantTimelineRecord {
+
     private String melatPtid;
     private Integer melatAdjtxTypCd;
     private String melatAdjtxTypDesc;
@@ -22,91 +49,91 @@ public class Skcm_mskcc_2015_chantTimelineAdjuvantTx implements Skcm_mskcc_2015_
     private Integer melatAdjtxStrtYear;
     private Integer melatAdjtxEndYear;
     private Integer melatAdjtxDaysDuration;
-    
+
     public Skcm_mskcc_2015_chantTimelineAdjuvantTx() {}
-    
-    public Skcm_mskcc_2015_chantTimelineAdjuvantTx(String melatPtid, 
-            Integer melatAdjtxTypCd, 
+
+    public Skcm_mskcc_2015_chantTimelineAdjuvantTx(String melatPtid,
+            Integer melatAdjtxTypCd,
             String melatAdjtxTypDesc,
             String melatAdjtxTypeOth,
             Integer melatAdjtxStrtYear,
             Integer melatAdjtxEndYear,
             Integer melatAdjtxDaysDuration) {
-        this.melatPtid = StringUtils.isNotEmpty(melatPtid) ? melatPtid : "NA";
+        this.melatPtid = ClinicalValueUtil.defaultWithNA(melatPtid);
         this.melatAdjtxTypCd = melatAdjtxTypCd != null ? melatAdjtxTypCd : -1;
-        this.melatAdjtxTypDesc = StringUtils.isNotEmpty(melatAdjtxTypDesc) ? melatAdjtxTypDesc : "NA";
-        this.melatAdjtxTypeOth = StringUtils.isNotEmpty(melatAdjtxTypeOth) ? melatAdjtxTypeOth : "NA";
+        this.melatAdjtxTypDesc = ClinicalValueUtil.defaultWithNA(melatAdjtxTypDesc);
+        this.melatAdjtxTypeOth = ClinicalValueUtil.defaultWithNA(melatAdjtxTypeOth);
         this.melatAdjtxStrtYear = melatAdjtxStrtYear != null ? melatAdjtxStrtYear : -1;
         this.melatAdjtxEndYear = melatAdjtxEndYear != null ? melatAdjtxEndYear : -1;
         this.melatAdjtxDaysDuration = melatAdjtxDaysDuration != null ? melatAdjtxDaysDuration : -1;
     }
-    
+
     public String getMELAT_PTID() {
         return melatPtid;
     }
-    
+
     public void setMELAT_PTID(String melatPtid) {
         this.melatPtid = melatPtid;
     }
-    
+
     public Integer getMELAT_ADJTX_TYP_CD() {
         return melatAdjtxTypCd;
     }
-    
+
     public void setMELAT_ADJTX_TYP_CD(Integer melatAdjtxTypCd) {
         this.melatAdjtxTypCd = melatAdjtxTypCd;
-    }    
-    
+    }
+
     public String getMELAT_ADJTX_TYP_DESC() {
         return melatAdjtxTypDesc;
     }
-    
+
     public void setMELAT_ADJTX_TYP_DESC(String melatAdjtxTypDesc) {
         this.melatAdjtxTypDesc = melatAdjtxTypDesc;
-    }    
+    }
 
     public String getMELAT_ADJTX_TYPE_OTH() {
         return melatAdjtxTypeOth;
     }
-    
+
     public void setMELAT_ADJTX_TYPE_OTH(String melatAdjtxTypeOth) {
         this.melatAdjtxTypeOth = melatAdjtxTypeOth;
-    }    
+    }
 
     public Integer getMELAT_ADJTX_STRT_YEAR() {
         return melatAdjtxStrtYear;
     }
-    
+
     public void setMELAT_ADJTX_STRT_YEAR(Integer melatAdjtxStrtYear) {
         this.melatAdjtxStrtYear = melatAdjtxStrtYear;
-    }        
-    
+    }
+
     public Integer getMELAT_ADJTX_END_YEAR() {
         return melatAdjtxEndYear;
     }
-    
+
     public void setMELAT_ADJTX_END_YEAR(Integer melatAdjtxEndYear) {
         this.melatAdjtxEndYear = melatAdjtxEndYear;
-    }      
-    
+    }
+
     public Integer getMELAT_ADJTX_DAYS_DURATION() {
         return melatAdjtxDaysDuration;
     }
-    
+
     public void setMELAT_ADJTX_DAYS_DURATION(Integer melatAdjtxDaysDuration) {
         this.melatAdjtxDaysDuration = melatAdjtxDaysDuration;
-    } 
+    }
 
     public List<String> getFieldNames() {
         List<String> fieldNames = new ArrayList<>();
-        
+
         fieldNames.add("PATIENT_ID");
         fieldNames.add("START_DATE");
         fieldNames.add("STOP_DATE");
         fieldNames.add("EVENT_TYPE");
         fieldNames.add("TREATMENT_TYPE");
         fieldNames.add("SUBTYPE");
-                
+
         return fieldNames;
     }
 
@@ -114,7 +141,7 @@ public class Skcm_mskcc_2015_chantTimelineAdjuvantTx implements Skcm_mskcc_2015_
     public String getPATIENT_ID() {
         return melatPtid;
     }
-    
+
     // due to insufficient data in darwin, start date is 0
     @Override
     public String getSTART_DATE() {
@@ -134,7 +161,7 @@ public class Skcm_mskcc_2015_chantTimelineAdjuvantTx implements Skcm_mskcc_2015_
     @Override
     public String getTREATMENT_TYPE() {
         return melatAdjtxTypDesc;
-        
+
     }
 
     @Override

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantTimelineRadTherapy.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantTimelineRadTherapy.java
@@ -1,20 +1,47 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
+ * Center has been advised of the possibility of such damage.
  */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.cbioportal.cmo.pipelines.common.util.ClinicalValueUtil;
 
 /**
  *
  * @author heinsz
  */
 public class Skcm_mskcc_2015_chantTimelineRadTherapy implements Skcm_mskcc_2015_chantTimelineRecord {
-    
+
     private String melrtPtid;
     private String melrtRttxTypeDesc;
     private String melrtRttxAdjDesc;
@@ -31,26 +58,26 @@ public class Skcm_mskcc_2015_chantTimelineRadTherapy implements Skcm_mskcc_2015_
             Integer melrtRttxEndDt,
             Integer melatRttxDaysDuration
             ) {
-        this.melrtPtid = StringUtils.isNotEmpty(melrtPtid) ? melrtPtid : "NA";
-        this.melrtRttxTypeDesc = StringUtils.isNotEmpty(melrtRttxTypeDesc) ? melrtRttxTypeDesc : "NA";
-        this.melrtRttxAdjDesc = StringUtils.isNotEmpty(melrtRttxAdjDesc) ? melrtRttxAdjDesc : "NA";
+        this.melrtPtid = ClinicalValueUtil.defaultWithNA(melrtPtid);
+        this.melrtRttxTypeDesc = ClinicalValueUtil.defaultWithNA(melrtRttxTypeDesc);
+        this.melrtRttxAdjDesc = ClinicalValueUtil.defaultWithNA(melrtRttxAdjDesc);
         this.melrtRttxStrtYear = melrtRttxStrtYear != null ? melrtRttxStrtYear : -1;
         this.melrtRttxEndDt = melrtRttxEndDt != null ? melrtRttxEndDt : -1;
         this.melatRttxDaysDuration = melatRttxDaysDuration != null ? melatRttxDaysDuration : -1;
-    }        
-    
+    }
+
     public String getMELRT_PTID() {
         return melrtPtid;
     }
-    
+
     public void setMELRT_PTID(String melrtPtid) {
         this.melrtPtid = melrtPtid;
     }
-    
+
     public String getMELRT_RTTX_TYPE_DESC() {
         return melrtRttxTypeDesc;
     }
-    
+
     public void setMELRT_RTTX_TYPE_DESC(String melrtRttxTypeDesc) {
         this.melrtRttxTypeDesc = melrtRttxTypeDesc;
     }
@@ -58,53 +85,53 @@ public class Skcm_mskcc_2015_chantTimelineRadTherapy implements Skcm_mskcc_2015_
     public String getMELRT_RTTX_ADJ_DESC() {
         return melrtRttxAdjDesc;
     }
-    
+
     public void setMELRT_RTTX_ADJ_DESC(String melrtRttxAdjDesc) {
         this.melrtRttxAdjDesc = melrtRttxAdjDesc;
-    }   
-    
+    }
+
     public Integer getMELRT_RTTX_STRT_YEAR() {
         return melrtRttxStrtYear;
     }
-    
+
     public void setMELRT_RTTX_STRT_YEAR(Integer melrtRttxStrtYear) {
         this.melrtRttxStrtYear = melrtRttxStrtYear;
-    }       
-    
+    }
+
     public Integer getMELRT_RTTX_END_DT() {
         return melrtRttxEndDt;
     }
-    
+
     public void setMELRT_RTTX_END_DT(Integer melrtRttxEndDt) {
         this.melrtRttxEndDt = melrtRttxEndDt;
-    } 
+    }
 
     public Integer getMELAT_RTTX_DAYS_DURATION() {
         return melatRttxDaysDuration;
     }
-    
+
     public void setMELAT_RTTX_DAYS_DURATION(Integer melatRttxDaysDuration) {
         this.melatRttxDaysDuration = melatRttxDaysDuration;
-    }     
-    
+    }
+
     public List<String> getFieldNames() {
         List<String> fieldNames = new ArrayList<>();
-        
+
         fieldNames.add("PATIENT_ID");
         fieldNames.add("START_DATE");
         fieldNames.add("STOP_DATE");
         fieldNames.add("EVENT_TYPE");
         fieldNames.add("TREATMENT_TYPE");
         fieldNames.add("SUBTYPE");
-                
+
         return fieldNames;
-    }    
+    }
 
     @Override
     public String getPATIENT_ID() {
         return melrtPtid;
     }
-    
+
     // due to insufficient data in darwin, start date is 0
     @Override
     public String getSTART_DATE() {
@@ -124,12 +151,12 @@ public class Skcm_mskcc_2015_chantTimelineRadTherapy implements Skcm_mskcc_2015_
     @Override
     public String getTREATMENT_TYPE() {
         return melrtRttxTypeDesc;
-        
+
     }
 
     @Override
     public String getSUBTYPE() {
         return melrtRttxAdjDesc;
     }
-    
+
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantTimelineSystemicTx.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/model/Skcm_mskcc_2015_chantTimelineSystemicTx.java
@@ -1,31 +1,58 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
+ * Center has been advised of the possibility of such damage.
  */
+
+/*
+ * This file is part of cBioPortal CMO-Pipelines.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package org.mskcc.cmo.ks.darwin.pipeline.model;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.cbioportal.cmo.pipelines.common.util.ClinicalValueUtil;
 
 /**
  *
  * @author heinsz
  */
 public class Skcm_mskcc_2015_chantTimelineSystemicTx implements Skcm_mskcc_2015_chantTimelineRecord {
-    
+
     private String melstPtid;
     private String melstSystxTypDesc;
     private String melstSystxTypeOth;
     private Integer melstSystxStrtYear;
     private Integer melstSystxEndYear;
-    private Integer melstSystxDaysDuration;  
+    private Integer melstSystxDaysDuration;
     private List<String> EXCLUDED_TREATMENTS = Arrays.asList("Vaccine, please specify", "CombChemo, please specify", "Other, please specify", "HILP/ILI, please specify");
 
     public Skcm_mskcc_2015_chantTimelineSystemicTx() {}
-    
+
     public Skcm_mskcc_2015_chantTimelineSystemicTx(String melstPtid,
             String melstSystxTypDesc,
             String melstSystxTypeOth,
@@ -33,26 +60,26 @@ public class Skcm_mskcc_2015_chantTimelineSystemicTx implements Skcm_mskcc_2015_
             Integer melstSystxEndYear,
             Integer melstSystxDaysDuration
             ) {
-        this.melstPtid = StringUtils.isNotEmpty(melstPtid) ? melstPtid : "NA";
-        this.melstSystxTypDesc = StringUtils.isNotEmpty(melstSystxTypDesc) ? melstSystxTypDesc : "NA";
-        this.melstSystxTypeOth = StringUtils.isNotEmpty(melstSystxTypeOth) ? melstSystxTypeOth : "NA";
+        this.melstPtid = ClinicalValueUtil.defaultWithNA(melstPtid);
+        this.melstSystxTypDesc = ClinicalValueUtil.defaultWithNA(melstSystxTypDesc);
+        this.melstSystxTypeOth = ClinicalValueUtil.defaultWithNA(melstSystxTypeOth);
         this.melstSystxStrtYear = melstSystxStrtYear != null ? melstSystxStrtYear : -1;
         this.melstSystxEndYear = melstSystxEndYear != null ? melstSystxEndYear : -1;
         this.melstSystxDaysDuration = melstSystxDaysDuration != null ? melstSystxDaysDuration : -1;
-    }        
-    
+    }
+
     public String getMELST_PTID() {
         return melstPtid;
     }
-    
+
     public void setMELST_PTID(String melstPtid) {
         this.melstPtid = melstPtid;
     }
-    
+
     public String getMELST_SYSTX_TYP_DESC() {
         return melstSystxTypDesc;
     }
-    
+
     public void setMELST_SYSTX_TYP_DESC(String melstSystxTypeDesc) {
         this.melstSystxTypDesc = melstSystxTypeDesc;
     }
@@ -60,53 +87,53 @@ public class Skcm_mskcc_2015_chantTimelineSystemicTx implements Skcm_mskcc_2015_
     public String getMELST_SYSTX_TYPE_OTH() {
         return melstSystxTypeOth;
     }
-    
+
     public void setMELST_SYSTX_TYPE_OTH(String melstSystxTypeOth) {
         this.melstSystxTypeOth = melstSystxTypeOth;
-    }   
-    
+    }
+
     public Integer getMELST_SYSTX_STRT_YEAR() {
         return melstSystxStrtYear;
     }
-    
+
     public void setMELST_SYSTX_STRT_YEAR(Integer melstSystxStrtYear) {
         this.melstSystxStrtYear = melstSystxStrtYear;
-    }       
-    
+    }
+
     public Integer getMELST_SYSTX_END_YEAR() {
         return melstSystxEndYear;
     }
-    
+
     public void setMELST_SYSTX_END_YEAR(Integer melstSystxEndYear) {
         this.melstSystxEndYear = melstSystxEndYear;
-    } 
+    }
 
     public Integer getMELST_SYSTX_DAYS_DURATION() {
         return melstSystxDaysDuration;
     }
-    
+
     public void setMELST_SYSTX_DAYS_DURATION(Integer melstSystxDaysDuration) {
         this.melstSystxDaysDuration = melstSystxDaysDuration;
-    } 
-    
+    }
+
     public List<String> getFieldNames() {
         List<String> fieldNames = new ArrayList<>();
-        
+
         fieldNames.add("PATIENT_ID");
         fieldNames.add("START_DATE");
         fieldNames.add("STOP_DATE");
         fieldNames.add("EVENT_TYPE");
         fieldNames.add("TREATMENT_TYPE");
         fieldNames.add("SUBTYPE");
-                
+
         return fieldNames;
-    }    
+    }
 
     @Override
     public String getPATIENT_ID() {
         return melstPtid;
     }
-    
+
     // due to insufficient data in darwin, start date is 0
     @Override
     public String getSTART_DATE() {

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -34,11 +34,10 @@ package org.mskcc.cmo.ks.darwin.pipeline.mskimpact_medicaltherapy;
 
 import java.util.*;
 import org.apache.commons.collections.map.MultiKeyMap;
-import org.apache.commons.lang.StringUtils;
 import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactMedicalTherapy;
 import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * This processor takes a list of medical therapy records all for a single patient, grouped by

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyTimelineWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpact_medicaltherapy/MskimpactMedicalTherapyTimelineWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,18 +29,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.mskimpact_medicaltherapy;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactMedicalTherapy;
-
-import org.springframework.batch.item.*;
-import org.springframework.batch.item.file.*;
-import org.springframework.core.io.*;
-import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
-import org.springframework.beans.factory.annotation.Value;
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactMedicalTherapy;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.*;
 
 /**
  * @author Benjamin Gross
@@ -49,7 +48,7 @@ public class MskimpactMedicalTherapyTimelineWriter implements ItemStreamWriter<M
 {
     @Value("#{jobParameters[outputDirectory]}")
     private String outputDirectory;
-    
+
     @Value("${darwin.medicaltherapy_timeline_filename}")
     private String outputFilename;
 
@@ -57,7 +56,7 @@ public class MskimpactMedicalTherapyTimelineWriter implements ItemStreamWriter<M
 
     private List<String> writeList = new ArrayList<>();
     private FlatFileItemWriter<String> flatFileItemWriter = new FlatFileItemWriter<>();
-        
+
     @Override
     public void open(ExecutionContext executionContext) throws ItemStreamException{
         PassThroughLineAggregator aggr = new PassThroughLineAggregator();
@@ -65,22 +64,22 @@ public class MskimpactMedicalTherapyTimelineWriter implements ItemStreamWriter<M
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback(){
             @Override
             public void writeHeader(Writer writer) throws IOException{
-                writer.write(StringUtils.join(MskimpactMedicalTherapy.getHeaders(), "\t"));
+                writer.write(String.join("\t", MskimpactMedicalTherapy.getHeaders()));
             }
         });
         stagingFile = outputDirectory + File.separator + outputFilename;
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
         flatFileItemWriter.open(executionContext);
     }
-    
+
     @Override
     public void update(ExecutionContext executionContext) throws ItemStreamException{}
-    
+
     @Override
     public void close() throws ItemStreamException{
         flatFileItemWriter.close();
     }
-    
+
     @Override
     public void write(List<? extends MskimpactMedicalTherapy> items) throws Exception {
         // TBD: figure out why we cannot pass items to FlatFileItemWriter directly

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactbrainspineclinical/MskimpactBrainSpineClinicalWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactbrainspineclinical/MskimpactBrainSpineClinicalWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,19 +29,19 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.mskimpactbrainspineclinical;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineClinical;
-
 import com.google.common.base.Strings;
-import org.springframework.batch.item.*;
-import org.springframework.batch.item.file.*;
-import org.springframework.core.io.*;
-import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
-import org.springframework.beans.factory.annotation.Value;
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineClinical;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.*;
+
 /**
  *
  * @author jake
@@ -65,7 +65,7 @@ public class MskimpactBrainSpineClinicalWriter implements ItemStreamWriter<Strin
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback(){
             @Override
             public void writeHeader(Writer writer) throws IOException{
-                writer.write(StringUtils.join(new MskimpactBrainSpineClinical().getHeaders(), "\t"));
+                writer.write(String.join("\t", new MskimpactBrainSpineClinical().getHeaders()));
             }
         });
         stagingFile = new File(outputDirectory, datasetFilename);

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactbrainspinetimeline/MskimpactTimelineBrainSpineCompositeToCompositeProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactbrainspinetimeline/MskimpactTimelineBrainSpineCompositeToCompositeProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,11 +33,10 @@
 package org.mskcc.cmo.ks.darwin.pipeline.mskimpactbrainspinetimeline;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineCompositeTimeline;
 import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  *
@@ -62,7 +61,7 @@ public class MskimpactTimelineBrainSpineCompositeToCompositeProcessor implements
             recordPost.add(darwinUtils.convertWhitespace(value));
         }
         if(recordPost.contains(type.toString().toUpperCase())){
-            composite.getClass().getMethod("set" + type.toString() + "Result", String.class).invoke(composite, StringUtils.join(recordPost, "\t"));
+            composite.getClass().getMethod("set" + type.toString() + "Result", String.class).invoke(composite, String.join("\t", recordPost));
         }
         return composite;
     }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactbrainspinetimeline/MskimpactTimelineBrainSpineModelToCompositeProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactbrainspinetimeline/MskimpactTimelineBrainSpineModelToCompositeProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,13 +33,12 @@
 package org.mskcc.cmo.ks.darwin.pipeline.mskimpactbrainspinetimeline;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineCompositeTimeline;
 import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineTimeline;
 import org.mskcc.cmo.ks.darwin.pipeline.mskimpactbrainspinetimeline.BrainSpineTimelineType;
 import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  *
@@ -65,7 +64,7 @@ public class MskimpactTimelineBrainSpineModelToCompositeProcessor implements Ite
             recordPost.add(darwinUtils.convertWhitespace(value));
         }
         if (recordPost.contains(type.toString().toUpperCase())) {
-            composite.getClass().getMethod("set" + type.toString() + "Result", String.class).invoke(composite, StringUtils.join(recordPost, "\t"));
+            composite.getClass().getMethod("set" + type.toString() + "Result", String.class).invoke(composite, String.join("\t", recordPost));
         }
         return composite;
     }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactbrainspinetimeline/MskimpactTimelineBrainSpineReader.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactbrainspinetimeline/MskimpactTimelineBrainSpineReader.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016-2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2018, 2023  Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,22 +29,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-package org.mskcc.cmo.ks.darwin.pipeline.mskimpactbrainspinetimeline;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineTimeline;
-import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinSampleListUtil;
+package org.mskcc.cmo.ks.darwin.pipeline.mskimpactbrainspinetimeline;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.sql.SQLQueryFactory;
-
-import org.springframework.batch.item.*;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
-import org.apache.log4j.Logger;
-
 import java.util.*;
+import org.apache.log4j.Logger;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineTimeline;
+import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinSampleListUtil;
+import org.springframework.batch.item.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.annotation.Transactional;
 import static com.querydsl.core.alias.Alias.*;
+
 /**
  *
  * @author jake
@@ -69,6 +68,11 @@ public class MskimpactTimelineBrainSpineReader implements ItemStreamReader<Mskim
         if (darwinTimelineResults == null || darwinTimelineResults.isEmpty()) {
             throw new ItemStreamException("Error fetching records from Darwin Brain Spine Timeline Views");
         }
+    }
+
+    // This method was added for unit testing of the read() method. An upgrade of mockito and jvp seems to not allow use of mocked objects (instantiated classes) into @Transactional blocks.
+    public void openForTestingAndSetDarwinTimelineResults(List<MskimpactBrainSpineTimeline> testingDarwinTimelineResults) {
+        darwinTimelineResults = testingDarwinTimelineResults;
     }
 
     @Transactional

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactbrainspinetimeline/MskimpactTimelineBrainSpineWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactbrainspinetimeline/MskimpactTimelineBrainSpineWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,21 +29,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.mskimpactbrainspinetimeline;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineCompositeTimeline;
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineTimeline;
-
 import com.google.common.base.Strings;
-import org.springframework.batch.item.*;
-import org.springframework.batch.item.file.*;
-import org.springframework.core.io.*;
-import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
-import org.springframework.beans.factory.annotation.Value;
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineCompositeTimeline;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineTimeline;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.*;
 
 /**
  *
@@ -75,7 +74,7 @@ public class MskimpactTimelineBrainSpineWriter implements ItemStreamWriter<Mskim
             public void writeHeader(Writer writer) throws IOException{
                 MskimpactBrainSpineTimeline mskImpactBrainSpineTimeline = new MskimpactBrainSpineTimeline();
                 try {
-                    writer.write(StringUtils.join((List<String>)mskImpactBrainSpineTimeline.getClass().getMethod("get" + type.toString() + "Headers").invoke(mskImpactBrainSpineTimeline), "\t"));
+                    writer.write(String.join("\t", (List<String>)mskImpactBrainSpineTimeline.getClass().getMethod("get" + type.toString() + "Headers").invoke(mskImpactBrainSpineTimeline)));
                 }
                 catch(Exception e) {
                     throw new ItemStreamException(e);

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactdemographics/MskimpactAgeWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactdemographics/MskimpactAgeWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016-2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,14 +29,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-package org.mskcc.cmo.ks.darwin.pipeline.mskimpactdemographics;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.*;
+package org.mskcc.cmo.ks.darwin.pipeline.mskimpactdemographics;
 
 import com.google.common.base.Strings;
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.darwin.pipeline.model.*;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
@@ -66,7 +65,7 @@ public class MskimpactAgeWriter implements ItemStreamWriter<MskimpactCompositeDe
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback(){
             @Override
             public void writeHeader(Writer writer) throws IOException{
-                writer.write(StringUtils.join(MskimpactPatientDemographics.getAgeHeaders(), "\t"));
+                writer.write(String.join("\t", MskimpactPatientDemographics.getAgeHeaders()));
             }
         });
         stagingFile = new File(outputDirectory, datasetFilename);

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactdemographics/MskimpactPatientDemographicsProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactdemographics/MskimpactPatientDemographicsProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,11 +32,9 @@
 
 package org.mskcc.cmo.ks.darwin.pipeline.mskimpactdemographics;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactPatientDemographics;
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactCompositeDemographics;
-
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactCompositeDemographics;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactPatientDemographics;
 import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinUtils;
 import org.mskcc.cmo.ks.darwin.pipeline.util.VitalStatusUtils;
 import org.springframework.batch.item.ItemProcessor;
@@ -54,23 +52,23 @@ public class MskimpactPatientDemographicsProcessor implements ItemProcessor<Mski
     @Override
     public MskimpactCompositeDemographics process(final MskimpactPatientDemographics darwinPatientDemographics) throws Exception{
         // format results for demographics, age, and survival status
-        List<String> patientDemographicsResult = new ArrayList<>();        
+        List<String> patientDemographicsResult = new ArrayList<>();
         for(String field : MskimpactPatientDemographics.getPatientDemographicsFieldNames()){
-            Object value = darwinPatientDemographics.getClass().getMethod("get"+field).invoke(darwinPatientDemographics);            
+            Object value = darwinPatientDemographics.getClass().getMethod("get"+field).invoke(darwinPatientDemographics);
             patientDemographicsResult.add(value != null ? darwinUtils.convertWhitespace(value.toString()) : "NA");
         }
         List<String> patientAgeResult = new ArrayList<>();
         for(String field : MskimpactPatientDemographics.getAgeFieldNames()){
-            Object value = darwinPatientDemographics.getClass().getMethod("get"+field).invoke(darwinPatientDemographics);            
+            Object value = darwinPatientDemographics.getClass().getMethod("get"+field).invoke(darwinPatientDemographics);
             patientAgeResult.add(value != null ? darwinUtils.convertWhitespace(value.toString()) : "NA");
         }
 
         List<String> patientVitalStatusResult = VitalStatusUtils.getVitalStatusResult(darwinUtils, darwinPatientDemographics);
 
         MskimpactCompositeDemographics compositeRecord = new MskimpactCompositeDemographics();
-        compositeRecord.setDemographicsResult(StringUtils.join(patientDemographicsResult, "\t"));
-        compositeRecord.setAgeResult(StringUtils.join(patientAgeResult, "\t"));
-        compositeRecord.setVitalStatusResult(StringUtils.join(patientVitalStatusResult, "\t"));
+        compositeRecord.setDemographicsResult(String.join("\t", patientDemographicsResult));
+        compositeRecord.setAgeResult(String.join("\t", patientAgeResult));
+        compositeRecord.setVitalStatusResult(String.join("\t", patientVitalStatusResult));
         return compositeRecord;
     }
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactdemographics/MskimpactPatientDemographicsWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactdemographics/MskimpactPatientDemographicsWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,20 +29,19 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.mskimpactdemographics;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactPatientDemographics;
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactCompositeDemographics;
-
 import com.google.common.base.Strings;
-import org.springframework.batch.item.*;
-import org.springframework.batch.item.file.*;
-import org.springframework.core.io.*;
-import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
-import org.springframework.beans.factory.annotation.Value;
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactCompositeDemographics;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactPatientDemographics;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.*;
 
 /**
  *
@@ -71,7 +70,7 @@ public class MskimpactPatientDemographicsWriter implements ItemStreamWriter<Mski
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback(){
             @Override
             public void writeHeader(Writer writer) throws IOException{
-                writer.write(StringUtils.join(MskimpactPatientDemographics.getPatientDemographicsHeaders(), "\t"));
+                writer.write(String.join("\t", MskimpactPatientDemographics.getPatientDemographicsHeaders()));
             }
         });
         stagingFile = new File(outputDirectory, datasetFilename);

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactdemographics/MskimpactVitalStatusWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactdemographics/MskimpactVitalStatusWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,16 +32,13 @@
 
 package org.mskcc.cmo.ks.darwin.pipeline.mskimpactdemographics;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactCompositeDemographics;
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactPatientDemographics;
-
 import com.google.common.base.Strings;
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
-
-import org.springframework.batch.item.ExecutionContext;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactCompositeDemographics;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactPatientDemographics;
 import org.springframework.batch.item.*;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
 import org.springframework.beans.factory.annotation.Value;
@@ -70,7 +67,7 @@ public class MskimpactVitalStatusWriter implements ItemStreamWriter<MskimpactCom
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback(){
             @Override
             public void writeHeader(Writer writer) throws IOException{
-                writer.write(StringUtils.join(MskimpactPatientDemographics.getVitalStatusHeaders(), "\t"));
+                writer.write(String.join("\t", MskimpactPatientDemographics.getVitalStatusHeaders()));
             }
         });
         stagingFile = new File(outputDirectory, datasetFilename);

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactgeniepatient/MskimpactGeniePatientProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactgeniepatient/MskimpactGeniePatientProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,11 +33,10 @@
 package org.mskcc.cmo.ks.darwin.pipeline.mskimpactgeniepatient;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactNAACCRClinical;
 import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  *
@@ -55,6 +54,6 @@ public class MskimpactGeniePatientProcessor implements ItemProcessor<MskimpactNA
             String value = mskimpactNAACCRClinical.getClass().getMethod("get" + field).invoke(mskimpactNAACCRClinical).toString();
             record.add(darwinUtils.convertWhitespace(value));
         }
-        return StringUtils.join(record, "\t");
+        return String.join("\t", record);
     }
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactgeniepatient/MskimpactGeniePatientWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/mskimpactgeniepatient/MskimpactGeniePatientWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,14 +29,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-package org.mskcc.cmo.ks.darwin.pipeline.mskimpactgeniepatient;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactNAACCRClinical;
+package org.mskcc.cmo.ks.darwin.pipeline.mskimpactgeniepatient;
 
 import com.google.common.base.Strings;
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactNAACCRClinical;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
@@ -66,7 +65,7 @@ public class MskimpactGeniePatientWriter implements ItemStreamWriter<String>{
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback(){
             @Override
             public void writeHeader(Writer writer) throws IOException{
-                writer.write(StringUtils.join(new MskimpactNAACCRClinical().getHeaders(), "\t"));
+                writer.write(String.join("\t", new MskimpactNAACCRClinical().getHeaders()));
             }
         });
         stagingFile = new File(outputDirectory, datasetFilename);

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalPatientProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalPatientProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,7 +33,6 @@
 package org.mskcc.cmo.ks.darwin.pipeline.skcm_mskcc_2015_chantclinical;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.mskcc.cmo.ks.darwin.pipeline.model.*;
 import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinUtils;
 import org.springframework.batch.item.ItemProcessor;
@@ -78,7 +77,7 @@ public class Skcm_mskcc_2015_chantClinicalPatientProcessor implements ItemProces
                 record.add(value);
             }
         }
-        melanomaClinicalCompositeRecord.setPatientRecord(StringUtils.join(record, "\t"));
+        melanomaClinicalCompositeRecord.setPatientRecord(String.join("\t", record));
         return melanomaClinicalCompositeRecord;
     }
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalPatientWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalPatientWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,20 +29,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.skcm_mskcc_2015_chantclinical;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.*;
-
 import com.google.common.base.Strings;
-import org.springframework.batch.item.*;
-import org.springframework.batch.item.file.*;
-import org.springframework.core.io.*;
-import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
-import org.springframework.beans.factory.annotation.*;
 import java.io.*;
 import java.util.*;
-
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.darwin.pipeline.model.*;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.core.io.*;
 
 /**
  *
@@ -107,7 +105,7 @@ public class Skcm_mskcc_2015_chantClinicalPatientWriter implements ItemStreamWri
 
     private String getMetaLine(List<String> metaData) {
         int pidIndex = patientHeader.get("header").indexOf("PATIENT_ID");
-        return metaData.remove(pidIndex) + "\t" + StringUtils.join(metaData, "\t");
+        return metaData.remove(pidIndex) + "\t" + String.join("\t", metaData);
     }
 
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalReader.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalReader.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,24 +29,24 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.skcm_mskcc_2015_chantclinical;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.sql.SQLQueryFactory;
 import java.lang.reflect.Method;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.mskcc.cmo.ks.darwin.pipeline.model.Skcm_mskcc_2015_chantClinicalRecord;
 import org.mskcc.cmo.ks.darwin.pipeline.model.Skcm_mskcc_2015_chantNormalizedClinicalRecord;
 import org.mskcc.cmo.ks.darwin.pipeline.mskimpactdemographics.MskimpactPatientDemographicsReader;
+import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
 import org.mskcc.cmo.ks.redcap.source.MetadataManager;
 import org.springframework.batch.item.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.transaction.annotation.Transactional;
 import static com.querydsl.core.alias.Alias.*;
 import static com.querydsl.core.alias.Alias.alias;
-import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
 
 /**
  *
@@ -236,7 +236,7 @@ public class Skcm_mskcc_2015_chantClinicalReader implements ItemStreamReader<Skc
                     Set<String> values = new HashSet<>();
                     values.add((String) fieldGetter.invoke(record1));
                     values.add((String) fieldGetter.invoke(record2));
-                    combined.getClass().getMethod("set" + field, String.class).invoke(combined, StringUtils.join(values, "|"));
+                    combined.getClass().getMethod("set" + field, String.class).invoke(combined, String.join("|", values));
             }
         }
         catch (Exception e) {

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalSampleProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalSampleProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,7 +33,6 @@
 package org.mskcc.cmo.ks.darwin.pipeline.skcm_mskcc_2015_chantclinical;
 
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.mskcc.cmo.ks.darwin.pipeline.model.*;
 import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinUtils;
 import org.springframework.batch.item.ItemProcessor;
@@ -77,7 +76,7 @@ public class Skcm_mskcc_2015_chantClinicalSampleProcessor implements ItemProcess
             }
         }
         Skcm_mskcc_2015_chantClinicalCompositeRecord compositeRecord = new Skcm_mskcc_2015_chantClinicalCompositeRecord(melanomaClinicalRecord);
-        compositeRecord.setSampleRecord(StringUtils.join(record, "\t"));
+        compositeRecord.setSampleRecord(String.join("\t", record));
         return compositeRecord;
     }
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalSampleWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chantclinical/Skcm_mskcc_2015_chantClinicalSampleWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,20 +29,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.darwin.pipeline.skcm_mskcc_2015_chantclinical;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.*;
-
 import com.google.common.base.Strings;
-import org.springframework.batch.item.*;
-import org.springframework.batch.item.file.*;
-import org.springframework.core.io.*;
-import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
-import org.springframework.beans.factory.annotation.*;
 import java.io.*;
 import java.util.*;
-
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.darwin.pipeline.model.*;
+import org.springframework.batch.item.*;
+import org.springframework.batch.item.file.*;
+import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.core.io.*;
 
 /**
  *
@@ -111,7 +109,7 @@ public class Skcm_mskcc_2015_chantClinicalSampleWriter implements ItemStreamWrit
     private String getMetaLine(List<String> sampleMetadata, List<String> patientMetadata) {
         int sidIndex = sampleHeader.get("header").indexOf("SAMPLE_ID");
         int pidIndex = patientHeader.get("header").indexOf("PATIENT_ID");
-        return sampleMetadata.remove(sidIndex) + "\t" + patientMetadata.get(pidIndex) + "\t" + StringUtils.join(sampleMetadata, "\t");
+        return sampleMetadata.remove(sidIndex) + "\t" + patientMetadata.get(pidIndex) + "\t" + String.join("\t", sampleMetadata);
     }
 
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chanttimeline/Skcm_mskcc_2015_chantTimelineProcessor.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chanttimeline/Skcm_mskcc_2015_chantTimelineProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -34,11 +34,10 @@ package org.mskcc.cmo.ks.darwin.pipeline.skcm_mskcc_2015_chanttimeline;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
 import org.mskcc.cmo.ks.darwin.pipeline.model.Skcm_mskcc_2015_chantTimelineRecord;
 import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  *
@@ -60,6 +59,6 @@ public class Skcm_mskcc_2015_chantTimelineProcessor implements ItemProcessor<Skc
             }
             record.add(value);
         }
-        return StringUtils.join(record, "\t");
+        return String.join("\t", record);
     }
 }

--- a/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chanttimeline/Skcm_mskcc_2015_chantTimelineWriter.java
+++ b/darwin/src/main/java/org/mskcc/cmo/ks/darwin/pipeline/skcm_mskcc_2015_chanttimeline/Skcm_mskcc_2015_chantTimelineWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,14 +29,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-package org.mskcc.cmo.ks.darwin.pipeline.skcm_mskcc_2015_chanttimeline;
 
-import org.mskcc.cmo.ks.darwin.pipeline.model.Skcm_mskcc_2015_chantTimelineAdjuvantTx;
+package org.mskcc.cmo.ks.darwin.pipeline.skcm_mskcc_2015_chanttimeline;
 
 import com.google.common.base.Strings;
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.darwin.pipeline.model.Skcm_mskcc_2015_chantTimelineAdjuvantTx;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.PassThroughLineAggregator;
@@ -66,7 +65,7 @@ public class Skcm_mskcc_2015_chantTimelineWriter implements ItemStreamWriter<Str
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback(){
             @Override
             public void writeHeader(Writer writer) throws IOException {
-                writer.write(StringUtils.join(new Skcm_mskcc_2015_chantTimelineAdjuvantTx().getFieldNames(), "\t"));
+                writer.write(String.join("\t", new Skcm_mskcc_2015_chantTimelineAdjuvantTx().getFieldNames()));
             }
         });
         stagingFile = new File(outputDirectory, filename);

--- a/darwin/src/test/java/org/mskcc/cmo/ks/darwin/MskimpactTimelineBrainSpineReaderTest.java
+++ b/darwin/src/test/java/org/mskcc/cmo/ks/darwin/MskimpactTimelineBrainSpineReaderTest.java
@@ -32,16 +32,14 @@
 
 package org.mskcc.cmo.ks.darwin;
 
+import java.util.ArrayList;
 import java.util.Set;
-
 import org.junit.Assert;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-
+import org.junit.Test;
 import org.mskcc.cmo.ks.darwin.pipeline.model.MskimpactBrainSpineTimeline;
+import org.mskcc.cmo.ks.darwin.pipeline.mskimpactbrainspinetimeline.MskimpactTimelineBrainSpineReader;
 import org.mskcc.cmo.ks.darwin.pipeline.util.DarwinSampleListUtil;
-
-import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
@@ -56,16 +54,15 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class MskimpactTimelineBrainSpineReaderTest {
 
     @Autowired
-    private ItemStreamReader<MskimpactBrainSpineTimeline> mskimpactTimelineBrainSpineReader;
+    private MskimpactTimelineBrainSpineReader mskimpactTimelineBrainSpineReader;
 
     @Autowired
     private DarwinSampleListUtil darwinSampleListUtil;
 
     @Test
     public void testReadFiltersNAStartDate() {
-        mskimpactTimelineBrainSpineReader.open(new ExecutionContext());
-        try { // to make sure we close mskimpactTimelineBrainSpineReader
-
+        mskimpactTimelineBrainSpineReader.openForTestingAndSetDarwinTimelineResults(makeMockMskimpactBrainSpineTimelineResults());
+        try {
             // confirm DarwinSampleListUtil.filteredMskimpactBrainSpineTimelineSet is empty before we start reading
             Set<MskimpactBrainSpineTimeline> filteredMskimpactBrainSpineTimelineSet = darwinSampleListUtil.getFilteredMskimpactBrainSpineTimelineSet();
             Assert.assertTrue("filteredMskimpactBrainSpineTimelineSet should be empty but contains " +
@@ -116,6 +113,28 @@ public class MskimpactTimelineBrainSpineReaderTest {
         } finally {
             mskimpactTimelineBrainSpineReader.close();
         }
+    }
+
+    private ArrayList<MskimpactBrainSpineTimeline> makeMockMskimpactBrainSpineTimelineResults() {
+        ArrayList<MskimpactBrainSpineTimeline> mskimpactBrainSpineTimelineResults = new ArrayList<MskimpactBrainSpineTimeline>();
+
+        MskimpactBrainSpineTimeline mskimpactBrainSpineTimelineNAStartDate = new MskimpactBrainSpineTimeline();
+        mskimpactBrainSpineTimelineNAStartDate.setDMP_PATIENT_ID_ALL_BRAINSPINETMLN("P-0000001");
+        mskimpactBrainSpineTimelineNAStartDate.setSTART_DATE("NA");
+
+        MskimpactBrainSpineTimeline mskimpactBrainSpineTimelineNullStartDate = new MskimpactBrainSpineTimeline();
+        mskimpactBrainSpineTimelineNullStartDate.setDMP_PATIENT_ID_ALL_BRAINSPINETMLN("P-0000002");
+        mskimpactBrainSpineTimelineNullStartDate.setSTART_DATE(null);
+
+        MskimpactBrainSpineTimeline mskimpactBrainSpineTimelineValidStartDate = new MskimpactBrainSpineTimeline();
+        mskimpactBrainSpineTimelineValidStartDate.setDMP_PATIENT_ID_ALL_BRAINSPINETMLN("P-0000003");
+        mskimpactBrainSpineTimelineValidStartDate.setSTART_DATE("757");
+
+        mskimpactBrainSpineTimelineResults.add(mskimpactBrainSpineTimelineNAStartDate); // should be filtered by MskimpactTimelineBrainSpineReader.read()
+        mskimpactBrainSpineTimelineResults.add(mskimpactBrainSpineTimelineNullStartDate); // should be filtered by MskimpactTimelineBrainSpineReader.read()
+        mskimpactBrainSpineTimelineResults.add(mskimpactBrainSpineTimelineValidStartDate); // should not be filtered by MskimpactTimelineBrainSpineReader.read()
+
+        return mskimpactBrainSpineTimelineResults;
     }
 
 }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/DDPPipeline.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/DDPPipeline.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2018 - 2023 Memorial Sloan Kettering Cancer Center.
+ * Copyright (c) 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,18 +32,16 @@
 
 package org.mskcc.cmo.ks.ddp;
 
-import org.mskcc.cmo.ks.ddp.pipeline.BatchConfiguration;
-
 import com.google.common.base.Strings;
 import java.io.File;
 import java.util.*;
 import org.apache.commons.cli.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.mskcc.cmo.ks.ddp.pipeline.BatchConfiguration;
 import org.springframework.batch.core.*;
 import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 
 /**
@@ -60,11 +58,11 @@ public class DDPPipeline {
         options.addOption("h", "help", false, "Shows this help document and quits.")
                 .addOption("f", "fetch_data", true, "List of comma delimited additional data to fetch [diagnosis,ageAtSeqDate,radiation,chemotherapy,surgery,survival] (demographics is always included)") // TODO do not hard code this
                 .addOption("o", "output_directory", true, "Output directory")
-                .addOption("c", "cohort_name", true, "Cohort name [" + StringUtils.join(ddpCohortMap.keySet(), " | ") + "]")
+                .addOption("c", "cohort_name", true, "Cohort name [" + String.join(" | ", ddpCohortMap.keySet()) + "]")
                 .addOption("p", "patient_subset_file", true, "File containing patient ID's to subset by")
                 .addOption("s", "seq_date_file", true, "File containing patient sequence dates for OS_MONTHS")
                 .addOption("e", "excluded_patients_file", true, "File containg patient ID's to exclude")
-                .addOption("r", "current_demographics_rec_count", true, "Count of records in current demographics file. Used to sanity check num of records in latest demographics data fetch.")            
+                .addOption("r", "current_demographics_rec_count", true, "Count of records in current demographics file. Used to sanity check num of records in latest demographics data fetch.")
                 .addOption("t", "test", false, "Run pipeline in test mode");
         return options;
     }
@@ -216,7 +214,7 @@ public class DDPPipeline {
             System.out.println("No such directory: " + outputDirectory);
             help(options, 2);
         }
-        launchJob(ctx, args, cohortName, subsetFilename, seqDateFilename, excludedPatientsFilename, outputDirectory, currentDemographicsRecCount, 
+        launchJob(ctx, args, cohortName, subsetFilename, seqDateFilename, excludedPatientsFilename, outputDirectory, currentDemographicsRecCount,
             commandLine.hasOption("t"), includeDiagnosis, includeAgeAtSeqDate, includeRadiation, includeChemotherapy, includeSurgery, includeSurvival);
     }
 }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/AgeAtSeqDateWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/AgeAtSeqDateWriter.java
@@ -4,12 +4,12 @@
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,12 +32,10 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline;
 
-import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
-import org.mskcc.cmo.ks.ddp.pipeline.model.AgeAtSeqDateRecord;
-
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.ddp.pipeline.model.AgeAtSeqDateRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.*;
@@ -68,7 +66,7 @@ public class AgeAtSeqDateWriter implements ItemStreamWriter<CompositeResult> {
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
                 @Override
                 public void writeHeader(Writer writer) throws IOException {
-                    writer.write(StringUtils.join(AgeAtSeqDateRecord.getFieldNames(), "\t"));
+                    writer.write(String.join("\t", AgeAtSeqDateRecord.getFieldNames()));
                 }
             });
             flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/ClinicalWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/ClinicalWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,12 +32,10 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline;
 
-import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
-import org.mskcc.cmo.ks.ddp.pipeline.model.ClinicalRecord;
-
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.ddp.pipeline.model.ClinicalRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.*;
@@ -73,7 +71,7 @@ public class ClinicalWriter implements ItemStreamWriter<CompositeResult> {
         flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
             @Override
             public void writeHeader(Writer writer) throws IOException {
-                writer.write(StringUtils.join(ClinicalRecord.getFieldNames(includeDiagnosis, includeRadiation, includeChemotherapy, includeSurgery), "\t"));
+                writer.write(String.join("\t", ClinicalRecord.getFieldNames(includeDiagnosis, includeRadiation, includeChemotherapy, includeSurgery)));
             }
         });
         flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPEmailTasklet.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPEmailTasklet.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2018-2019 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018, 2019, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,24 +29,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.ddp.pipeline;
 
+import java.util.*;
+import org.apache.log4j.Logger;
 import org.cbioportal.cmo.pipelines.common.util.EmailUtil;
 import org.mskcc.cmo.ks.ddp.pipeline.util.DDPPatientListUtil;
 import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
-
-import org.apache.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
-
-import java.util.*;
-import org.apache.commons.lang.StringUtils;
 
 /**
  *
@@ -91,7 +89,7 @@ public class DDPEmailTasklet implements Tasklet {
             body.append("Found ")
                     .append(patientsWithNegativeOsMOnths.size())
                     .append(" patients with negative OS_MONTHS - see DDP fetcher log for further details:\n")
-                    .append(StringUtils.join(patientsWithNegativeOsMOnths, "\n\t"));
+                    .append(String.join("\n\t", patientsWithNegativeOsMOnths));
         }
         if (!body.toString().isEmpty()) {
             emailUtil.sendEmailToDefaultRecipient(subject, body.toString());

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTasklet.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSeqDateTasklet.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2019 - 2023 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2019, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,17 +29,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.ddp.pipeline;
-
-import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.springframework.batch.core.StepContribution;
-import org.springframework.batch.core.scope.context.ChunkContext;
-import org.springframework.batch.core.step.tasklet.Tasklet;
-import org.springframework.batch.repeat.RepeatStatus;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -47,6 +38,13 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import org.apache.log4j.Logger;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  *
@@ -69,7 +67,7 @@ public class DDPSeqDateTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext) throws Exception {
-        if (!StringUtils.isEmpty(seqDateFilename)) {
+        if (seqDateFilename != null && !seqDateFilename.isEmpty()) {
             LOG.debug("Seq date file is: " + seqDateFilename);
             BufferedReader reader = new BufferedReader(new FileReader(seqDateFilename));
             // pass reader as parameter so we can mock it in tests
@@ -98,7 +96,7 @@ public class DDPSeqDateTasklet implements Tasklet {
             DDPUtils.setSampleSeqDateMap(sampleSeqDateMap); // empty map
             DDPUtils.setPatientFirstSeqDateMap(patientFirstSeqDateMap); // empty map
             return;
-        } 
+        }
         // e.g. Wed, 16 Mar 2016 18:09:02 GMT
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
         String line;
@@ -108,7 +106,7 @@ public class DDPSeqDateTasklet implements Tasklet {
             String dmpSampleId = record[dmpSampleIdColumnIndex];
             String dmpPatientId = record[dmpPatientIdColumnIndex];
             String seqDateString = record[seqDateColumnIndex];
-            if (!StringUtils.isEmpty(seqDateString)) {
+            if (seqDateString != null && !seqDateString.isEmpty()) {
                 try {
                     Date parsedRecordSeqDate = simpleDateFormat.parse(seqDateString);
                     sampleSeqDateMap.put(dmpSampleId, parsedRecordSeqDate);
@@ -127,7 +125,7 @@ public class DDPSeqDateTasklet implements Tasklet {
         if (warnings.size() > 0) {
             LOG.warn(warnings.size() + " sample(s) found with invalid records.  The first " + MAX_ERRORS_TO_SHOW + " are listed below:");
             for (int w = 0; w < warnings.size() && w < MAX_ERRORS_TO_SHOW; w++) {
-                LOG.warn(warnings.get(w)); 
+                LOG.warn(warnings.get(w));
             }
         }
         DDPUtils.setSampleSeqDateMap(sampleSeqDateMap);

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSortTasklet.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPSortTasklet.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2018 - 2023 Memorial Sloan Kettering Cancer Center.
+ * Copyright (c) 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -29,26 +29,24 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.mskcc.cmo.ks.ddp.pipeline;
 
 import java.io.IOException;
+import java.nio.file.*;
+import java.util.*;
+import org.apache.log4j.Logger;
 import org.mskcc.cmo.ks.ddp.pipeline.model.AgeAtSeqDateRecord;
 import org.mskcc.cmo.ks.ddp.pipeline.model.ClinicalRecord;
 import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineChemoRecord;
 import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineRadiationRecord;
 import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineSurgeryRecord;
 import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
-
-import org.apache.log4j.Logger;
-import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Value;
-
-import org.apache.commons.lang.StringUtils;
-import java.nio.file.*;
-import java.util.*;
 
 /**
  *
@@ -101,7 +99,7 @@ public class DDPSortTasklet implements Tasklet {
         // sort and overwrite timeline files if applicable
         if (includeChemotherapy) {
             String timelineChemotherapyFilePath = Paths.get(outputDirectory, timelineChemotherapyFilename).toString();
-            String timelineChemotherapyHeader = StringUtils.join(TimelineChemoRecord.getFieldNames(), "\t");
+            String timelineChemotherapyHeader = String.join("\t", TimelineChemoRecord.getFieldNames());
             LOG.info("Sorting and overwriting " + timelineChemotherapyFilePath);
             DDPUtils.sortAndWrite(timelineChemotherapyFilePath, timelineChemotherapyHeader);
         }
@@ -130,6 +128,6 @@ public class DDPSortTasklet implements Tasklet {
 
     private void sortAndOverwriteFile(Path filePath, List<String> fieldNames) throws IOException {
         LOG.info("Sorting and overwriting file:" + filePath.toString());
-        DDPUtils.sortAndWrite(filePath.toString(), StringUtils.join(fieldNames, "\t"));
+        DDPUtils.sortAndWrite(filePath.toString(), String.join("\t", fieldNames));
     }
 }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppNaaccrMappingsWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppNaaccrMappingsWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2019, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,14 +32,12 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline;
 
-import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
-import org.mskcc.cmo.ks.ddp.pipeline.model.SuppNaaccrMappingsRecord;
-import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
-
 import com.google.common.base.Strings;
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
+import org.mskcc.cmo.ks.ddp.pipeline.model.SuppNaaccrMappingsRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.*;
@@ -75,7 +73,7 @@ public class SuppNaaccrMappingsWriter implements ItemStreamWriter<CompositeResul
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
                 @Override
                 public void writeHeader(Writer writer) throws IOException {
-                    writer.write(StringUtils.join(SuppNaaccrMappingsRecord.getFieldNames(), "\t"));
+                    writer.write(String.join("\t", SuppNaaccrMappingsRecord.getFieldNames()));
                 }
             });
             flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppVitalStatusWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppVitalStatusWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2019, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,14 +32,12 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline;
 
-import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
-import org.mskcc.cmo.ks.ddp.pipeline.model.SuppVitalStatusRecord;
-import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
-
 import com.google.common.base.Strings;
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
+import org.mskcc.cmo.ks.ddp.pipeline.model.SuppVitalStatusRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.*;
@@ -75,7 +73,7 @@ public class SuppVitalStatusWriter implements ItemStreamWriter<CompositeResult> 
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
                 @Override
                 public void writeHeader(Writer writer) throws IOException {
-                    writer.write(StringUtils.join(SuppVitalStatusRecord.getFieldNames(), "\t"));
+                    writer.write(String.join("\t", SuppVitalStatusRecord.getFieldNames()));
                 }
             });
             flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineChemoWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineChemoWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,12 +32,10 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline;
 
-import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
-import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineChemoRecord;
-
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
+import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineChemoRecord;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.*;
@@ -68,7 +66,7 @@ public class TimelineChemoWriter implements ItemStreamWriter<CompositeResult> {
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
                 @Override
                 public void writeHeader(Writer writer) throws IOException {
-                    writer.write(StringUtils.join(TimelineChemoRecord.getFieldNames(), "\t"));
+                    writer.write(String.join("\t", TimelineChemoRecord.getFieldNames()));
                 }
             });
             flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineRadiationWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineRadiationWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,12 +32,10 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline;
 
-import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
-import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineRadiationRecord;
-
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
+import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineRadiationRecord;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.*;
@@ -68,7 +66,7 @@ public class TimelineRadiationWriter implements ItemStreamWriter<CompositeResult
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
                 @Override
                 public void writeHeader(Writer writer) throws IOException {
-                    writer.write(StringUtils.join(TimelineRadiationRecord.getFieldNames(), "\t"));
+                    writer.write(String.join("\t", TimelineRadiationRecord.getFieldNames()));
                 }
             });
             flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineSurgeryWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/TimelineSurgeryWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,12 +32,10 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline;
 
-import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
-import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineSurgeryRecord;
-
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang.StringUtils;
+import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
+import org.mskcc.cmo.ks.ddp.pipeline.model.TimelineSurgeryRecord;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.*;
@@ -68,7 +66,7 @@ public class TimelineSurgeryWriter implements ItemStreamWriter<CompositeResult> 
             flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
                 @Override
                 public void writeHeader(Writer writer) throws IOException {
-                    writer.write(StringUtils.join(TimelineSurgeryRecord.getFieldNames(), "\t"));
+                    writer.write(String.join("\t", TimelineSurgeryRecord.getFieldNames()));
                 }
             });
             flatFileItemWriter.setResource(new FileSystemResource(stagingFile));

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2018 - 2023 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,17 +32,15 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline.util;
 
-import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
-import org.mskcc.cmo.ks.ddp.source.model.PatientDiagnosis;
-
 import com.google.common.base.Strings;
+import java.io.*;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.util.*;
-import java.io.*;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
+import org.mskcc.cmo.ks.ddp.source.model.PatientDiagnosis;
 
 /**
  *
@@ -682,7 +680,7 @@ public class DDPUtils {
             String value = object.getClass().getMethod("get" + field).invoke(object).toString();
             record.add(value.trim());
         }
-        return StringUtils.join(record, "\t");
+        return String.join("\t", record);
     }
 
     /**
@@ -704,7 +702,7 @@ public class DDPUtils {
             String value = object.getClass().getMethod("get" + field).invoke(object).toString();
             record.add(value.trim());
         }
-        return StringUtils.join(record, "\t");
+        return String.join("\t", record);
     }
 
     /**

--- a/gdd/src/main/java/org/mskcc/cmo/ks/gdd/pipeline/BatchConfiguration.java
+++ b/gdd/src/main/java/org/mskcc/cmo/ks/gdd/pipeline/BatchConfiguration.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,21 +33,19 @@
 package org.cbioportal.cmo.pipelines.gdd;
 
 import org.cbioportal.cmo.pipelines.gdd.model.GDDResult;
-
 import org.springframework.batch.core.*;
-import org.springframework.batch.item.*;
 import org.springframework.batch.core.configuration.annotation.*;
-import org.springframework.context.annotation.*;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.*;
 
 /**
  * @author Benjamin Gross
  */
 @Configuration
 @EnableBatchProcessing
-public class BatchConfiguration
-{
+public class BatchConfiguration {
     public static final String GDD_JOB = "gddJob";
 
     @Autowired
@@ -57,16 +55,14 @@ public class BatchConfiguration
     public StepBuilderFactory stepBuilderFactory;
 
     @Bean
-    public Job gddJob()
-    {
+    public Job gddJob() {
         return jobBuilderFactory.get(GDD_JOB)
             .start(step())
             .build();
     }
 
     @Bean
-    public Step step()
-    {
+    public Step step() {
         return stepBuilderFactory.get("step")
             .<GDDResult, String> chunk(10)
             .reader(reader())
@@ -77,21 +73,18 @@ public class BatchConfiguration
 
     @Bean
     @StepScope
-	public ItemStreamReader<GDDResult> reader()
-    {
-		return new GDDClassifierReader();
-	}
+    public ItemStreamReader<GDDResult> reader() {
+        return new GDDClassifierReader();
+    }
 
     @Bean
-    public GDDClassifierProcessor processor()
-    {
+    public GDDClassifierProcessor processor() {
         return new GDDClassifierProcessor();
     }
 
     @Bean
     @StepScope
-    public ItemStreamWriter<String> writer()
-    {
+    public ItemStreamWriter<String> writer() {
         return new GDDResultWriter();
     }
     

--- a/pom.xml
+++ b/pom.xml
@@ -28,13 +28,12 @@
   </parent>
 
   <properties>
-
     <spring.version>5.2.6.RELEASE</spring.version>
     <jackson.version>2.11.2</jackson.version>
     <slf4j.version>1.7.30</slf4j.version>
-    <maven.compiler.version>1.8</maven.compiler.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.version>3.11.0</maven.compiler.version>
+    <maven.compiler.java.source>11</maven.compiler.java.source>
+    <maven.compiler.java.target>11</maven.compiler.java.target>
   </properties>
 
   <dependencies>
@@ -72,9 +71,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <!-- required for mockito -->
+        <artifactId>byte-buddy</artifactId>
+        <version>1.14.5</version>
+        </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.11.0</version>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <!-- slf4j -->
@@ -106,11 +111,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.6</version>
-    </dependency>
-    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.3</version>
@@ -122,10 +122,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>${maven.compiler.version}</version>
         <configuration>
-          <source>${maven.compiler.version}</source>
-          <target>${maven.compiler.version}</target>
+          <source>${maven.compiler.java.source}</source>
+          <target>${maven.compiler.java.target}</target>
           <compilerArgument>-Xlint:deprecation</compilerArgument>
         </configuration>
       </plugin>

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalPatientDataProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalPatientDataProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,7 +33,6 @@
 package org.mskcc.cmo.ks.redcap.pipeline;
 
 import java.util.*;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.batch.item.ItemProcessor;
 
@@ -61,7 +60,7 @@ public class ClinicalPatientDataProcessor implements ItemProcessor<ClinicalDataC
             }
         }
 
-        composite.setPatientResult(StringUtils.join(record, "\t"));
+        composite.setPatientResult(String.join("\t", record));
         return composite;
     }
 }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalSampleDataProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/ClinicalSampleDataProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,7 +32,6 @@
 package org.mskcc.cmo.ks.redcap.pipeline;
 
 import java.util.*;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -65,7 +64,7 @@ public class ClinicalSampleDataProcessor implements ItemProcessor<Map<String, St
             }
         }
 
-        composite.setSampleResult(StringUtils.join(record, "\t"));
+        composite.setSampleResult(String.join("\t", record));
         return composite;
     }
 }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -33,7 +33,6 @@
 package org.mskcc.cmo.ks.redcap.pipeline;
 
 import java.util.*;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -58,6 +57,6 @@ public class RawClinicalDataProcessor implements ItemProcessor<Map<String, Strin
                 record.add(i.getOrDefault(column, ""));
             }
         }
-        return StringUtils.join(record, "\t");
+        return String.join("\t", record);
     }
 }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataWriter.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/RawClinicalDataWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -34,7 +34,6 @@ package org.mskcc.cmo.ks.redcap.pipeline;
 
 import java.io.*;
 import java.util.*;
-import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cmo.ks.redcap.source.ClinicalDataSource;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineProcessor.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineProcessor.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -35,7 +35,6 @@ package org.mskcc.cmo.ks.redcap.pipeline;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -67,6 +66,6 @@ public class TimelineProcessor implements ItemProcessor<Map<String, String>, Str
                 record.add(i.getOrDefault(column, ""));
             }
         }
-        return StringUtils.join(record, "\t");
+        return String.join("\t", record);
     }
 }

--- a/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineWriter.java
+++ b/redcap/redcap_pipeline/src/main/java/org/mskcc/cmo/ks/redcap/pipeline/TimelineWriter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2016-17 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016, 2017, 2023 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -38,7 +38,6 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamWriter;
@@ -128,7 +127,7 @@ public class TimelineWriter  implements ItemStreamWriter<String> {
                 header.add(column);
             }
         }
-        return StringUtils.join(header, "\t");
+        return String.join("\t", header);
     }
 
 }


### PR DESCRIPTION
- codebase made consistent with java 11
  - Mockito update required
  - apache commons StringUtil dropped because of dependency clash
- switch to latest genome-nexus-annotation-pipeline version (brings in java 11 code in cbioportal dependency)
  - calls to annotator.getAnnotatedRecordsUsingPOST updated to include new required arguments
- whitespace and style cleanup