### PR TITLE
Change airflow API url to prod server and remove unneeded cert

### DIFF
--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -29,8 +29,7 @@ MSK_IMPACT_SEQ_DATE="$MSK_IMPACT_DATA_HOME/$SEQ_DATE_FILENAME"
 TMP_LOG_FILE="${PORTAL_HOME}/tmp/trigger_s3_dag.log"
 AIRFLOW_ADMIN_CREDENTIALS_FILE="${PORTAL_HOME}/pipelines-credentials/airflow-admin.credentials"
 AIRFLOW_CREDS=$(cat $AIRFLOW_ADMIN_CREDENTIALS_FILE)
-AIRFLOW_CERT="${PORTAL_HOME}/pipelines-credentials/airflow-dev-cert.pem"
-AIRFLOW_URL="https://airflow.cbioportal.dev.aws.mskcc.org"
+AIRFLOW_URL="https://airflow.cbioportal.aws.mskcc.org"
 DAG_ID="cdm_etl_cbioportal_s3_pull"
 AIRFLOW_API_ENDPOINT="${AIRFLOW_URL}/api/v1/dags/${DAG_ID}/dagRuns"
 
@@ -73,7 +72,7 @@ rm $CDM_DELIVERABLE
 
 # Trigger CDM DAG to pull updated data_clinical_sample.txt from S3
 # This DAG will kick off the rest of the CDM pipeline when it completes
-HTTP_STATUS_CODE=$(curl -X POST --write-out "%{http_code}" --silent --output $TMP_LOG_FILE --header "Authorization: Basic ${AIRFLOW_CREDS}" --header "Content-Type: application/json" --cacert $AIRFLOW_CERT --data "{}" $AIRFLOW_API_ENDPOINT)
+HTTP_STATUS_CODE=$(curl -X POST --write-out "%{http_code}" --silent --output $TMP_LOG_FILE --header "Authorization: Basic ${AIRFLOW_CREDS}" --header "Content-Type: application/json" --data "{}" $AIRFLOW_API_ENDPOINT)
 if [ $HTTP_STATUS_CODE -ne 200 ] ; then
   # Send alert for HTTP status code if not 200
   echo "`date`: Failed attempt to trigger DAG ${DAG_ID} on Airflow server ${AIRFLOW_URL}. HTTP status code = ${HTTP_STATUS_CODE}, exiting..."


### PR DESCRIPTION
This PR:
- Changes `AIRFLOW_URL` to point to prod Airflow server
- Removes  `AIRFLOW_CERT` (only needed for dev Airflow server)