### PR TITLE
Modify subset-impact-data to include or exclude msk-chord elements based on flag

### DIFF
--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -878,7 +878,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     # subset the mixedpact study for Queens Cancer Center, Lehigh Valley, Kings County Cancer Center, Miami Cancer Institute, and Hartford Health Care
 
     # KINGSCOUNTY subset
-    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_kingscounty -o=$MSK_KINGS_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Kings County Cancer Center" -s=$MSK_DMP_TMPDIR/kings_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
+    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_kingscounty -o=$MSK_KINGS_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Kings County Cancer Center" -s=$MSK_DMP_TMPDIR/kings_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt --include-msk-chord-data
     if [ $? -gt 0 ] ; then
         echo "MSK Kings County subset failed! Study will not be updated in the portal."
         MSK_KINGS_SUBSET_FAIL=1
@@ -906,7 +906,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     fi
 
     # LEHIGHVALLEY subset
-    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_lehighvalley -o=$MSK_LEHIGH_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Lehigh Valley Health Network" -s=$MSK_DMP_TMPDIR/lehigh_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
+    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_lehighvalley -o=$MSK_LEHIGH_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Lehigh Valley Health Network" -s=$MSK_DMP_TMPDIR/lehigh_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt --include-msk-chord-data
     if [ $? -gt 0 ] ; then
         echo "MSK Lehigh Valley subset failed! Study will not be updated in the portal."
         MSK_LEHIGH_SUBSET_FAIL=1
@@ -934,7 +934,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     fi
 
     # QUEENSCANCERCENTER subset
-    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_queenscancercenter -o=$MSK_QUEENS_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Queens Cancer Center,Queens Hospital Cancer Center" -s=$MSK_DMP_TMPDIR/queens_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
+    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_queenscancercenter -o=$MSK_QUEENS_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Queens Cancer Center,Queens Hospital Cancer Center" -s=$MSK_DMP_TMPDIR/queens_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt --include-msk-chord-data
     if [ $? -gt 0 ] ; then
         echo "MSK Queens Cancer Center subset failed! Study will not be updated in the portal."
         MSK_QUEENS_SUBSET_FAIL=1
@@ -962,7 +962,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     fi
 
     # MIAMICANCERINSTITUTE subset
-    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_miamicancerinstitute -o=$MSK_MCI_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Miami Cancer Institute" -s=$MSK_DMP_TMPDIR/mci_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
+    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_miamicancerinstitute -o=$MSK_MCI_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Miami Cancer Institute" -s=$MSK_DMP_TMPDIR/mci_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt --include-msk-chord-data
     if [ $? -gt 0 ] ; then
         echo "MSK Miami Cancer Institute subset failed! Study will not be updated in the portal."
         MSK_MCI_SUBSET_FAIL=1
@@ -990,7 +990,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     fi
 
     # HARTFORDHEALTHCARE subset
-    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_hartfordhealthcare -o=$MSK_HARTFORD_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Hartford Healthcare" -s=$MSK_DMP_TMPDIR/hartford_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
+    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_hartfordhealthcare -o=$MSK_HARTFORD_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Hartford Healthcare" -s=$MSK_DMP_TMPDIR/hartford_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt --include-msk-chord-data
     if [ $? -gt 0 ] ; then
         echo "MSK Hartford Healthcare subset failed! Study will not be updated in the portal."
         MSK_HARTFORD_SUBSET_FAIL=1
@@ -1018,7 +1018,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     fi
 
     # RALPHLAUREN subset
-    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_ralphlauren -o=$MSK_RALPHLAUREN_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Ralph Lauren Center" -s=$MSK_DMP_TMPDIR/ralphlauren_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
+    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_ralphlauren -o=$MSK_RALPHLAUREN_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Ralph Lauren Center" -s=$MSK_DMP_TMPDIR/ralphlauren_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt --include-msk-chord-data
     if [ $? -gt 0 ] ; then
         echo "MSK Ralph Lauren subset failed! Study will not be updated in the portal."
         MSK_RALPHLAUREN_SUBSET_FAIL=1
@@ -1046,7 +1046,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     fi
 
     # RIKENGENESISJAPAN subset
-    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_rikengenesisjapan -o=$MSK_RIKENGENESISJAPAN_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Riken Genesis" -s=$MSK_DMP_TMPDIR/rikengenesisjapan_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt
+    bash $PORTAL_HOME/scripts/subset-impact-data.sh -i=msk_rikengenesisjapan -o=$MSK_RIKENGENESISJAPAN_DATA_HOME -d=$MSK_MIXEDPACT_DATA_HOME -f="INSTITUTE=Riken Genesis" -s=$MSK_DMP_TMPDIR/rikengenesisjapan_subset.txt -c=$MSK_MIXEDPACT_DATA_HOME/data_clinical_sample.txt --include-msk-chord-data
     if [ $? -gt 0 ] ; then
         echo "MSK Tailor Med Japan subset failed! Study will not be updated in the portal."
         MSK_RIKENGENESISJAPAN_SUBSET_FAIL=1

--- a/import-scripts/filter-clinical-arg-functions.sh
+++ b/import-scripts/filter-clinical-arg-functions.sh
@@ -87,24 +87,48 @@ function find_clinical_attributes_to_filter_arg() {
 
 function filter_clinical_attribute_columns() {
     # Path to clinical file taken as an argument
-    clinical_attribute_filepath="$1"
+    clinical_filepath="$1"
 
     # Attributes to deliver in the clinical file
     attributes_to_deliver="$2"
 
-    # Path to output clinical file taken as an argument
-    output_filepath="$3"
+    # Temporary output file, removed at end of function
+    tmp_processing_file=$(mktemp -q)
 
     # Determine which columns to exclude in the patient file
-    if ! find_clinical_attributes_to_filter_arg "$clinical_attribute_filepath" "$attributes_to_deliver" ; then
+    if ! find_clinical_attributes_to_filter_arg "$clinical_filepath" "$attributes_to_deliver" ; then
         return 1
     fi
-    EXCLUDED_HEADER_FIELD_LIST="$clinical_attributes_to_filter_arg"
+    excluded_header_field_list="$clinical_attributes_to_filter_arg"
 
     # Filter out the columns we want to exclude
-    $PYTHON_BINARY $PORTAL_HOME/scripts/filter_clinical_data.py -c "$clinical_attribute_filepath" -e "$EXCLUDED_HEADER_FIELD_LIST" > "$output_filepath"
+    $PYTHON_BINARY $PORTAL_HOME/scripts/filter_clinical_data.py -c "$clinical_filepath" -e "$excluded_header_field_list" > "$tmp_processing_file"
     if [ $? -gt 0 ] ; then
         return 1
     fi
-    mv "$output_filepath" "$clinical_attribute_filepath"
+    mv "$tmp_processing_file" "$clinical_filepath"
+}
+
+function filter_cdm_clinical_elements() {
+    # Removes CDM elements from a given study
+    # Path to study directory
+    study_dir="$1"
+    patient_input_filepath="$study_dir/data_clinical_patient.txt"
+    sample_input_filepath="$study_dir/data_clinical_sample.txt"
+
+    # Clinical elements to maintain
+    patient_attributes="PATIENT_ID GENDER RACE ETHNICITY CURRENT_AGE_DEID OS_MONTHS OS_STATUS OTHER_PATIENT_ID PARTA_CONSENTED_12_245 PARTC_CONSENTED_12_245"
+    sample_attributes="SAMPLE_ID PATIENT_ID MONTH_ADDED WEEK_ADDED CANCER_TYPE SAMPLE_TYPE SAMPLE_CLASS METASTATIC_SITE PRIMARY_SITE CANCER_TYPE_DETAILED GENE_PANEL SO_COMMENTS SAMPLE_COVERAGE TUMOR_PURITY ONCOTREE_CODE MSI_COMMENT MSI_SCORE MSI_TYPE INSTITUTE SOMATIC_STATUS ARCHER CVR_TMB_COHORT_PERCENTILE CVR_TMB_SCORE CVR_TMB_TT_COHORT_PERCENTILE PATH_SLIDE_EXISTS MSK_SLIDE_ID CYCLE_THRESHOLD"
+
+    # Filter columns from patient file
+    if ! filter_clinical_attribute_columns "$patient_input_filepath" "$patient_attributes" ; then
+        echo "Failed to filter clinical patient attributes"
+        return 1
+    fi
+
+    # Filter columns from sample file
+    if ! filter_clinical_attribute_columns "$sample_input_filepath" "$sample_attributes" ; then
+        echo "Failed to filter clinical sample attributes"
+        return 1
+    fi
 }

--- a/import-scripts/filter-clinical-arg-functions.sh
+++ b/import-scripts/filter-clinical-arg-functions.sh
@@ -104,6 +104,7 @@ function filter_clinical_attribute_columns() {
     # Filter out the columns we want to exclude
     $PYTHON_BINARY $PORTAL_HOME/scripts/filter_clinical_data.py -c "$clinical_filepath" -e "$excluded_header_field_list" > "$tmp_processing_file"
     if [ $? -gt 0 ] ; then
+        echo "Failed to filter columns from clinical file $clinical_filepath, see output at $tmp_processing_file"
         return 1
     fi
     mv "$tmp_processing_file" "$clinical_filepath"

--- a/import-scripts/update-az-mskimpact.sh
+++ b/import-scripts/update-az-mskimpact.sh
@@ -117,18 +117,16 @@ function rename_files_in_delivery_directory() {
 }
 
 function filter_clinical_cols() {
-    # Determine which columns to exclude in the patient file
+    # Filter columns from patient file
     PATIENT_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_clinical_patient.txt"
-    PATIENT_OUTPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_clinical_patient.txt.filtered"
-    if ! filter_clinical_attribute_columns "$PATIENT_INPUT_FILEPATH" "$DELIVERED_PATIENT_ATTRIBUTES" "$PATIENT_OUTPUT_FILEPATH" ; then
+    if ! filter_clinical_attribute_columns "$PATIENT_INPUT_FILEPATH" "$DELIVERED_PATIENT_ATTRIBUTES" ; then
         echo "Failed to filter clinical patient attributes"
         return 1
     fi
 
-    # Determine which columns to exclude in the sample file
+    # Filter columns from sample file
     SAMPLE_INPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_clinical_sample.txt"
-    SAMPLE_OUTPUT_FILEPATH="$AZ_MSK_IMPACT_DATA_HOME/data_clinical_sample.txt.filtered"
-    if ! filter_clinical_attribute_columns "$SAMPLE_INPUT_FILEPATH" "$DELIVERED_SAMPLE_ATTRIBUTES" "$SAMPLE_OUTPUT_FILEPATH" ; then
+    if ! filter_clinical_attribute_columns "$SAMPLE_INPUT_FILEPATH" "$DELIVERED_SAMPLE_ATTRIBUTES" ; then
         echo "Failed to filter clinical sample attributes"
         return 1
     fi

--- a/import-scripts/update-cdm-deliverable.sh
+++ b/import-scripts/update-cdm-deliverable.sh
@@ -52,13 +52,11 @@ function set_cohort_filepaths() {
 
 function filter_sample_file() {
     DELIVERED_SAMPLE_ATTRIBUTES="SAMPLE_ID PATIENT_ID CANCER_TYPE CANCER_TYPE_DETAILED"
-    TMP_PROCESSING_FILE=$(mktemp -q)
 
     # Copy sample file to tmp file since script overwrites existing file (don't want to overwrite DMP pipeline files)
     # Removes all clinical attributes except those specified in $DELIVERED_SAMPLE_ATTRIBUTES set
-    # TMP_PROCESSING_FILE automatically removed // TODO: move TMP_FILE creation to filter_clinical function
     cp -a $CLINICAL_SAMPLE_FILEPATH $CDM_DELIVERABLE
-    filter_clinical_attribute_columns "$CDM_DELIVERABLE" "$DELIVERED_SAMPLE_ATTRIBUTES" "$TMP_PROCESSING_FILE"
+    filter_clinical_attribute_columns "$CDM_DELIVERABLE" "$DELIVERED_SAMPLE_ATTRIBUTES"
     if [ $? -ne 0 ] ; then
         echo "`date`: Failed to subset clinical sample file, exiting..."
         exit 1

--- a/import-scripts/update-sophia-mskimpact.sh
+++ b/import-scripts/update-sophia-mskimpact.sh
@@ -155,18 +155,16 @@ function rename_files_in_delivery_directory() {
 }
 
 function filter_clinical_cols() {
-    # Determine which columns to exclude in the patient file
+    # Filter columns from patient file
     PATIENT_INPUT_FILEPATH="$SOPHIA_MSK_IMPACT_DATA_HOME/data_clinical_patient.txt"
-    PATIENT_OUTPUT_FILEPATH="$SOPHIA_MSK_IMPACT_DATA_HOME/data_clinical_patient.txt.filtered"
-    if ! filter_clinical_attribute_columns "$PATIENT_INPUT_FILEPATH" "$DELIVERED_PATIENT_ATTRIBUTES" "$PATIENT_OUTPUT_FILEPATH" ; then
+    if ! filter_clinical_attribute_columns "$PATIENT_INPUT_FILEPATH" "$DELIVERED_PATIENT_ATTRIBUTES" ; then
         echo "Failed to filter clinical patient attributes"
         return 1
     fi
 
-    # Determine which columns to exclude in the sample file
+    # Filter columns from sample file
     SAMPLE_INPUT_FILEPATH="$SOPHIA_MSK_IMPACT_DATA_HOME/data_clinical_sample.txt"
-    SAMPLE_OUTPUT_FILEPATH="$SOPHIA_MSK_IMPACT_DATA_HOME/data_clinical_sample.txt.filtered"
-    if ! filter_clinical_attribute_columns "$SAMPLE_INPUT_FILEPATH" "$DELIVERED_SAMPLE_ATTRIBUTES" "$SAMPLE_OUTPUT_FILEPATH" ; then
+    if ! filter_clinical_attribute_columns "$SAMPLE_INPUT_FILEPATH" "$DELIVERED_SAMPLE_ATTRIBUTES" ; then
         echo "Failed to filter clinical sample attributes"
         return 1
     fi


### PR DESCRIPTION
Changes in this PR:

- In `filter-clinical-arg-functions.sh`: Update to `filter_clinical_attribute_columns()` function to use a temp processing file. This change is propagated to function calls in `update-az-mskimpact.sh`, `update-sophia-mskimpact.sh`, and `update-cdm-deliverable.sh`
- In `filter-clinical-arg-function.sh`: New function `filter_cdm_clinical_elements()` that will remove CDM clinical patient and sample elements from a given study.
- In `subset-impact-data.sh`: Added flag `--include-msk-chord-data` to indicate whether CDM data should be included in the generated subset. If it should be excluded, `filter_cdm_clinical_elements()` is called to remove CDM clinical elements. If it should be included, CDM timeline files are subsetted via the `subset-cdm-timeline-files.sh` script.
- In `fetch-dmp-data-for-import.sh`: Flag `--include-msk-chord-data` is now passed to `subset-impact-data.sh` calls for appropriate studies (all subset studies except for sclc_mskimpact_2017).