### PR TITLE
Fix logic bug in CVR seq date backfill

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/clinical/CVRClinicalDataReader.java
@@ -94,10 +94,12 @@ public class CVRClinicalDataReader implements ItemStreamReader<CVRClinicalRecord
             throw new RuntimeException(message);
         }
         processClinicalFile(ec);
-        processJsonFile();
         if (CVRUtilities.SUPPORTED_SEQ_DATE_STUDY_IDS.contains(studyId)) {
             processSeqDateFile(ec);
         }
+        // It's important that we process the JSON file *after* backfilling the sequencing date.
+        // Otherwise, the old SEQ_DATE value from the clinical file will overwrite the value from the CVR queue.
+        processJsonFile();
         // updates portalSamplesNotInDmpList and dmpSamplesNotInPortal sample lists
         // portalSamples list is only updated if threshold check for max num samples to remove passes
         cvrSampleListUtil.updateSampleLists(masterListDoesNotExcludeSamples);


### PR DESCRIPTION
## Problem

CVR seq date file had blank seq dates for some samples. This was occurring with samples from the AZ / Sophia cohorts.

## Cause

Once a sample was in the CVR clinical sample file, its seq date would never get updated even if it was pulled again from the queue. This is because even though the queue contains the correct date, the value would get overwritten by a subsequent call to `processSeqDateFile` which backfills the old value from `seq_date.txt`.

## Solution

This PR updates the code so that the JSON seq date is pulled after the existing one. This way, the value is only backfilled for pre-existing samples that do not have an incoming update from the CVR queue.

/cc @averyniceday @callachennault @sheridancbio 