### PR TITLE
Limit DDP file writing to mskimpact, mskaccess, and hemepact

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
@@ -165,10 +165,12 @@ public class DDPCompositeProcessor implements ItemProcessor<DDPCompositeRecord, 
         compositeResult.setTimelineChemoResults(timelineChemoProcessor.process(compositeRecord));
         compositeResult.setTimelineSurgeryResults(timelineSurgeryProcessor.process(compositeRecord));
 
-        // if cohort is mskimpact then update composite record with supplemental data
-        // provided to genie (vital status, age as years since birth, naaccr codes)
-        compositeResult.setSuppVitalStatusResult(suppVitalStatusProcessor.process(compositeRecord));
-        compositeResult.setSuppNaccrMappingsResult(suppNaaccrMappingsProcessor.process(compositeRecord));
+        // if cohort is mskimpact, mskaccess, or hemepact then update composite record with supplemental data
+        // provided to genie (vital status, naaccr codes)
+        if (DDPUtils.isMskimpactCohort(cohortName) || DDPUtils.isHemepactCohort(cohortName) || DDPUtils.isMskaccessCohort(cohortName)) {
+            compositeResult.setSuppVitalStatusResult(suppVitalStatusProcessor.process(compositeRecord));
+            compositeResult.setSuppNaccrMappingsResult(suppNaaccrMappingsProcessor.process(compositeRecord));
+        }
 
         return compositeResult;
     }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppNaaccrMappingsWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppNaaccrMappingsWriter.java
@@ -37,6 +37,7 @@ import java.io.*;
 import java.util.*;
 import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
 import org.mskcc.cmo.ks.ddp.pipeline.model.SuppNaaccrMappingsRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.*;
@@ -65,17 +66,19 @@ public class SuppNaaccrMappingsWriter implements ItemStreamWriter<CompositeResul
 
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
-        File stagingFile = new File(outputDirectory, ddpSuppDirname + File.separator + ddpSuppNaaccrMappingsFilename);
-        LineAggregator<String> aggr = new PassThroughLineAggregator<>();
-        flatFileItemWriter.setLineAggregator(aggr);
-        flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
-            @Override
-            public void writeHeader(Writer writer) throws IOException {
-                writer.write(String.join("\t", SuppNaaccrMappingsRecord.getFieldNames()));
-            }
-        });
-        flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
-        flatFileItemWriter.open(ec);
+        if (DDPUtils.isMskimpactCohort(cohortName) || DDPUtils.isHemepactCohort(cohortName) || DDPUtils.isMskaccessCohort(cohortName)) {
+            File stagingFile = new File(outputDirectory, ddpSuppDirname + File.separator + ddpSuppNaaccrMappingsFilename);
+            LineAggregator<String> aggr = new PassThroughLineAggregator<>();
+            flatFileItemWriter.setLineAggregator(aggr);
+            flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
+                @Override
+                public void writeHeader(Writer writer) throws IOException {
+                    writer.write(String.join("\t", SuppNaaccrMappingsRecord.getFieldNames()));
+                }
+            });
+            flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
+            flatFileItemWriter.open(ec);
+        }
     }
 
     @Override
@@ -83,18 +86,22 @@ public class SuppNaaccrMappingsWriter implements ItemStreamWriter<CompositeResul
 
     @Override
     public void close() throws ItemStreamException {
-        flatFileItemWriter.close();
+        if (DDPUtils.isMskimpactCohort(cohortName) || DDPUtils.isHemepactCohort(cohortName) || DDPUtils.isMskaccessCohort(cohortName)) {
+            flatFileItemWriter.close();
+        }
     }
 
     @Override
     public void write(List<? extends CompositeResult> compositeResults) throws Exception {
-        List<String> records = new ArrayList<>();
-        for (CompositeResult result : compositeResults) {
-            if (Strings.isNullOrEmpty(result.getSuppNaccrMappingsResult())) {
-                continue;
+        if (DDPUtils.isMskimpactCohort(cohortName) || DDPUtils.isHemepactCohort(cohortName) || DDPUtils.isMskaccessCohort(cohortName)) {
+            List<String> records = new ArrayList<>();
+            for (CompositeResult result : compositeResults) {
+                if (Strings.isNullOrEmpty(result.getSuppNaccrMappingsResult())) {
+                    continue;
+                }
+                records.add(result.getSuppNaccrMappingsResult());
             }
-            records.add(result.getSuppNaccrMappingsResult());
+            flatFileItemWriter.write(records);
         }
-        flatFileItemWriter.write(records);
     }
 }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppVitalStatusWriter.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/SuppVitalStatusWriter.java
@@ -37,6 +37,7 @@ import java.io.*;
 import java.util.*;
 import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
 import org.mskcc.cmo.ks.ddp.pipeline.model.SuppVitalStatusRecord;
+import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.file.*;
 import org.springframework.batch.item.file.transform.*;
@@ -65,17 +66,19 @@ public class SuppVitalStatusWriter implements ItemStreamWriter<CompositeResult> 
 
     @Override
     public void open(ExecutionContext ec) throws ItemStreamException {
-        File stagingFile = new File(outputDirectory, ddpSuppDirname + File.separator + ddpSuppVitalStatusFilename);
-        LineAggregator<String> aggr = new PassThroughLineAggregator<>();
-        flatFileItemWriter.setLineAggregator(aggr);
-        flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
-            @Override
-            public void writeHeader(Writer writer) throws IOException {
-                writer.write(String.join("\t", SuppVitalStatusRecord.getFieldNames()));
-            }
-        });
-        flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
-        flatFileItemWriter.open(ec);
+        if (DDPUtils.isMskimpactCohort(cohortName) || DDPUtils.isHemepactCohort(cohortName) || DDPUtils.isMskaccessCohort(cohortName)) {
+            File stagingFile = new File(outputDirectory, ddpSuppDirname + File.separator + ddpSuppVitalStatusFilename);
+            LineAggregator<String> aggr = new PassThroughLineAggregator<>();
+            flatFileItemWriter.setLineAggregator(aggr);
+            flatFileItemWriter.setHeaderCallback(new FlatFileHeaderCallback() {
+                @Override
+                public void writeHeader(Writer writer) throws IOException {
+                    writer.write(String.join("\t", SuppVitalStatusRecord.getFieldNames()));
+                }
+            });
+            flatFileItemWriter.setResource(new FileSystemResource(stagingFile));
+            flatFileItemWriter.open(ec);
+        }
     }
 
     @Override
@@ -83,18 +86,22 @@ public class SuppVitalStatusWriter implements ItemStreamWriter<CompositeResult> 
 
     @Override
     public void close() throws ItemStreamException {
-        flatFileItemWriter.close();
+        if (DDPUtils.isMskimpactCohort(cohortName) || DDPUtils.isHemepactCohort(cohortName) || DDPUtils.isMskaccessCohort(cohortName)) {
+            flatFileItemWriter.close();
+        }
     }
 
     @Override
     public void write(List<? extends CompositeResult> compositeResults) throws Exception {
-        List<String> records = new ArrayList<>();
-        for (CompositeResult result : compositeResults) {
-            if (Strings.isNullOrEmpty(result.getSuppVitalStatusResult())) {
-                continue;
+        if (DDPUtils.isMskimpactCohort(cohortName) || DDPUtils.isHemepactCohort(cohortName) || DDPUtils.isMskaccessCohort(cohortName)) {
+            List<String> records = new ArrayList<>();
+            for (CompositeResult result : compositeResults) {
+                if (Strings.isNullOrEmpty(result.getSuppVitalStatusResult())) {
+                    continue;
+                }
+                records.add(result.getSuppVitalStatusResult());
             }
-            records.add(result.getSuppVitalStatusResult());
+            flatFileItemWriter.write(records);
         }
-        flatFileItemWriter.write(records);
     }
 }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -49,6 +49,8 @@ import org.mskcc.cmo.ks.ddp.source.model.PatientDiagnosis;
 public class DDPUtils {
 
     public static final String MSKIMPACT_STUDY_ID = "mskimpact";
+    public static final String HEMEPACT_STUDY_ID = "mskimpact_heme";
+    public static final String MSKACCESS_STUDY_ID = "mskaccess";
     public static final Double DAYS_TO_YEARS_CONVERSION = 365.2422;
     public static final Double DAYS_TO_MONTHS_CONVERSION = 30.4167;
     public static final List<String> NULL_EMPTY_VALUES = Arrays.asList(new String[]{"NA", "N/A"});
@@ -141,6 +143,14 @@ public class DDPUtils {
 
     public static Boolean isMskimpactCohort(String cohortName) {
         return (!Strings.isNullOrEmpty(cohortName) && DDPUtils.MSKIMPACT_STUDY_ID.equalsIgnoreCase(cohortName));
+    }
+
+    public static Boolean isHemepactCohort(String cohortName) {
+        return (!Strings.isNullOrEmpty(cohortName) && DDPUtils.HEMEPACT_STUDY_ID.equalsIgnoreCase(cohortName));
+    }
+
+    public static Boolean isMskaccessCohort(String cohortName) {
+        return (!Strings.isNullOrEmpty(cohortName) && DDPUtils.MSKACCESS_STUDY_ID.equalsIgnoreCase(cohortName));
     }
 
     /**


### PR DESCRIPTION
Bug fix for https://github.com/knowledgesystems/cmo-pipelines/pull/1065: without the cohort check, the mskimpact ddp files were overwritten by the mskimpact ped fetch. This explicitly checks the cohorts for impact, access, and hemepact.