### PR TITLE
Fix CVR Requeue step-- Java 21 serialization

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
@@ -68,6 +68,8 @@ import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.job.flow.*;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.support.SimpleJobLauncher;
+import org.springframework.batch.core.repository.dao.Jackson2ExecutionContextStringSerializer;
+import org.springframework.batch.core.repository.ExecutionContextSerializer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.batch.core.step.builder.StepBuilder;

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/BatchConfiguration.java
@@ -88,6 +88,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  */
 @Configuration
 @ComponentScan(basePackages = {"org.cbioportal.annotator", "org.mskcc.cmo.messaging", "org.mskcc.cmo.common.*"})
+@EnableBatchProcessing(executionContextSerializerRef = "jacksonSerializer")
 public class BatchConfiguration {
     public static final String CVR_JOB = "cvrJob";
     public static final String JSON_JOB = "jsonJob";
@@ -885,4 +886,8 @@ public class BatchConfiguration {
         return jobLauncher;
     }
 
+    @Bean
+    public ExecutionContextSerializer jacksonSerializer() {
+        return new Jackson2ExecutionContextStringSerializer();
+    }
 }


### PR DESCRIPTION
## Issue

Pre-import errors from the CVR fetcher

## Cause

During the migration to Java 21, we also migrated to Spring Batch 5. The [default serialization behavior for ExecutionContexts](https://docs.spring.io/spring-batch/docs/5.0.4/reference/html/whatsnew.html#execution-context-serialization-updates) was changed in this version, and the new serializer was not able to handle some of the model classes we were using. This resulted in a `NotSerializableException` being thrown during the CVR requeue step when there were samples that failed to requeue.

## Solution

This PR changes the Spring configuration to use the `JacksonExecutionContextStringSerializer`, which behaves the same as the pre-Spring Batch 5 serializer and avoids this error.

/cc @averyniceday @sheridancbio @mandawilson 