### PR TITLE
Use Airflow REST API to trigger s3 pull DAG

### DIFF
--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -794,7 +794,9 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     #--------------------------------------------------------------
     # CDM Fetch is optional -- does not break import if it fails, but will send notif
 
+    # Generate and upload data_clinical_sample.txt to S3 bucket for CDM use
     sh $PORTAL_HOME/scripts/update-cdm-deliverable.sh
+
     echo "fetching clinical demographics & timeline updates from S3..."
     sh $PORTAL_HOME/scripts/pull-cdm-data.sh
 

--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -64,11 +64,12 @@ AIRFLOW_CREDS=$(cat $AIRFLOW_ADMIN_CREDENTIALS_FILE)
 AIRFLOW_CERT=$PORTAL_HOME/pipelines-credentials/airflow-dev-cert.pem
 DAG_ID="cdm_etl_cbioportal_s3_pull"
 AIRFLOW_URL="https://airflow.cbioportal.dev.aws.mskcc.org"
+API_ENDPOINT="${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns"
 TMP_LOG_FILE="$PORTAL_HOME/tmp/trigger_s3_dag.log"
 
 # Trigger CDM DAG to pull updated data_clinical_sample.txt from S3
 # This DAG will kick off the rest of the CDM pipeline when it completes
-HTTP_STATUS_CODE=$(curl -X POST --write-out "%{http_code}" --silent --output $TMP_LOG_FILE --header "Authorization: Basic ${AIRFLOW_CREDS}" --header "Content-Type: application/json" --cacert $AIRFLOW_CERT --data "{}" "${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns")
+HTTP_STATUS_CODE=$(curl -X POST --write-out "%{http_code}" --silent --output $TMP_LOG_FILE --header "Authorization: Basic ${AIRFLOW_CREDS}" --header "Content-Type: application/json" --cacert $AIRFLOW_CERT --data "{}" $API_ENDPOINT)
 if [ $HTTP_STATUS_CODE -ne 200 ] ; then
   # Send alert for HTTP status code if not 200
   echo "`date`: Failed attempt to trigger DAG ${DAG_ID} on Airflow server ${AIRFLOW_URL}. HTTP status code = ${HTTP_STATUS_CODE}, exiting..."

--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -58,3 +58,16 @@ rm $TMP_MERGED_SEQ_DATE
 rm $CDM_DELIVERABLE
 
 echo "`date`: CDM deliverable generation and upload complete"
+
+AIRFLOW_ADMIN_CREDENTIALS_FILE=$PORTAL_HOME/pipelines-credentials/airflow-admin.credentials
+AIRFLOW_CREDS=$(cat $AIRFLOW_ADMIN_CREDENTIALS_FILE)
+AIRFLOW_CERT=$PORTAL_HOME/pipelines-credentials/airflow-dev-cert.pem
+DAG_ID="cdm_etl_cbioportal_s3_pull"
+AIRFLOW_URL="https://airflow.cbioportal.dev.aws.mskcc.org"
+
+# Trigger CDM DAG to pull updated data_clinical_sample.txt from S3
+# This DAG will kick off the rest of the CDM pipeline when it completes
+curl -X POST --header "Authorization: Basic ${AIRFLOW_CREDS}" --header "Content-Type: application/json" --cacert $AIRFLOW_CERT --data "{}" "${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns"
+if [ $? -ne 0 ] ; then
+  echo "`date`: Failed to trigger DAG ${DAG_ID} on ${AIRFLOW_URL}, exiting..."
+fi

--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -2,6 +2,11 @@
 
 DELIVERED_SAMPLE_ATTRIBUTES="SAMPLE_ID PATIENT_ID CANCER_TYPE CANCER_TYPE_DETAILED"
 
+if ! [ -n "$PORTAL_HOME" ] ; then
+    echo "Error : update-cdm-deliverable.sh cannot be run without setting the PORTAL_HOME environment variable."
+    exit 1
+fi
+
 if [ ! -f $PORTAL_HOME/scripts/automation-environment.sh ] || [ ! -f $PORTAL_HOME/scripts/filter-clinical-arg-functions.sh ] ; then
   echo "`date`: Unable to locate automation_env and additional modules, exiting..."
   exit 1
@@ -59,13 +64,13 @@ rm $CDM_DELIVERABLE
 
 echo "`date`: CDM deliverable generation and upload complete"
 
+TMP_LOG_FILE="${PORTAL_HOME}/tmp/trigger_s3_dag.log"
 AIRFLOW_ADMIN_CREDENTIALS_FILE="${PORTAL_HOME}/pipelines-credentials/airflow-admin.credentials"
 AIRFLOW_CREDS=$(cat $AIRFLOW_ADMIN_CREDENTIALS_FILE)
 AIRFLOW_CERT="${PORTAL_HOME}/pipelines-credentials/airflow-dev-cert.pem"
-DAG_ID="cdm_etl_cbioportal_s3_pull"
 AIRFLOW_URL="https://airflow.cbioportal.dev.aws.mskcc.org"
+DAG_ID="cdm_etl_cbioportal_s3_pull"
 API_ENDPOINT="${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns"
-TMP_LOG_FILE="${PORTAL_HOME}/tmp/trigger_s3_dag.log"
 
 # Trigger CDM DAG to pull updated data_clinical_sample.txt from S3
 # This DAG will kick off the rest of the CDM pipeline when it completes

--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -3,8 +3,8 @@
 DELIVERED_SAMPLE_ATTRIBUTES="SAMPLE_ID PATIENT_ID CANCER_TYPE CANCER_TYPE_DETAILED"
 
 if ! [ -n "$PORTAL_HOME" ] ; then
-    echo "Error : update-cdm-deliverable.sh cannot be run without setting the PORTAL_HOME environment variable."
-    exit 1
+  echo "Error : update-cdm-deliverable.sh cannot be run without setting the PORTAL_HOME environment variable."
+  exit 1
 fi
 
 if [ ! -f $PORTAL_HOME/scripts/automation-environment.sh ] || [ ! -f $PORTAL_HOME/scripts/filter-clinical-arg-functions.sh ] ; then

--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -68,7 +68,7 @@ TMP_LOG_FILE="$PORTAL_HOME/tmp/trigger_s3_dag.log"
 
 # Trigger CDM DAG to pull updated data_clinical_sample.txt from S3
 # This DAG will kick off the rest of the CDM pipeline when it completes
-HTTP_STATUS_CODE=$(curl -X POST --write-out "%{http_code}" --silent --output FILE?? --header "Authorization: Basic ${AIRFLOW_CREDS}" --header "Content-Type: application/json" --cacert $AIRFLOW_CERT --data "{}" "${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns")
+HTTP_STATUS_CODE=$(curl -X POST --write-out "%{http_code}" --silent --output $TMP_LOG_FILE --header "Authorization: Basic ${AIRFLOW_CREDS}" --header "Content-Type: application/json" --cacert $AIRFLOW_CERT --data "{}" "${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns")
 if [ $HTTP_STATUS_CODE -ne 200 ] ; then
   # Send alert for HTTP status code if not 200
   echo "`date`: Failed attempt to trigger DAG ${DAG_ID} on Airflow server ${AIRFLOW_URL}. HTTP status code = ${HTTP_STATUS_CODE}, exiting..."

--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -26,6 +26,14 @@ MSK_ACCESS_SEQ_DATE="$MSK_ACCESS_DATA_HOME/$SEQ_DATE_FILENAME"
 MSK_HEMEPACT_SEQ_DATE="$MSK_HEMEPACT_DATA_HOME/$SEQ_DATE_FILENAME"
 MSK_IMPACT_SEQ_DATE="$MSK_IMPACT_DATA_HOME/$SEQ_DATE_FILENAME"
 
+TMP_LOG_FILE="${PORTAL_HOME}/tmp/trigger_s3_dag.log"
+AIRFLOW_ADMIN_CREDENTIALS_FILE="${PORTAL_HOME}/pipelines-credentials/airflow-admin.credentials"
+AIRFLOW_CREDS=$(cat $AIRFLOW_ADMIN_CREDENTIALS_FILE)
+AIRFLOW_CERT="${PORTAL_HOME}/pipelines-credentials/airflow-dev-cert.pem"
+AIRFLOW_URL="https://airflow.cbioportal.dev.aws.mskcc.org"
+DAG_ID="cdm_etl_cbioportal_s3_pull"
+AIRFLOW_API_ENDPOINT="${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns"
+
 if [ ! -f $MSK_SOLID_HEME_CLINICAL_FILE ] || [ ! -f $MSK_ACCESS_SEQ_DATE ] || [ ! -f $MSK_HEMEPACT_SEQ_DATE ] || [ ! -f $MSK_IMPACTSEQ_DATE ] ; then
   echo "`date`: Unable to locate required files, exiting..."
 fi
@@ -62,22 +70,16 @@ rm $TMP_SAMPLE_FILE
 rm $TMP_MERGED_SEQ_DATE
 rm $CDM_DELIVERABLE
 
-echo "`date`: CDM deliverable generation and upload complete"
-
-TMP_LOG_FILE="${PORTAL_HOME}/tmp/trigger_s3_dag.log"
-AIRFLOW_ADMIN_CREDENTIALS_FILE="${PORTAL_HOME}/pipelines-credentials/airflow-admin.credentials"
-AIRFLOW_CREDS=$(cat $AIRFLOW_ADMIN_CREDENTIALS_FILE)
-AIRFLOW_CERT="${PORTAL_HOME}/pipelines-credentials/airflow-dev-cert.pem"
-AIRFLOW_URL="https://airflow.cbioportal.dev.aws.mskcc.org"
-DAG_ID="cdm_etl_cbioportal_s3_pull"
-API_ENDPOINT="${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns"
-
 # Trigger CDM DAG to pull updated data_clinical_sample.txt from S3
 # This DAG will kick off the rest of the CDM pipeline when it completes
-HTTP_STATUS_CODE=$(curl -X POST --write-out "%{http_code}" --silent --output $TMP_LOG_FILE --header "Authorization: Basic ${AIRFLOW_CREDS}" --header "Content-Type: application/json" --cacert $AIRFLOW_CERT --data "{}" $API_ENDPOINT)
+HTTP_STATUS_CODE=$(curl -X POST --write-out "%{http_code}" --silent --output $TMP_LOG_FILE --header "Authorization: Basic ${AIRFLOW_CREDS}" --header "Content-Type: application/json" --cacert $AIRFLOW_CERT --data "{}" $AIRFLOW_API_ENDPOINT)
 if [ $HTTP_STATUS_CODE -ne 200 ] ; then
   # Send alert for HTTP status code if not 200
   echo "`date`: Failed attempt to trigger DAG ${DAG_ID} on Airflow server ${AIRFLOW_URL}. HTTP status code = ${HTTP_STATUS_CODE}, exiting..."
+  # Write out failed HTTP response contents and exit with error
   cat $TMP_LOG_FILE
+  rm $TMP_LOG_FILE
   exit 1
 fi
+
+echo "`date`: CDM deliverable generation and upload complete"

--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -59,13 +59,13 @@ rm $CDM_DELIVERABLE
 
 echo "`date`: CDM deliverable generation and upload complete"
 
-AIRFLOW_ADMIN_CREDENTIALS_FILE=$PORTAL_HOME/pipelines-credentials/airflow-admin.credentials
+AIRFLOW_ADMIN_CREDENTIALS_FILE="${PORTAL_HOME}/pipelines-credentials/airflow-admin.credentials"
 AIRFLOW_CREDS=$(cat $AIRFLOW_ADMIN_CREDENTIALS_FILE)
-AIRFLOW_CERT=$PORTAL_HOME/pipelines-credentials/airflow-dev-cert.pem
+AIRFLOW_CERT="${PORTAL_HOME}/pipelines-credentials/airflow-dev-cert.pem"
 DAG_ID="cdm_etl_cbioportal_s3_pull"
 AIRFLOW_URL="https://airflow.cbioportal.dev.aws.mskcc.org"
 API_ENDPOINT="${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns"
-TMP_LOG_FILE="$PORTAL_HOME/tmp/trigger_s3_dag.log"
+TMP_LOG_FILE="${PORTAL_HOME}/tmp/trigger_s3_dag.log"
 
 # Trigger CDM DAG to pull updated data_clinical_sample.txt from S3
 # This DAG will kick off the rest of the CDM pipeline when it completes


### PR DESCRIPTION
This PR:

- Uses Airflow [REST API endpoint](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/post_dag_run) to trigger a DAG run of the cdm_etl_cbioportal_s3_pull DAG after the sample list has been uploaded to S3 by the cBioPortal ETL.