### PR TITLE
Call correct function name

### DIFF
--- a/import-scripts/update-az-mskimpact.sh
+++ b/import-scripts/update-az-mskimpact.sh
@@ -302,7 +302,7 @@ if ! rename_files_in_delivery_directory ; then
 fi
 
 # Filter clinical attribute columns from clinical files
-if ! filter_clinical_attribute_columns ; then
+if ! filter_clinical_cols ; then
     report_error "ERROR: Failed to filter non-delivered clinical attribute columns for AstraZeneca MSK-IMPACT. Exiting."
 fi
 


### PR DESCRIPTION
Bug in AZ script introduced in https://github.com/knowledgesystems/cmo-pipelines/pull/1105 - was calling incorrect function for filtering clinical arguments. This PR fixes that bug