### PR TITLE
Change age bucketing values to <18 and >89

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/AgeAtSeqDateProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/AgeAtSeqDateProcessor.java
@@ -41,13 +41,11 @@ import java.text.ParseException;
 import org.apache.log4j.Logger;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 
 /**
  *
  * @author Manda Wilson and Calla Chennault
  */
-@Component
 public class AgeAtSeqDateProcessor implements ItemProcessor<DDPCompositeRecord, List<String>> {
 
     @Value("#{jobParameters[includeSurvival]}")

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/AgeAtSeqDateProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/AgeAtSeqDateProcessor.java
@@ -40,6 +40,7 @@ import java.util.*;
 import java.text.ParseException;
 import org.apache.log4j.Logger;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -49,11 +50,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class AgeAtSeqDateProcessor implements ItemProcessor<DDPCompositeRecord, List<String>> {
 
+    @Value("#{jobParameters[includeSurvival]}")
+    private Boolean includeSurvival;
     private final Logger LOG = Logger.getLogger(AgeAtSeqDateProcessor.class);
 
     @Override
     public List<String> process(DDPCompositeRecord compositeRecord) throws Exception {
-        List<AgeAtSeqDateRecord> ageAtSeqDateRecords = convertAgeAtSeqDateRecord(compositeRecord.getDmpPatientId(), compositeRecord.getDmpSampleIds(), compositeRecord.getPatientBirthDate());
+        String osMonths = includeSurvival ? DDPUtils.resolveOsMonths(DDPUtils.resolveOsStatus(compositeRecord), compositeRecord) : "NA";
+        List<AgeAtSeqDateRecord> ageAtSeqDateRecords = convertAgeAtSeqDateRecord(compositeRecord.getDmpPatientId(), compositeRecord.getDmpSampleIds(), compositeRecord.getPatientBirthDate(), osMonths);
         // construct records into strings for writing to output file
         List<String> records = new ArrayList<>();
         for (AgeAtSeqDateRecord ageAtSeqDateRecord : ageAtSeqDateRecords) {
@@ -73,11 +77,11 @@ public class AgeAtSeqDateProcessor implements ItemProcessor<DDPCompositeRecord, 
      * @param sampleId
      * @return
      */
-    private List<AgeAtSeqDateRecord> convertAgeAtSeqDateRecord(String patientId, List<String> sampleIds, String patientBirthDate) {
+    private List<AgeAtSeqDateRecord> convertAgeAtSeqDateRecord(String patientId, List<String> sampleIds, String patientBirthDate, String osMonths) {
         List<AgeAtSeqDateRecord> ageAtSeqDateRecords = new ArrayList<>();
         for (String sampleId : sampleIds) {
             try {
-                ageAtSeqDateRecords.add(new AgeAtSeqDateRecord(patientId, sampleId, patientBirthDate));
+                ageAtSeqDateRecords.add(new AgeAtSeqDateRecord(patientId, sampleId, patientBirthDate, osMonths));
             }
             catch (ParseException e) {
                 continue;

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/BatchConfiguration.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/BatchConfiguration.java
@@ -44,7 +44,6 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.item.*;
 import org.springframework.batch.item.support.CompositeItemWriter;
 import org.springframework.beans.factory.annotation.*;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.*;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -169,6 +168,12 @@ public class BatchConfiguration {
     @StepScope
     public ClinicalProcessor clinicalProcessor() {
         return new ClinicalProcessor();
+    }
+
+    @Bean
+    @StepScope
+    public AgeAtSeqDateProcessor ageAtSeqDateProcessor() {
+        return new AgeAtSeqDateProcessor();
     }
 
     @Bean

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
@@ -32,7 +32,6 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline;
 
-import org.mskcc.cmo.ks.ddp.pipeline.model.ClinicalRecord;
 import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
 import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
 import org.mskcc.cmo.ks.ddp.pipeline.util.DDPPatientListUtil;

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/DDPCompositeProcessor.java
@@ -32,6 +32,7 @@
 
 package org.mskcc.cmo.ks.ddp.pipeline;
 
+import org.mskcc.cmo.ks.ddp.pipeline.model.ClinicalRecord;
 import org.mskcc.cmo.ks.ddp.pipeline.model.CompositeResult;
 import org.mskcc.cmo.ks.ddp.pipeline.util.DDPUtils;
 import org.mskcc.cmo.ks.ddp.pipeline.util.DDPPatientListUtil;
@@ -106,7 +107,7 @@ public class DDPCompositeProcessor implements ItemProcessor<DDPCompositeRecord, 
 
     @Override
     public CompositeResult process(DDPCompositeRecord compositeRecord) throws Exception {
-        // all get methods are asynchrnous - won't wait for completion before completing
+        // all get methods are asynchronous - won't wait for completion before completing
         CompletableFuture<PatientDemographics> futurePatientDemographics = ddpDataSource.getPatientDemographics(compositeRecord.getDmpPatientId());
         CompletableFuture<List<PatientDiagnosis>> futurePatientDiagnosis = (includeDiagnosis ?
                 ddpDataSource.getPatientDiagnoses(compositeRecord.getDmpPatientId()) : null);

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/AgeAtSeqDateRecord.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/model/AgeAtSeqDateRecord.java
@@ -49,10 +49,10 @@ public class AgeAtSeqDateRecord {
 
     public AgeAtSeqDateRecord(){}
 
-    public AgeAtSeqDateRecord(String patientId, String sampleId, String patientBirthDate) throws ParseException {
+    public AgeAtSeqDateRecord(String patientId, String sampleId, String patientBirthDate, String osMonths) throws ParseException {
         this.PATIENT_ID = patientId;
         this.SAMPLE_ID = sampleId;
-        this.AGE_AT_SEQ_REPORTED_YEARS = DDPUtils.resolveAgeAtSeqDate(sampleId, patientBirthDate);
+        this.AGE_AT_SEQ_REPORTED_YEARS = DDPUtils.resolveAgeAtSeqDate(sampleId, patientBirthDate, osMonths);
     }
 
     /**


### PR DESCRIPTION
For all cohorts:
- Any `AGE_CURRENT` over 89 will be binned to >89 and any age under 18 will be binned to <18.
- `AGE_AT_SEQ_REPORTED_YEARS` over 89 will be binned to >89 and any age under 18 will be binned to <18.
- For any patient such that `sum(AGE_AT_SEQ_REPORTED_YEARS + OS_MONTHS) > 89`, `AGE_AT_SEQ_REPORTED_YEARS` will be capped to `>{max(0, 89 - OS_MONTHS)}`.
- `OS_MONTHS` will be altered to have a 2 digit precision limit.