### PR TITLE
Do not assume consent status has changed if germline fetch fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ target
 **/src/main/resources/naaccr*.json
 **/repository.sqlite
 **/dependency-reduced-pom.xml
+.idea/
+.vscode/


### PR DESCRIPTION
Recently, the germline server at `draco.mskcc.org` has been returning an empty response for the consent values. This causes us to assume that all germline samples have been unconsented and remove them from the `mskimpact` mutations file, leading to https://github.com/knowledgesystems/pipelines-scrum/issues/1246.

This PR fixes that behavior by exiting early if no consent values are found.

/cc @averyniceday @callachennault 