### PR TITLE
Java 11 migration DDP changes

### DIFF
--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -604,7 +604,7 @@ public class DDPUtils {
         if (date != null) {
             Calendar calendar = Calendar.getInstance();
             calendar.setTime(date);
-            return new Long(calendar.get(Calendar.YEAR));
+            return Long.valueOf(calendar.get(Calendar.YEAR));
         }
         return null;
     }
@@ -621,7 +621,7 @@ public class DDPUtils {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
             Calendar calendar = Calendar.getInstance();
             calendar.setTime(sdf.parse(dateValue));
-            return new Long(calendar.get(Calendar.YEAR));
+            return Long.valueOf(calendar.get(Calendar.YEAR));
         }
         return null;
     }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -39,6 +39,7 @@ import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.Calendar;
 import org.apache.log4j.Logger;
 import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
 import org.mskcc.cmo.ks.ddp.source.model.PatientDiagnosis;
@@ -80,7 +81,8 @@ public class DDPUtils {
 
     private static Integer getOffsetMinutesForSavingsTimeChange() {
         if (offsetMinutesForSavingsTimeChange == null) {
-            offsetMinutesForSavingsTimeChange = ZonedDateTime.now().getOffset().getTotalSeconds();
+            Calendar cal = Calendar.getInstance();
+            offsetMinutesForSavingsTimeChange = cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET) / (60 * 1000);
         }
         return offsetMinutesForSavingsTimeChange;
     }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -38,7 +38,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.util.*;
-
 import org.apache.log4j.Logger;
 import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
 import org.mskcc.cmo.ks.ddp.source.model.PatientDiagnosis;

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -569,11 +569,11 @@ public class DDPUtils {
         if (!Strings.isNullOrEmpty(dateValue) && !NULL_EMPTY_VALUES.contains(dateValue)) {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
             Date date = sdf.parse(dateValue);
-            //Integer savingstimeOffsetMinutesForParsedDate = date.getTimezoneOffset();
+            Integer savingstimeOffsetMinutesForParsedDate = date.getTimezoneOffset();
 
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-            ZonedDateTime zdt = ZonedDateTime.parse(dateValue, formatter);
-            Integer savingstimeOffsetMinutesForParsedDate = zdt.getOffset().getTotalSeconds();
+            //DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            //ZonedDateTime zdt = ZonedDateTime.parse(dateValue, formatter);
+            //Integer savingstimeOffsetMinutesForParsedDate = zdt.getOffset().getTotalSeconds();
 
             Integer localTimezoneOffsetMinuteDifference = getOffsetMinutesForSavingsTimeChange() - savingstimeOffsetMinutesForParsedDate;
             return computeDaysFromDateUsingLocalMidnight(date, localTimezoneOffsetMinuteDifference);

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -37,7 +37,6 @@ import java.io.*;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 import org.apache.log4j.Logger;

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -39,7 +39,7 @@ import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.Calendar;
+
 import org.apache.log4j.Logger;
 import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
 import org.mskcc.cmo.ks.ddp.source.model.PatientDiagnosis;
@@ -81,8 +81,8 @@ public class DDPUtils {
 
     private static Integer getOffsetMinutesForSavingsTimeChange() {
         if (offsetMinutesForSavingsTimeChange == null) {
-            Calendar cal = Calendar.getInstance();
-            offsetMinutesForSavingsTimeChange = cal.get(Calendar.ZONE_OFFSET) + cal.get(Calendar.DST_OFFSET) / (60 * 1000);
+            Date now = new Date();
+            offsetMinutesForSavingsTimeChange = now.getTimezoneOffset();
         }
         return offsetMinutesForSavingsTimeChange;
     }
@@ -572,11 +572,6 @@ public class DDPUtils {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
             Date date = sdf.parse(dateValue);
             Integer savingstimeOffsetMinutesForParsedDate = date.getTimezoneOffset();
-
-            //DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-            //ZonedDateTime zdt = ZonedDateTime.parse(dateValue, formatter);
-            //Integer savingstimeOffsetMinutesForParsedDate = zdt.getOffset().getTotalSeconds();
-
             Integer localTimezoneOffsetMinuteDifference = getOffsetMinutesForSavingsTimeChange() - savingstimeOffsetMinutesForParsedDate;
             return computeDaysFromDateUsingLocalMidnight(date, localTimezoneOffsetMinuteDifference);
         }

--- a/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
+++ b/ddp/ddp_pipeline/src/main/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtils.java
@@ -37,6 +37,7 @@ import java.io.*;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import org.apache.log4j.Logger;
 import org.mskcc.cmo.ks.ddp.source.composite.DDPCompositeRecord;
@@ -79,8 +80,7 @@ public class DDPUtils {
 
     private static Integer getOffsetMinutesForSavingsTimeChange() {
         if (offsetMinutesForSavingsTimeChange == null) {
-            Date now = new Date();
-            offsetMinutesForSavingsTimeChange = now.getTimezoneOffset();
+            offsetMinutesForSavingsTimeChange = ZonedDateTime.now().getOffset().getTotalSeconds();
         }
         return offsetMinutesForSavingsTimeChange;
     }
@@ -569,7 +569,12 @@ public class DDPUtils {
         if (!Strings.isNullOrEmpty(dateValue) && !NULL_EMPTY_VALUES.contains(dateValue)) {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
             Date date = sdf.parse(dateValue);
-            Integer savingstimeOffsetMinutesForParsedDate = date.getTimezoneOffset();
+            //Integer savingstimeOffsetMinutesForParsedDate = date.getTimezoneOffset();
+
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            ZonedDateTime zdt = ZonedDateTime.parse(dateValue, formatter);
+            Integer savingstimeOffsetMinutesForParsedDate = zdt.getOffset().getTotalSeconds();
+
             Integer localTimezoneOffsetMinuteDifference = getOffsetMinutesForSavingsTimeChange() - savingstimeOffsetMinutesForParsedDate;
             return computeDaysFromDateUsingLocalMidnight(date, localTimezoneOffsetMinuteDifference);
         }

--- a/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtilsTest.java
+++ b/ddp/ddp_pipeline/src/test/java/org/mskcc/cmo/ks/ddp/pipeline/util/DDPUtilsTest.java
@@ -497,7 +497,7 @@ public class DDPUtilsTest {
         cohortPatient.setPTVITALSTATUS("ALIVE");
         PatientDemographics patientDemographics = new PatientDemographics();
         patientDemographics.setPLALASTACTVDTE("2019-04-12");
-        patientDemographics.setCurrentAge(new Integer(75));
+        patientDemographics.setCurrentAge(Integer.valueOf(75));
         Map<String, Date> patientFirstSeqDateMap = new HashMap<String, Date>();
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
         Date seqDate = simpleDateFormat.parse("Fri, 13 Oct 2017 15:33:32 GMT");


### PR DESCRIPTION
- Removed use of deprecated functions: `Long(long)`, `Integer(int)`
- TODO: Calls to `Date.getTimezoneOffset()` need to be removed in a future effort