### PR TITLE
Add script to generate age at seq for genie deliveries

### DIFF
--- a/import-scripts/generate-age-at-seq.sh
+++ b/import-scripts/generate-age-at-seq.sh
@@ -6,15 +6,37 @@ MSK_ACCESS_TMP_DIR="$TMP_DIR/mskaccess"
 
 source /data/portal-cron/scripts/dmp-import-vars-functions.sh
 
-# Create tmp dir if necessary
-if ! [ -d "$TMP_DIR" ] ; then
-    if ! mkdir -p "$TMP_DIR" ; then
-        echo "Error : could not create tmp directory '$TMP_DIR'" >&2
+# Create mskimpact tmp dir if necessary
+if ! [ -d "$MSK_IMPACT_TMP_DIR" ] ; then
+    if ! mkdir -p "$MSK_IMPACT_TMP_DIR" ; then
+        echo "Error : could not create tmp directory '$MSK_IMPACT_TMP_DIR'" >&2
         exit 1
     fi
 else
     # Remove files from last fetch
-    rm -rf $TMP_DIR/*
+    rm -rf $MSK_IMPACT_TMP_DIR/*
+fi
+
+# Create mskimpact tmp dir if necessary
+if ! [ -d "$MSK_HEMEPACT_TMP_DIR" ] ; then
+    if ! mkdir -p "$MSK_HEMEPACT_TMP_DIR" ; then
+        echo "Error : could not create tmp directory '$MSK_HEMEPACT_TMP_DIR'" >&2
+        exit 1
+    fi
+else
+    # Remove files from last fetch
+    rm -rf $MSK_HEMEPACT_TMP_DIR/*
+fi
+
+# Create mskimpact tmp dir if necessary
+if ! [ -d "$MSK_ACCESS_TMP_DIR" ] ; then
+    if ! mkdir -p "$MSK_ACCESS_TMP_DIR" ; then
+        echo "Error : could not create tmp directory '$MSK_ACCESS_TMP_DIR'" >&2
+        exit 1
+    fi
+else
+    # Remove files from last fetch
+    rm -rf $MSK_ACCESS_TMP_DIR/*
 fi
 
 # --------------------------------------------------------------------------------------------------------------

--- a/import-scripts/generate-age-at-seq.sh
+++ b/import-scripts/generate-age-at-seq.sh
@@ -143,8 +143,7 @@ MERGED_AGE_AT_SEQ="$TMP_DIR/merged_age_at_seq.txt"
 SAMPLE_INPUT_FILEPATH="$MSK_SOLID_HEME_DATA_HOME/data_clinical_sample.txt"
 SAMPLE_OUTPUT_FILEPATH="$TMP_DIR/data_clinical_sample.txt"
 KEY_COLUMNS="SAMPLE_ID PATIENT_ID"
-CDD_URL="https://cdd.cbioportal.mskcc.org/api/"
 
 $PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$MSK_IMPACT_AGE_AT_SEQ" "$MSK_HEMEPACT_AGE_AT_SEQ" "$MSK_ACCESS_AGE_AT_SEQ" -o "$MERGED_AGE_AT_SEQ" -m outer &&
 $PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$SAMPLE_INPUT_FILEPATH" "$MERGED_AGE_AT_SEQ" -o "$SAMPLE_OUTPUT_FILEPATH" -c $KEY_COLUMNS -m left &&
-$PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -f $SAMPLE_OUTPUT_FILEPATH -c "$CDD_URL" -s mskimpact
+$PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -f $SAMPLE_OUTPUT_FILEPATH -s mskimpact -i /data/portal-cron/scripts/cdm_metadata.json

--- a/import-scripts/generate-age-at-seq.sh
+++ b/import-scripts/generate-age-at-seq.sh
@@ -55,7 +55,7 @@ fi
 
 printTimeStampedDataProcessingStepMessage "DDP demographics fetch for mskimpact"
 mskimpact_dmp_pids_file=$MSK_IMPACT_TMP_DIR/mskimpact_patient_list.txt
-awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt | sort | uniq > $mskimpact_dmp_pids_file
+awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_TMP_DIR/data_clinical_mskimpact_data_clinical_cvr.txt | sort | uniq > $mskimpact_dmp_pids_file
 MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSK_IMPACT_TMP_DIR/data_clinical_mskimpact_data_clinical_ddp_demographics.txt)
 if [ $MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT ] ; then
     MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT
@@ -84,7 +84,7 @@ fi
 
 printTimeStampedDataProcessingStepMessage "DDP demographics fetch for hemepact"
 mskimpact_heme_dmp_pids_file=$MSK_HEMEPACT_TMP_DIR/mskimpact_heme_patient_list.txt
-awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt | sort | uniq > $mskimpact_heme_dmp_pids_file
+awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_HEMEPACT_TMP_DIR/data_clinical_hemepact_data_clinical.txt | sort | uniq > $mskimpact_heme_dmp_pids_file
 HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSK_HEMEPACT_TMP_DIR/data_clinical_hemepact_data_clinical_ddp_demographics.txt)
 if [ $HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT ] ; then
     HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT
@@ -113,7 +113,7 @@ fi
 
 printTimeStampedDataProcessingStepMessage "DDP demographics fetch for access"
 mskaccess_dmp_pids_file=$MSK_ACCESS_TMP_DIR/mskaccess_patient_list.txt
-awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_ACCESS_DATA_HOME/data_clinical_mskaccess_data_clinical.txt | sort | uniq > $mskaccess_dmp_pids_file
+awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_ACCESS_TMP_DIR/data_clinical_mskaccess_data_clinical.txt | sort | uniq > $mskaccess_dmp_pids_file
 ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSK_ACCESS_TMP_DIR/data_clinical_mskaccess_data_clinical_ddp_demographics.txt)
 if [ $ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT ] ; then
     ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT

--- a/import-scripts/generate-age-at-seq.sh
+++ b/import-scripts/generate-age-at-seq.sh
@@ -17,7 +17,7 @@ else
     rm -rf $MSK_IMPACT_TMP_DIR/*
 fi
 
-# Create mskimpact tmp dir if necessary
+# Create hemepact tmp dir if necessary
 if ! [ -d "$MSK_HEMEPACT_TMP_DIR" ] ; then
     if ! mkdir -p "$MSK_HEMEPACT_TMP_DIR" ; then
         echo "Error : could not create tmp directory '$MSK_HEMEPACT_TMP_DIR'" >&2
@@ -28,7 +28,7 @@ else
     rm -rf $MSK_HEMEPACT_TMP_DIR/*
 fi
 
-# Create mskimpact tmp dir if necessary
+# Create mskaccess tmp dir if necessary
 if ! [ -d "$MSK_ACCESS_TMP_DIR" ] ; then
     if ! mkdir -p "$MSK_ACCESS_TMP_DIR" ; then
         echo "Error : could not create tmp directory '$MSK_ACCESS_TMP_DIR'" >&2
@@ -138,11 +138,13 @@ AGE_AT_SEQ_FILENAME="data_clinical_ddp_age_at_seq.txt"
 MSK_IMPACT_AGE_AT_SEQ="$MSK_IMPACT_TMP_DIR/$AGE_AT_SEQ_FILENAME"
 MSK_HEMEPACT_AGE_AT_SEQ="$MSK_HEMEPACT_TMP_DIR/$AGE_AT_SEQ_FILENAME"
 MSK_ACCESS_AGE_AT_SEQ="$MSK_ACCESS_TMP_DIR/$AGE_AT_SEQ_FILENAME"
-MERGED_SEQ_DATE="$TMP_DIR/merged_age_at_seq.txt"
+MERGED_AGE_AT_SEQ="$TMP_DIR/merged_age_at_seq.txt"
 
 SAMPLE_INPUT_FILEPATH="$MSK_SOLID_HEME_DATA_HOME/data_clinical_sample.txt"
 SAMPLE_OUTPUT_FILEPATH="$TMP_DIR/data_clinical_sample.txt"
 KEY_COLUMNS="SAMPLE_ID PATIENT_ID"
+CDD_URL="https://cdd.cbioportal.mskcc.org/api/"
 
 $PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$MSK_IMPACT_AGE_AT_SEQ" "$MSK_HEMEPACT_AGE_AT_SEQ" "$MSK_ACCESS_AGE_AT_SEQ" -o "$MERGED_AGE_AT_SEQ" -m outer &&
-$PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$SAMPLE_INPUT_FILEPATH" "$MERGED_AGE_AT_SEQ" -o "$SAMPLE_OUTPUT_FILEPATH" -c $KEY_COLUMNS -m left
+$PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$SAMPLE_INPUT_FILEPATH" "$MERGED_AGE_AT_SEQ" -o "$SAMPLE_OUTPUT_FILEPATH" -c $KEY_COLUMNS -m left &&
+$PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -f $SAMPLE_OUTPUT_FILEPATH -c "$CDD_URL" -s mskimpact

--- a/import-scripts/generate-age-at-seq.sh
+++ b/import-scripts/generate-age-at-seq.sh
@@ -4,6 +4,8 @@ MSK_IMPACT_TMP_DIR="$TMP_DIR/mskimpact"
 MSK_HEMEPACT_TMP_DIR="$TMP_DIR/mskhemepact"
 MSK_ACCESS_TMP_DIR="$TMP_DIR/mskaccess"
 
+source /data/portal-cron/scripts/dmp-import-vars-functions.sh
+
 # Create tmp dir if necessary
 if ! [ -d "$TMP_DIR" ] ; then
     if ! mkdir -p "$TMP_DIR" ; then

--- a/import-scripts/generate-age-at-seq.sh
+++ b/import-scripts/generate-age-at-seq.sh
@@ -45,12 +45,14 @@ echo "exporting impact data_clinical_mskimpact_data_clinical_ddp_demographics.tx
 export_project_from_redcap $MSK_IMPACT_TMP_DIR mskimpact_data_clinical_ddp_demographics
 if [ $? -gt 0 ] ; then
     echo "ERROR: MSKIMPACT Redcap export of mskimpact_data_clinical_ddp_demographics"
+    exit 1
 fi
 
 echo "exporting impact data_clinical.txt from redcap"
 export_project_from_redcap $MSK_IMPACT_TMP_DIR mskimpact_data_clinical_cvr
 if [ $? -gt 0 ] ; then
     echo "ERROR: MSKIMPACT Redcap export of mskimpact_data_clinical_cvr"
+    exit 1
 fi
 
 printTimeStampedDataProcessingStepMessage "DDP demographics fetch for mskimpact"
@@ -63,8 +65,8 @@ fi
 
 $JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact -p $mskimpact_dmp_pids_file -s $MSK_IMPACT_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_IMPACT_TMP_DIR -r $MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT
 if [ $? -gt 0 ] ; then
-    cd $DMP_DATA_HOME ; $GIT_BINARY reset HEAD --hard
     echo "ERROR: MSKIMPACT DDP Demographics Fetch"
+    exit 1
 fi
 
 # --------------------------------------------------------------------------------------------------------------
@@ -74,12 +76,14 @@ echo "exporting heme data_clinical_hemepact_data_clinical_ddp_demographics.txt f
 export_project_from_redcap $MSK_HEMEPACT_TMP_DIR hemepact_data_clinical_ddp_demographics
 if [ $? -gt 0 ] ; then
     echo "ERROR: HEMEPACT Redcap export of hemepact_data_clinical_ddp_demographics"
+    exit 1
 fi
 
 echo "exporting heme data_clinical.txt from redcap"
 export_project_from_redcap $MSK_HEMEPACT_TMP_DIR hemepact_data_clinical
 if [ $? -gt 0 ] ; then
     echo "ERROR: HEMEPACT Redcap export of hemepact_data_clinical_cvr"
+    exit 1
 fi
 
 printTimeStampedDataProcessingStepMessage "DDP demographics fetch for hemepact"
@@ -92,8 +96,8 @@ fi
 
 $JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact_heme -p $mskimpact_heme_dmp_pids_file -s $MSK_HEMEPACT_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_HEMEPACT_TMP_DIR -r $HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT
 if [ $? -gt 0 ] ; then
-    cd $DMP_DATA_HOME ; $GIT_BINARY reset HEAD --hard
     echo "ERROR: HEMEPACT DDP Demographics Fetch"
+    exit 1
 fi
 
 # --------------------------------------------------------------------------------------------------------------
@@ -103,12 +107,14 @@ echo "exporting access data_clinical_mskaccess_data_clinical_ddp_demographics.tx
 export_project_from_redcap $MSK_ACCESS_TMP_DIR mskaccess_data_clinical_ddp_demographics
 if [ $? -gt 0 ] ; then
     echo "ERROR: ACCESS Redcap export of mskaccess_data_clinical_ddp_demographics"
+    exit 1
 fi
 
 echo "exporting access data_clinical.txt from redcap"
 export_project_from_redcap $MSK_ACCESS_TMP_DIR mskaccess_data_clinical
 if [ $? -gt 0 ] ; then
     echo "ERROR: ACCESS Redcap export of mskaccess_data_clinical_cvr"
+    exit 1
 fi
 
 printTimeStampedDataProcessingStepMessage "DDP demographics fetch for access"
@@ -121,8 +127,8 @@ fi
 
 $JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskaccess -p $mskaccess_dmp_pids_file -s $MSK_ACCESS_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_ACCESS_TMP_DIR -r $ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT
 if [ $? -gt 0 ] ; then
-    cd $DMP_DATA_HOME ; $GIT_BINARY reset HEAD --hard
     echo "ERROR: ACCESS DDP Demographics Fetch"
+    exit 1
 fi
 
 # --------------------------------------------------------------------------------------------------------------

--- a/import-scripts/generate-age-at-seq.sh
+++ b/import-scripts/generate-age-at-seq.sh
@@ -1,35 +1,43 @@
-#Put a ddp fetch into a script - genie
-#Run the ddp fetcher in age at seq mode
-#Ideally just write out the age at seq - but a clinical might be written out
+# Define temporary directories
+TMP_DIR="/data/portal-cron/tmp/generate_age_at_seq"
+MSK_IMPACT_TMP_DIR="$TMP_DIR/mskimpact"
+MSK_HEMEPACT_TMP_DIR="$TMP_DIR/mskhemepact"
+MSK_ACCESS_TMP_DIR="$TMP_DIR/mskaccess"
 
-# MSKIMPACT DDP Fetch - took like 2.5 hours
-# wrote out
-# data_clinical_ddp_age_at_seq.txt
-# data_clinical_ddp.txt
-# ddp/ddp_naaccr.txt
-# ddp/ddp_vital_status.txt
+# Create tmp dir if necessary
+if ! [ -d "$TMP_DIR" ] ; then
+    if ! mkdir -p "$TMP_DIR" ; then
+        echo "Error : could not create tmp directory '$TMP_DIR'" >&2
+        exit 1
+    fi
+else
+    # Remove files from last fetch
+    rm -rf $TMP_DIR/*
+fi
 
+# --------------------------------------------------------------------------------------------------------------
+# MSKIMPACT DDP Fetch
 echo "exporting impact data_clinical_mskimpact_data_clinical_ddp_demographics.txt from redcap"
-export_project_from_redcap $MSK_IMPACT_DATA_HOME mskimpact_data_clinical_ddp_demographics
+export_project_from_redcap $MSK_IMPACT_TMP_DIR mskimpact_data_clinical_ddp_demographics
 if [ $? -gt 0 ] ; then
     echo "ERROR: MSKIMPACT Redcap export of mskimpact_data_clinical_ddp_demographics"
 fi
 
 echo "exporting impact data_clinical.txt from redcap"
-export_project_from_redcap $MSK_IMPACT_DATA_HOME mskimpact_data_clinical_cvr
+export_project_from_redcap $MSK_IMPACT_TMP_DIR mskimpact_data_clinical_cvr
 if [ $? -gt 0 ] ; then
     echo "ERROR: MSKIMPACT Redcap export of mskimpact_data_clinical_cvr"
 fi
 
 printTimeStampedDataProcessingStepMessage "DDP demographics fetch for mskimpact"
-mskimpact_dmp_pids_file=$MSK_IMPACT_DATA_HOME/mskimpact_patient_list.txt
+mskimpact_dmp_pids_file=$MSK_IMPACT_TMP_DIR/mskimpact_patient_list.txt
 awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt | sort | uniq > $mskimpact_dmp_pids_file
-MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSKIMPACT_REDCAP_BACKUP/data_clinical_mskimpact_data_clinical_ddp_demographics.txt)
+MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSK_IMPACT_TMP_DIR/data_clinical_mskimpact_data_clinical_ddp_demographics.txt)
 if [ $MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT ] ; then
     MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT
 fi
 
-$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact -p $mskimpact_dmp_pids_file -s $MSK_IMPACT_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_IMPACT_DATA_HOME -r $MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact -p $mskimpact_dmp_pids_file -s $MSK_IMPACT_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_IMPACT_TMP_DIR -r $MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT
 if [ $? -gt 0 ] ; then
     cd $DMP_DATA_HOME ; $GIT_BINARY reset HEAD --hard
     echo "ERROR: MSKIMPACT DDP Demographics Fetch"
@@ -39,72 +47,72 @@ fi
 # HEMEPACT DDP Fetch
 
 echo "exporting heme data_clinical_hemepact_data_clinical_ddp_demographics.txt from redcap"
-export_project_from_redcap $MSK_HEMEPACT_DATA_HOME hemepact_data_clinical_ddp_demographics
+export_project_from_redcap $MSK_HEMEPACT_TMP_DIR hemepact_data_clinical_ddp_demographics
 if [ $? -gt 0 ] ; then
     echo "ERROR: HEMEPACT Redcap export of hemepact_data_clinical_ddp_demographics"
 fi
 
 echo "exporting heme data_clinical.txt from redcap"
-export_project_from_redcap $MSK_HEMEPACT_DATA_HOME hemepact_data_clinical
+export_project_from_redcap $MSK_HEMEPACT_TMP_DIR hemepact_data_clinical
 if [ $? -gt 0 ] ; then
     echo "ERROR: HEMEPACT Redcap export of hemepact_data_clinical_cvr"
 fi
 
 printTimeStampedDataProcessingStepMessage "DDP demographics fetch for hemepact"
-mskimpact_heme_dmp_pids_file=$MSK_HEMEPACT_DATA_HOME/mskimpact_heme_patient_list.txt
+mskimpact_heme_dmp_pids_file=$MSK_HEMEPACT_TMP_DIR/mskimpact_heme_patient_list.txt
 awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt | sort | uniq > $mskimpact_heme_dmp_pids_file
-HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical_ddp_demographics.txt)
+HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSK_HEMEPACT_TMP_DIR/data_clinical_hemepact_data_clinical_ddp_demographics.txt)
 if [ $HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT ] ; then
     HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT
 fi
 
-$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact_heme -p $mskimpact_heme_dmp_pids_file -s $MSK_HEMEPACT_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_HEMEPACT_DATA_HOME -r $HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact_heme -p $mskimpact_heme_dmp_pids_file -s $MSK_HEMEPACT_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_HEMEPACT_TMP_DIR -r $HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT
 if [ $? -gt 0 ] ; then
     cd $DMP_DATA_HOME ; $GIT_BINARY reset HEAD --hard
-    sendPreImportFailureMessageMskPipelineLogsSlack "HEMEPACT DDP Demographics Fetch"
+    echo "ERROR: HEMEPACT DDP Demographics Fetch"
 fi
 
 # --------------------------------------------------------------------------------------------------------------
 # ACCESS DDP Fetch
 
 echo "exporting access data_clinical_mskaccess_data_clinical_ddp_demographics.txt from redcap"
-export_project_from_redcap $MSK_ACCESS_DATA_HOME mskaccess_data_clinical_ddp_demographics
+export_project_from_redcap $MSK_ACCESS_TMP_DIR mskaccess_data_clinical_ddp_demographics
 if [ $? -gt 0 ] ; then
     echo "ERROR: ACCESS Redcap export of mskaccess_data_clinical_ddp_demographics"
 fi
 
 echo "exporting access data_clinical.txt from redcap"
-export_project_from_redcap $MSK_ACCESS_DATA_HOME mskaccess_data_clinical
+export_project_from_redcap $MSK_ACCESS_TMP_DIR mskaccess_data_clinical
 if [ $? -gt 0 ] ; then
     echo "ERROR: ACCESS Redcap export of mskaccess_data_clinical_cvr"
 fi
 
 printTimeStampedDataProcessingStepMessage "DDP demographics fetch for access"
-mskaccess_dmp_pids_file=$MSK_ACCESS_DATA_HOME/mskaccess_patient_list.txt
+mskaccess_dmp_pids_file=$MSK_ACCESS_TMP_DIR/mskaccess_patient_list.txt
 awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_ACCESS_DATA_HOME/data_clinical_mskaccess_data_clinical.txt | sort | uniq > $mskaccess_dmp_pids_file
-ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSK_ACCESS_DATA_HOME/data_clinical_mskaccess_data_clinical_ddp_demographics.txt)
+ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSK_ACCESS_TMP_DIR/data_clinical_mskaccess_data_clinical_ddp_demographics.txt)
 if [ $ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT ] ; then
     ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT
 fi
 
-$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskaccess -p $mskaccess_dmp_pids_file -s $MSK_ACCESS_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_ACCESS_DATA_HOME -r $ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskaccess -p $mskaccess_dmp_pids_file -s $MSK_ACCESS_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_ACCESS_TMP_DIR -r $ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT
 if [ $? -gt 0 ] ; then
     cd $DMP_DATA_HOME ; $GIT_BINARY reset HEAD --hard
-    sendPreImportFailureMessageMskPipelineLogsSlack "ACCESS DDP Demographics Fetch"
+    echo "ERROR: ACCESS DDP Demographics Fetch"
 fi
 
 # --------------------------------------------------------------------------------------------------------------
-# Combine age at seq files and merge into clinical sample file
+# Combine age at seq files and merge into msk_solid_heme clinical sample file
 
 AGE_AT_SEQ_FILENAME="data_clinical_ddp_age_at_seq.txt"
-MSK_ACCESS_AGE_AT_SEQ="$MSK_ACCESS_DATA_HOME/$AGE_AT_SEQ_FILENAME"
-MSK_HEMEPACT_AGE_AT_SEQ="$MSK_HEMEPACT_DATA_HOME/$AGE_AT_SEQ_FILENAME"
-MSK_IMPACT_AGE_AT_SEQ="$MSK_IMPACT_DATA_HOME/$AGE_AT_SEQ_FILENAME"
-MERGED_SEQ_DATE="./merged_age_at_seq.txt"
+MSK_IMPACT_AGE_AT_SEQ="$MSK_IMPACT_TMP_DIR/$AGE_AT_SEQ_FILENAME"
+MSK_HEMEPACT_AGE_AT_SEQ="$MSK_HEMEPACT_TMP_DIR/$AGE_AT_SEQ_FILENAME"
+MSK_ACCESS_AGE_AT_SEQ="$MSK_ACCESS_TMP_DIR/$AGE_AT_SEQ_FILENAME"
+MERGED_SEQ_DATE="$TMP_DIR/merged_age_at_seq.txt"
 
 SAMPLE_INPUT_FILEPATH="$MSK_SOLID_HEME_DATA_HOME/data_clinical_sample.txt"
-SAMPLE_OUTPUT_FILEPATH="$./data_clinical_sample.txt"
+SAMPLE_OUTPUT_FILEPATH="$TMP_DIR/data_clinical_sample.txt"
 KEY_COLUMNS="SAMPLE_ID PATIENT_ID"
 
-$PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$MSK_ACCESS_AGE_AT_SEQ" "$MSK_HEMEPACT_AGE_AT_SEQ" "$MSK_IMPACT_AGE_AT_SEQ" -o "$MERGED_AGE_AT_SEQ" -m outer &&
+$PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$MSK_IMPACT_AGE_AT_SEQ" "$MSK_HEMEPACT_AGE_AT_SEQ" "$MSK_ACCESS_AGE_AT_SEQ" -o "$MERGED_AGE_AT_SEQ" -m outer &&
 $PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$SAMPLE_INPUT_FILEPATH" "$MERGED_AGE_AT_SEQ" -o "$SAMPLE_OUTPUT_FILEPATH" -c $KEY_COLUMNS -m left

--- a/import-scripts/generate-age-at-seq.sh
+++ b/import-scripts/generate-age-at-seq.sh
@@ -1,0 +1,110 @@
+#Put a ddp fetch into a script - genie
+#Run the ddp fetcher in age at seq mode
+#Ideally just write out the age at seq - but a clinical might be written out
+
+# MSKIMPACT DDP Fetch - took like 2.5 hours
+# wrote out
+# data_clinical_ddp_age_at_seq.txt
+# data_clinical_ddp.txt
+# ddp/ddp_naaccr.txt
+# ddp/ddp_vital_status.txt
+
+echo "exporting impact data_clinical_mskimpact_data_clinical_ddp_demographics.txt from redcap"
+export_project_from_redcap $MSK_IMPACT_DATA_HOME mskimpact_data_clinical_ddp_demographics
+if [ $? -gt 0 ] ; then
+    echo "ERROR: MSKIMPACT Redcap export of mskimpact_data_clinical_ddp_demographics"
+fi
+
+echo "exporting impact data_clinical.txt from redcap"
+export_project_from_redcap $MSK_IMPACT_DATA_HOME mskimpact_data_clinical_cvr
+if [ $? -gt 0 ] ; then
+    echo "ERROR: MSKIMPACT Redcap export of mskimpact_data_clinical_cvr"
+fi
+
+printTimeStampedDataProcessingStepMessage "DDP demographics fetch for mskimpact"
+mskimpact_dmp_pids_file=$MSK_IMPACT_DATA_HOME/mskimpact_patient_list.txt
+awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt | sort | uniq > $mskimpact_dmp_pids_file
+MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSKIMPACT_REDCAP_BACKUP/data_clinical_mskimpact_data_clinical_ddp_demographics.txt)
+if [ $MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT ] ; then
+    MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT
+fi
+
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact -p $mskimpact_dmp_pids_file -s $MSK_IMPACT_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_IMPACT_DATA_HOME -r $MSKIMPACT_DDP_DEMOGRAPHICS_RECORD_COUNT
+if [ $? -gt 0 ] ; then
+    cd $DMP_DATA_HOME ; $GIT_BINARY reset HEAD --hard
+    echo "ERROR: MSKIMPACT DDP Demographics Fetch"
+fi
+
+# --------------------------------------------------------------------------------------------------------------
+# HEMEPACT DDP Fetch
+
+echo "exporting heme data_clinical_hemepact_data_clinical_ddp_demographics.txt from redcap"
+export_project_from_redcap $MSK_HEMEPACT_DATA_HOME hemepact_data_clinical_ddp_demographics
+if [ $? -gt 0 ] ; then
+    echo "ERROR: HEMEPACT Redcap export of hemepact_data_clinical_ddp_demographics"
+fi
+
+echo "exporting heme data_clinical.txt from redcap"
+export_project_from_redcap $MSK_HEMEPACT_DATA_HOME hemepact_data_clinical
+if [ $? -gt 0 ] ; then
+    echo "ERROR: HEMEPACT Redcap export of hemepact_data_clinical_cvr"
+fi
+
+printTimeStampedDataProcessingStepMessage "DDP demographics fetch for hemepact"
+mskimpact_heme_dmp_pids_file=$MSK_HEMEPACT_DATA_HOME/mskimpact_heme_patient_list.txt
+awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt | sort | uniq > $mskimpact_heme_dmp_pids_file
+HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical_ddp_demographics.txt)
+if [ $HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT ] ; then
+    HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT
+fi
+
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskimpact_heme -p $mskimpact_heme_dmp_pids_file -s $MSK_HEMEPACT_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_HEMEPACT_DATA_HOME -r $HEMEPACT_DDP_DEMOGRAPHICS_RECORD_COUNT
+if [ $? -gt 0 ] ; then
+    cd $DMP_DATA_HOME ; $GIT_BINARY reset HEAD --hard
+    sendPreImportFailureMessageMskPipelineLogsSlack "HEMEPACT DDP Demographics Fetch"
+fi
+
+# --------------------------------------------------------------------------------------------------------------
+# ACCESS DDP Fetch
+
+echo "exporting access data_clinical_mskaccess_data_clinical_ddp_demographics.txt from redcap"
+export_project_from_redcap $MSK_ACCESS_DATA_HOME mskaccess_data_clinical_ddp_demographics
+if [ $? -gt 0 ] ; then
+    echo "ERROR: ACCESS Redcap export of mskaccess_data_clinical_ddp_demographics"
+fi
+
+echo "exporting access data_clinical.txt from redcap"
+export_project_from_redcap $MSK_ACCESS_DATA_HOME mskaccess_data_clinical
+if [ $? -gt 0 ] ; then
+    echo "ERROR: ACCESS Redcap export of mskaccess_data_clinical_cvr"
+fi
+
+printTimeStampedDataProcessingStepMessage "DDP demographics fetch for access"
+mskaccess_dmp_pids_file=$MSK_ACCESS_DATA_HOME/mskaccess_patient_list.txt
+awk -F'\t' 'NR==1 { for (i=1; i<=NF; i++) { f[$i] = i } }{ if ($f["PATIENT_ID"] != "PATIENT_ID") { print $(f["PATIENT_ID"]) } }' $MSK_ACCESS_DATA_HOME/data_clinical_mskaccess_data_clinical.txt | sort | uniq > $mskaccess_dmp_pids_file
+ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT=$(wc -l < $MSK_ACCESS_DATA_HOME/data_clinical_mskaccess_data_clinical_ddp_demographics.txt)
+if [ $ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT -le $DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT ] ; then
+    ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT=$DEFAULT_DDP_DEMOGRAPHICS_ROW_COUNT
+fi
+
+$JAVA_BINARY $JAVA_DDP_FETCHER_ARGS -c mskaccess -p $mskaccess_dmp_pids_file -s $MSK_ACCESS_DATA_HOME/cvr/seq_date.txt -f ageAtSeqDate -o $MSK_ACCESS_DATA_HOME -r $ACCESS_DDP_DEMOGRAPHICS_RECORD_COUNT
+if [ $? -gt 0 ] ; then
+    cd $DMP_DATA_HOME ; $GIT_BINARY reset HEAD --hard
+    sendPreImportFailureMessageMskPipelineLogsSlack "ACCESS DDP Demographics Fetch"
+fi
+
+# --------------------------------------------------------------------------------------------------------------
+# Combine age at seq files and merge into clinical sample file
+
+AGE_AT_SEQ_FILENAME="data_clinical_ddp_age_at_seq.txt"
+MSK_ACCESS_AGE_AT_SEQ="$MSK_ACCESS_DATA_HOME/$AGE_AT_SEQ_FILENAME"
+MSK_HEMEPACT_AGE_AT_SEQ="$MSK_HEMEPACT_DATA_HOME/$AGE_AT_SEQ_FILENAME"
+MSK_IMPACT_AGE_AT_SEQ="$MSK_IMPACT_DATA_HOME/$AGE_AT_SEQ_FILENAME"
+MERGED_SEQ_DATE="./merged_age_at_seq.txt"
+
+SAMPLE_INPUT_FILEPATH="$MSK_SOLID_HEME_DATA_HOME/data_clinical_sample.txt"
+SAMPLE_OUTPUT_FILEPATH="$./data_clinical_sample.txt"
+KEY_COLUMNS="SAMPLE_ID PATIENT_ID"
+
+$PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$MSK_ACCESS_AGE_AT_SEQ" "$MSK_HEMEPACT_AGE_AT_SEQ" "$MSK_IMPACT_AGE_AT_SEQ" -o "$MERGED_AGE_AT_SEQ" -m outer &&
+$PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$SAMPLE_INPUT_FILEPATH" "$MERGED_AGE_AT_SEQ" -o "$SAMPLE_OUTPUT_FILEPATH" -c $KEY_COLUMNS -m left


### PR DESCRIPTION
Adds temporary script to generate `age_at_sequencing_reported_years` attribute (removed during MSK-CHORD rollout).  The attribute is needed for genie deliveries.

Need to discuss and implement long-term solution for attribute source