### PR TITLE
Determine how many lines to skip at beginning of file

### DIFF
--- a/import-scripts/combine_files_py3.py
+++ b/import-scripts/combine_files_py3.py
@@ -41,13 +41,22 @@ def write_tsv(df, path, **opts):
 def combine_files(input_files, output_file, sep="\t", columns=None, merge_type="inner"):
     data_frames = []
     for file in input_files:
+        # Determine which line to start reading from
+        start_read = 0
+        with open(file, "r") as f:
+            # Assumes that commented lines are at the start of the file
+            for line_count, line in enumerate(f):
+                if not line.startswith("#"):
+                    start_read = line_count
+                    break
+
         df = pd.read_table(
             file,
             sep=sep,
-            comment="#",
             float_precision="round_trip",
             na_filter=False,
             low_memory=False,
+            skiprows=start_read
         )
         data_frames.append(df)
 


### PR DESCRIPTION
This PR fixes a bug in the `combine_files_py3.py` script. Previously, the script passed the argument `comment='#'` to the `pd.read_table()` function, intending to ignore commented lines beginning with a '#'. This caused an unintended bug where any string values in the table were truncated after '#' character if present. This PR removes the `comment='#'` argument and programmatically determines which comment lines at the beginning of a file to skip.