### PR TITLE
Modify preconsume script to work on one cohort at a time

### DIFF
--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -185,10 +185,8 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         # fetch new/updated IMPACT samples using CVR Web service   (must come after git fetching)
         drop_dead_instant_step=$(date --date="+3hours" -Iseconds) # nearly 3 hours from now
         drop_dead_instant_string=$(find_earlier_instant "$drop_dead_instant_step" "$DROP_DEAD_INSTANT_END_TO_END")
-        
         # pre-consume any samples missing values for normal_ad/tumor_dp/ad fields, or having UNKNOWN gene-panel
         bash $PORTAL_HOME/scripts/preconsume_problematic_samples.sh mskimpact
-
         printTimeStampedDataProcessingStepMessage "CVR fetch for mskimpact"
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_IMPACT_DATA_HOME -p $MSK_IMPACT_PRIVATE_DATA_HOME -n data_clinical_mskimpact_data_clinical_cvr.txt -i mskimpact -r 150 $CVR_TEST_MODE_ARGS -z $drop_dead_instant_string
         if [ $? -gt 0 ] ; then
@@ -266,10 +264,8 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         # fetch new/updated heme samples using CVR Web service (must come after git fetching). Threshold is set to 50 since heme contains only 190 samples (07/12/2017)
         drop_dead_instant_step=$(date --date="+3hours" -Iseconds) # nearly 3 hours from now
         drop_dead_instant_string=$(find_earlier_instant "$drop_dead_instant_step" "$DROP_DEAD_INSTANT_END_TO_END")
-        
         # pre-consume any samples missing values for normal_ad/tumor_dp/ad fields, or having UNKNOWN gene-panel
         bash $PORTAL_HOME/scripts/preconsume_problematic_samples.sh mskimpact_heme
-
         printTimeStampedDataProcessingStepMessage "CVR fetch for hemepact"
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_HEMEPACT_DATA_HOME -p $MSK_HEMEPACT_PRIVATE_DATA_HOME -n data_clinical_hemepact_data_clinical.txt -i mskimpact_heme -r 50 $CVR_TEST_MODE_ARGS -z $drop_dead_instant_string
         if [ $? -gt 0 ] ; then
@@ -334,10 +330,8 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         # fetch new/updated archer samples using CVR Web service (must come after git fetching).
         drop_dead_instant_step=$(date --date="+3hours" -Iseconds) # nearly 3 hours from now
         drop_dead_instant_string=$(find_earlier_instant "$drop_dead_instant_step" "$DROP_DEAD_INSTANT_END_TO_END")
-
         # pre-consume any samples missing values for normal_ad/tumor_dp/ad fields, or having UNKNOWN gene-panel
         bash $PORTAL_HOME/scripts/preconsume_problematic_samples.sh mskarcher
-
         printTimeStampedDataProcessingStepMessage "CVR fetch for archer"
         # archer has -b option to block warnings for samples with zero variants (all samples will have zero variants)
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_ARCHER_UNFILTERED_DATA_HOME -p $MSK_ARCHER_UNFILTERED_PRIVATE_DATA_HOME -n data_clinical_mskarcher_data_clinical.txt -i mskarcher -s -b -r 50 $CVR_TEST_MODE_ARGS -z $drop_dead_instant_string
@@ -373,10 +367,8 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         # fetch new/updated access samples using CVR Web service (must come after git fetching).
         drop_dead_instant_step=$(date --date="+3hours" -Iseconds) # nearly 3 hours from now
         drop_dead_instant_string=$(find_earlier_instant "$drop_dead_instant_step" "$DROP_DEAD_INSTANT_END_TO_END")
-
         # pre-consume any samples missing values for normal_ad/tumor_dp/ad fields, or having UNKNOWN gene-panel
         bash $PORTAL_HOME/scripts/preconsume_problematic_samples.sh mskaccess
-
         printTimeStampedDataProcessingStepMessage "CVR fetch for access"
         # access has -b option to block warnings for samples with zero variants (all samples will have zero variants)
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_ACCESS_DATA_HOME -p $MSK_ACCESS_PRIVATE_DATA_HOME -n data_clinical_mskaccess_data_clinical.txt -i mskaccess -s -b -r 50 $CVR_TEST_MODE_ARGS -z $drop_dead_instant_string

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -102,9 +102,6 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         fi
     fi
 
-    # pre-consume any samples missing values for normal_ad/tumor_dp/ad fields, or having UNKNOWN Archer gene-panel
-    bash $PORTAL_HOME/scripts/preconsume_problematic_samples.sh
-
     # fetch clinical data from data repository
     echo "fetching updates from dmp repository..."
     $JAVA_BINARY $JAVA_IMPORTER_ARGS --fetch-data --data-source dmp --run-date latest
@@ -188,6 +185,10 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         # fetch new/updated IMPACT samples using CVR Web service   (must come after git fetching)
         drop_dead_instant_step=$(date --date="+3hours" -Iseconds) # nearly 3 hours from now
         drop_dead_instant_string=$(find_earlier_instant "$drop_dead_instant_step" "$DROP_DEAD_INSTANT_END_TO_END")
+        
+        # pre-consume any samples missing values for normal_ad/tumor_dp/ad fields, or having UNKNOWN gene-panel
+        bash $PORTAL_HOME/scripts/preconsume_problematic_samples.sh mskimpact
+
         printTimeStampedDataProcessingStepMessage "CVR fetch for mskimpact"
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_IMPACT_DATA_HOME -p $MSK_IMPACT_PRIVATE_DATA_HOME -n data_clinical_mskimpact_data_clinical_cvr.txt -i mskimpact -r 150 $CVR_TEST_MODE_ARGS -z $drop_dead_instant_string
         if [ $? -gt 0 ] ; then
@@ -265,6 +266,10 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         # fetch new/updated heme samples using CVR Web service (must come after git fetching). Threshold is set to 50 since heme contains only 190 samples (07/12/2017)
         drop_dead_instant_step=$(date --date="+3hours" -Iseconds) # nearly 3 hours from now
         drop_dead_instant_string=$(find_earlier_instant "$drop_dead_instant_step" "$DROP_DEAD_INSTANT_END_TO_END")
+        
+        # pre-consume any samples missing values for normal_ad/tumor_dp/ad fields, or having UNKNOWN gene-panel
+        bash $PORTAL_HOME/scripts/preconsume_problematic_samples.sh mskimpact_heme
+
         printTimeStampedDataProcessingStepMessage "CVR fetch for hemepact"
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_HEMEPACT_DATA_HOME -p $MSK_HEMEPACT_PRIVATE_DATA_HOME -n data_clinical_hemepact_data_clinical.txt -i mskimpact_heme -r 50 $CVR_TEST_MODE_ARGS -z $drop_dead_instant_string
         if [ $? -gt 0 ] ; then
@@ -329,6 +334,10 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         # fetch new/updated archer samples using CVR Web service (must come after git fetching).
         drop_dead_instant_step=$(date --date="+3hours" -Iseconds) # nearly 3 hours from now
         drop_dead_instant_string=$(find_earlier_instant "$drop_dead_instant_step" "$DROP_DEAD_INSTANT_END_TO_END")
+
+        # pre-consume any samples missing values for normal_ad/tumor_dp/ad fields, or having UNKNOWN gene-panel
+        bash $PORTAL_HOME/scripts/preconsume_problematic_samples.sh mskarcher
+
         printTimeStampedDataProcessingStepMessage "CVR fetch for archer"
         # archer has -b option to block warnings for samples with zero variants (all samples will have zero variants)
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_ARCHER_UNFILTERED_DATA_HOME -p $MSK_ARCHER_UNFILTERED_PRIVATE_DATA_HOME -n data_clinical_mskarcher_data_clinical.txt -i mskarcher -s -b -r 50 $CVR_TEST_MODE_ARGS -z $drop_dead_instant_string
@@ -364,6 +373,10 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         # fetch new/updated access samples using CVR Web service (must come after git fetching).
         drop_dead_instant_step=$(date --date="+3hours" -Iseconds) # nearly 3 hours from now
         drop_dead_instant_string=$(find_earlier_instant "$drop_dead_instant_step" "$DROP_DEAD_INSTANT_END_TO_END")
+
+        # pre-consume any samples missing values for normal_ad/tumor_dp/ad fields, or having UNKNOWN gene-panel
+        bash $PORTAL_HOME/scripts/preconsume_problematic_samples.sh mskaccess
+
         printTimeStampedDataProcessingStepMessage "CVR fetch for access"
         # access has -b option to block warnings for samples with zero variants (all samples will have zero variants)
         $JAVA_BINARY $JAVA_CVR_FETCHER_ARGS -d $MSK_ACCESS_DATA_HOME -p $MSK_ACCESS_PRIVATE_DATA_HOME -n data_clinical_mskaccess_data_clinical.txt -i mskaccess -s -b -r 50 $CVR_TEST_MODE_ARGS -z $drop_dead_instant_string

--- a/import-scripts/preconsume_problematic_samples.sh
+++ b/import-scripts/preconsume_problematic_samples.sh
@@ -126,7 +126,6 @@ function consume_hardcoded_samples() {
     touch ${PROBLEMATIC_EVENT_CONSUME_IDS_FILEPATH}
     touch ${PROBLEMATIC_METADATA_CONSUME_IDS_FILEPATH}
 
-    # see if we still need this ?
     if [ "$COHORT" == "mskimpact" ] ; then
         echo "P-0025907-N01-IM6" >> "${PROBLEMATIC_METADATA_CONSUME_IDS_FILEPATH}"
     fi

--- a/import-scripts/preconsume_problematic_samples.sh
+++ b/import-scripts/preconsume_problematic_samples.sh
@@ -135,8 +135,8 @@ function consume_hardcoded_samples() {
 }
 
 function log_actions() {
-    # add cohort name to log actions?
     date
+    echo -e "${COHORT^^} Problematic Samples"
     echo -e "consumed the following samples with problematic events:\n${succeeded_to_consume_problematic_events_sample_list[*]}"
     echo -e "attempted but failed to consume the following samples with problematic events:\n${failed_to_consume_problematic_events_sample_list[*]}"
     echo -e "consumed the following samples with problematic metadata:\n${succeeded_to_consume_problematic_metadata_sample_list[*]}"
@@ -145,8 +145,7 @@ function log_actions() {
 }
 
 function post_slack_message() {
-    # add cohort name to message?
-    MESSAGE="<@U02D0Q0RWUE> <@U03FERRJ6SE> Warning : the following samples have been preemptively consumed before fetch because they contained events which required a value for fields {normal_dp, normal_ad, tumor_dp, tumor_ad} but contained no value in one or more of these fields.\nSuccessfully Consumed :\n${succeeded_to_consume_problematic_events_sample_list[*]}"
+    MESSAGE="<@U02D0Q0RWUE> <@U03FERRJ6SE> ${COHORT^^} Problematic Samples \nWarning : \nThe following samples have been preemptively consumed before fetch because they contained events which required a value for fields {normal_dp, normal_ad, tumor_dp, tumor_ad} but contained no value in one or more of these fields.\nSuccessfully Consumed :\n${succeeded_to_consume_problematic_events_sample_list[*]}"
     if [ ${#failed_to_consume_problematic_events_sample_list[@]} -gt 0 ]; then
         MESSAGE="${MESSAGE} Attempted Unsuccessfully To Consume :\n${failed_to_consume_problematic_events_sample_list[*]}"
     fi
@@ -175,4 +174,4 @@ failed_to_consume_problematic_metadata_sample_list=()
 succeeded_to_consume_problematic_metadata_sample_list=()
 attempt_to_consume_problematic_samples
 log_actions
-#post_slack_message
+post_slack_message

--- a/import-scripts/preconsume_problematic_samples.sh
+++ b/import-scripts/preconsume_problematic_samples.sh
@@ -166,6 +166,7 @@ function post_slack_message() {
 }
 
 date
+check_args
 make_tmp_dir_if_necessary
 failed_to_consume_problematic_events_sample_list=() # temporary code
 succeeded_to_consume_problematic_events_sample_list=() # temporary code

--- a/import-scripts/preconsume_problematic_samples.sh
+++ b/import-scripts/preconsume_problematic_samples.sh
@@ -32,6 +32,18 @@ function make_tmp_dir_if_necessary() {
     fi
 }
 
+function check_args() {
+    if [[ -z $COHORT ]] || [[ "$COHORT" != "mskimpact" && "$COHORT" != "mskimpact_heme" && "$COHORT" != "mskaccess" && "$COHORT" != "mskarcher" ]]; then
+        usage
+        exit 1
+    fi
+}
+
+function usage {
+    echo "preconsume_problematic_samples.sh \$COHORT_ID"
+    echo -e "\t\$COHORT_ID                      one of: ['mskimpact', 'mskimpact_heme', 'mskaccess', 'mskarcher']"
+}
+
 function set_cvr_fetch_url_prefix() {
     if [ "$COHORT" == "mskimpact" ] ; then
         CVR_FETCH_URL_PREFIX=$CVR_IMPACT_FETCH_URL_PREFIX
@@ -41,9 +53,6 @@ function set_cvr_fetch_url_prefix() {
         CVR_FETCH_URL_PREFIX=$CVR_ARCHER_FETCH_URL_PREFIX
     elif [ "$COHORT" == "mskaccess" ] ; then
         CVR_FETCH_URL_PREFIX=$CVR_ACCESS_FETCH_URL_PREFIX
-    else
-        echo "Error: Invalid cohort name '$COHORT'" >&2
-        exit 1
     fi
 }
 


### PR DESCRIPTION
This PR :
- modifies the `preconsume_problematic_samples.sh` script to work on one cohort at a time. 
- Modifies the `fetch-dmp-data-for-import.sh` script to call the `preconsume_problematic_samples.sh` once for each cohort, immediately before the CVR fetch for that cohort.
- This should prevent problematic samples from being queued in the time between the preconsume step and the CVR fetcher step.