### PR TITLE
Cdm merge bugfix

### DIFF
--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -53,7 +53,7 @@ fi
 $PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$MSK_ACCESS_SEQ_DATE" "$MSK_HEMEPACT_SEQ_DATE" "$MSK_IMPACT_SEQ_DATE" -o "$TMP_MERGED_SEQ_DATE" -m outer
 
 # Combines filtered clinical sample file with seq data file and outputs to tmp file for upload
-# Uses left join -- SAMPLE_ID in the clinical_sample_file (first arg) will be valid keys
+# Uses left join -- SAMPLE_ID and PATIENT_ID in the clinical_sample_file (first arg) will be valid keys
 $PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$TMP_SAMPLE_FILE" "$TMP_MERGED_SEQ_DATE" -o "$CDM_DELIVERABLE" -c SAMPLE_ID PATIENT_ID -m left
 if [ $? -ne 0 ] ; then
   echo "`date`: Failed to combine files, exiting..."

--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -54,7 +54,7 @@ $PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$MSK_ACCESS_SEQ_DA
 
 # Combines filtered clinical sample file with seq data file and outputs to tmp file for upload
 # Uses left join -- SAMPLE_ID in the clinical_sample_file (first arg) will be valid keys
-$PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$TMP_SAMPLE_FILE" "$TMP_MERGED_SEQ_DATE" -o "$CDM_DELIVERABLE" -c SAMPLE_ID -m left
+$PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$TMP_SAMPLE_FILE" "$TMP_MERGED_SEQ_DATE" -o "$CDM_DELIVERABLE" -c SAMPLE_ID PATIENT_ID -m left
 if [ $? -ne 0 ] ; then
   echo "`date`: Failed to combine files, exiting..."
   exit 1

--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -34,8 +34,9 @@ AIRFLOW_URL="https://airflow.cbioportal.dev.aws.mskcc.org"
 DAG_ID="cdm_etl_cbioportal_s3_pull"
 AIRFLOW_API_ENDPOINT="${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns"
 
-if [ ! -f $MSK_SOLID_HEME_CLINICAL_FILE ] || [ ! -f $MSK_ACCESS_SEQ_DATE ] || [ ! -f $MSK_HEMEPACT_SEQ_DATE ] || [ ! -f $MSK_IMPACTSEQ_DATE ] ; then
+if [ ! -f $MSK_SOLID_HEME_CLINICAL_FILE ] || [ ! -f $MSK_ACCESS_SEQ_DATE ] || [ ! -f $MSK_HEMEPACT_SEQ_DATE ] || [ ! -f $MSK_IMPACT_SEQ_DATE ] ; then
   echo "`date`: Unable to locate required files, exiting..."
+  exit 1
 fi
 
 # Copy sample file to tmp file since script overwrites existing file (don't want to overwrite DMP pipeline files)


### PR DESCRIPTION
This PR:

- Fixes typo with `MSK_IMPACT_SEQ_DATE` variable
- Fixes bug with CDM merge code that was producing `PATIENT_ID_x` and `PATIENT_ID_y` columns. The solution was to use `PATIENT_ID` as an additional merge column. When it is not specified as a merge column, Pandas recognizes that the column is common to both dataframes and must specify the source by appending `_x` and `_y` to the column name. Note that the merge will default to the intersection of columns in both dataframes if no merge columns are specified.