### PR TITLE
use FLUSHDB to clear persistence cache

### DIFF
--- a/import-scripts/clear-persistence-cache-shell-functions.sh
+++ b/import-scripts/clear-persistence-cache-shell-functions.sh
@@ -30,6 +30,7 @@ function clearPersistenceCachesForPortals() {
     return $exit_status
 }
 
+# Cache clearing is organized by database. All portals based on the same (updated) cBioPortal mysql database are cleared
 function clearPersistenceCachesForMskPortals() {
     all_msk_portals="msk msk-beta"
     clearPersistenceCachesForPortals "$all_msk_portals"
@@ -56,8 +57,13 @@ function clearPersistenceCachesForPublicPortals() {
     clearPersistenceCachesForPortals "$all_public_portals"
 }
 
-function clearPersistenceCachesForGeniePortals() {
-    all_genie_portals="genie-public genie-private"
+function clearPersistenceCachesForGenieBluePortals() {
+    all_genie_portals="genie-public-blue genie-private-blue"
+    clearPersistenceCachesForPortals "$all_genie_portals"
+}
+
+function clearPersistenceCachesForGenieGreenPortals() {
+    all_genie_portals="genie-public-green genie-private-green"
     clearPersistenceCachesForPortals "$all_genie_portals"
 }
 

--- a/import-scripts/clear-persistence-caches-for-changed-studies.sh
+++ b/import-scripts/clear-persistence-caches-for-changed-studies.sh
@@ -101,23 +101,18 @@ TMP_DIR_ROOT="/data/portal-cron/tmp/clear-persistence-cache"
 MYSQL_COMMAND_FILE_TO_GET_STUDY_LIST="$TMP_DIR_ROOT/get_study_list_with_info.sql"
 unset PORTAL_DB_LIST
 PORTAL_DB_LIST="public"
-#PORTAL_DB_LIST="public genie-public"
 unset PORTAL_DB_TO_CONFIG_MAP_FILE
 declare -A PORTAL_DB_TO_CONFIG_MAP_FILE
 PORTAL_DB_TO_CONFIG_MAP_FILE["public"]="/data/portal-cron/git-repos/portal-configuration/k8s-config-vars/public/config_map.yaml"
-PORTAL_DB_TO_CONFIG_MAP_FILE["genie-public"]="/data/portal-cron/git-repos/portal-configuration/k8s-config-vars/public/config_map_genie_public.yaml"
 unset PORTAL_DB_TO_PORTAL_API_BASE_URI
 declare -A PORTAL_DB_TO_PORTAL_API_BASE_URI
 PORTAL_DB_TO_PORTAL_API_BASE_URI["public"]="https://www.cbioportal.org/api"
-PORTAL_DB_TO_PORTAL_API_BASE_URI["genie-public"]="https://genie.cbioportal.org/api"
 unset portal_db_to_cache_api_key
 declare -A portal_db_to_cache_api_key
 portal_db_to_cache_api_key["public"]="unknown"
-portal_db_to_cache_api_key["genie-public"]="unknown"
 unset portal_db_to_full_cache_clearing_function
 declare -A portal_db_to_full_cache_clearing_function
 portal_db_to_full_cache_clearing_function["public"]="clearPersistenceCachesForPublicPortals"
-portal_db_to_full_cache_clearing_function["genie-public"]="clearPersistenceCachesForGeniePortals"
 MAXIMUM_TIME_FOR_STUDY_RESET_BEFORE_ESCALATION=480  # 480 seconds (8 minutes)
 CACHE_RESET_NEEDED_FILENAME="CACHE_RESET_NEEDED"
 CACHE_RESET_SUCCEEDED_FILENAME="CACHE_RESET_SUCCEEDED"

--- a/import-scripts/clear_cbioportal_persistence_cache.sh
+++ b/import-scripts/clear_cbioportal_persistence_cache.sh
@@ -14,8 +14,10 @@ CLUSTER_ID_KS="knowledgesystems-kubernetes"
 unset portal_to_cluster_map
 declare -A portal_to_cluster_map
 portal_to_cluster_map["public"]="$CLUSTER_ID_KS"
-portal_to_cluster_map["genie-public"]="$CLUSTER_ID_KS"
-portal_to_cluster_map["genie-private"]="$CLUSTER_ID_KS"
+portal_to_cluster_map["genie-public-blue"]="$CLUSTER_ID_KS"
+portal_to_cluster_map["genie-public-green"]="$CLUSTER_ID_KS"
+portal_to_cluster_map["genie-private-blue"]="$CLUSTER_ID_KS"
+portal_to_cluster_map["genie-private-green"]="$CLUSTER_ID_KS"
 portal_to_cluster_map["crdc"]="$CLUSTER_ID_KS"
 portal_to_cluster_map["triage"]="$CLUSTER_ID_DIGITS"
 portal_to_cluster_map["hgnc"]="$CLUSTER_ID_DIGITS"
@@ -27,8 +29,10 @@ portal_to_cluster_map["sclc"]="$CLUSTER_ID_DIGITS"
 unset portal_to_deployment_map
 declare -A portal_to_deployment_map
 portal_to_deployment_map["public"]="cbioportal-spring-boot"
-portal_to_deployment_map["genie-public"]="cbioportal-backend-genie-public"
-portal_to_deployment_map["genie-private"]="cbioportal-backend-genie-private"
+portal_to_deployment_map["genie-public-blue"]="cbioportal-backend-genie-public-blue"
+portal_to_deployment_map["genie-public-green"]="cbioportal-backend-genie-public-green"
+portal_to_deployment_map["genie-private-blue"]="cbioportal-backend-genie-private-blue"
+portal_to_deployment_map["genie-private-green"]="cbioportal-backend-genie-private-green"
 portal_to_deployment_map["crdc"]="cbioportal-backend-nci"
 portal_to_deployment_map["triage"]="eks-triage"
 portal_to_deployment_map["hgnc"]="eks-hgnc"
@@ -37,24 +41,55 @@ portal_to_deployment_map["msk-beta"]="eks-msk-beta"
 portal_to_deployment_map["private"]="eks-private"
 portal_to_deployment_map["sclc"]="eks-sclc"
 
-unset portal_to_cache_service_list
-declare -A portal_to_cache_service_list
-portal_to_cache_service_list["public"]="cbioportal-public-persistence-redis-master cbioportal-public-persistence-redis-replicas"
-portal_to_cache_service_list["genie-public"]="cbioportal-genie-persistence-redis-master cbioportal-genie-persistence-redis-replicas"
-portal_to_cache_service_list["genie-private"]="cbioportal-genie-persistence-redis-master cbioportal-genie-persistence-redis-replicas"
-portal_to_cache_service_list["crdc"]="cbioportal-genie-persistence-redis-master cbioportal-genie-persistence-redis-replicas"
-portal_to_cache_service_list["triage"]="triage-cbioportal-persistence-redis-master triage-cbioportal-persistence-redis-replicas"
-portal_to_cache_service_list["hgnc"]=""
-portal_to_cache_service_list["msk"]="eks-msk-persistence-redis-master eks-msk-persistence-redis-replicas"
-portal_to_cache_service_list["msk-beta"]="cbioportal-persistence-redis-master cbioportal-persistence-redis-replicas"
-portal_to_cache_service_list["private"]="cbioportal-persistence-redis-master cbioportal-persistence-redis-replicas"
-portal_to_cache_service_list["sclc"]="cbioportal-persistence-redis-master cbioportal-persistence-redis-replicas"
+# TODO : the cache service basename and cache database number could be extracted from the kubernetes deployment and config map
+
+unset portal_to_cache_service_basename
+declare -A portal_to_cache_service_basename
+portal_to_cache_service_basename["public"]="cbioportal-public-persistence-redis"
+portal_to_cache_service_basename["genie-public-blue"]="cbioportal-genie-persistence-redis"
+portal_to_cache_service_basename["genie-public-green"]="cbioportal-genie-persistence-redis"
+portal_to_cache_service_basename["genie-private-blue"]="cbioportal-genie-persistence-redis"
+portal_to_cache_service_basename["genie-private-green"]="cbioportal-genie-persistence-redis"
+portal_to_cache_service_basename["crdc"]="cbioportal-genie-persistence-redis"
+portal_to_cache_service_basename["triage"]="triage-cbioportal-persistence-redis"
+portal_to_cache_service_basename["hgnc"]=""
+portal_to_cache_service_basename["msk"]="eks-msk-cbioportal-persistence-redis"
+portal_to_cache_service_basename["msk-beta"]="eks-msk-cbioportal-persistence-redis"
+portal_to_cache_service_basename["private"]="cbioportal-persistence-redis"
+portal_to_cache_service_basename["sclc"]="cbioportal-persistence-redis"
+
+unset portal_to_cache_database_number
+declare -A portal_to_cache_database_number
+portal_to_cache_database_number["public"]="8"
+portal_to_cache_database_number["genie-public-blue"]="1"
+portal_to_cache_database_number["genie-public-green"]="2"
+portal_to_cache_database_number["genie-private-blue"]="3"
+portal_to_cache_database_number["genie-private-green"]="4"
+portal_to_cache_database_number["crdc"]="7"
+portal_to_cache_database_number["triage"]="1"
+portal_to_cache_database_number["hgnc"]="unassigned"
+portal_to_cache_database_number["msk"]=1
+portal_to_cache_database_number["msk-beta"]=1
+portal_to_cache_database_number["private"]=1
+portal_to_cache_database_number["sclc"]=2
 
 function print_portal_id_values() {
     echo "valid portal ids:"
     for portal in ${!portal_to_deployment_map[@]} ; do
         echo "  $portal"
     done
+}
+
+function database_number_is_valid() {
+    number=$1
+    v=0
+    while [ $v -lt 16 ] ; do
+        if [ "$number" == "$v" ] ; then
+            return 0 # valid
+        fi
+        v=$(($v+1))
+    done
+    return 1 # not valid
 }
 
 portal_id=$1
@@ -89,18 +124,18 @@ if [ $webapp_restart_status -ne 0 ] ; then
     echo "          nonetheless, a command to clear the persistence cache will now occur." >&2
 fi
 
-cache_service_list=${portal_to_cache_service_list[$portal_id]}
-if [ -n "$cache_service_list" ] ; then
-    for cache_service in $cache_service_list ; do
-        $KUBECTL_BINARY $KUBECONFIG_ARG set env statefulset $cache_service --env="LAST_RESTART=$(date)"
-        cache_reset_status=$?
-        if [ $cache_reset_status -ne 0 ] ; then
-            echo "error encountered during attempt to clear portal persistence cache for portal $portal_id : $KUBECTL_BINARY returned status $cache_reset_status" >&2
-            exit 1
-        fi
-    done
+cache_service_basename=${portal_to_cache_service_basename[$portal_id]}
+cache_leader_pod_name="${cache_service_basename}-master-0"
+cache_database_number=${portal_to_cache_database_number[$portal_id]}
+if [ -n "$cache_service_basename" ] && database_number_is_valid "$cache_database_number" ; then
+    $KUBECTL_BINARY $KUBECONFIG_ARG exec -t -n "default" "$cache_leader_pod_name" -- "/bin/bash" -c "redis-cli -a \$REDIS_PASSWORD -n $cache_database_number FLUSHDB"
+    cache_flush_status=$?
+    if [ $cache_flush_status -ne 0 ] ; then
+        echo "error encountered during attempt to clear portal persistence cache for portal $portal_id : $KUBECTL_BINARY returned status $cache_flush_status" >&2
+        exit 1
+    fi
 else
-    echo portal $portal_id has no persistence cache service. skipping.
+    echo portal $portal_id has no persistence cache service or has no valid database number. skipping.
     exit 0
 fi
 exit 0

--- a/import-scripts/import-genie-data.sh
+++ b/import-scripts/import-genie-data.sh
@@ -46,8 +46,6 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-genie-data.lock"
         exit 1
     fi
 
-    source $PORTAL_HOME/scripts/clear-persistence-cache-shell-functions.sh
-
     tmp=$PORTAL_HOME/tmp/import-cron-genie
     if ! [ -d "$tmp" ] ; then
         if ! mkdir -p "$tmp" ; then
@@ -75,7 +73,6 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-genie-data.lock"
     else
         oncotree_version_to_use=oncotree_2019_12_01
     fi
-    CLEAR_PERSISTENCE_CACHE=0 # 0 = do not clear cache, non-0 = clear cache
 
     # import is beginning - create status file showing "in_progress", and remove trigger
     rm -f "$START_GENIE_IMPORT_TRIGGER_FILENAME"
@@ -135,24 +132,8 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/import-genie-data.lock"
         fi
         if [ -z $num_studies_updated ] ; then
             echo "could not determine the number of studies that have been updated"
-            # if import fails [presumed to have failed if num_studies_updated.txt is missing or empty], some checked-off studies still may have been successfully imported, so clear the persistence caches
-            CLEAR_PERSISTENCE_CACHE=1
         else
             echo "'$num_studies_updated' studies have been updated"
-            if [[ $num_studies_updated != "0" ]]; then
-                # if at least 1 study was imported, clear the persistence cache
-                CLEAR_PERSISTENCE_CACHE=1
-            fi
-        fi
-
-        # clear persistence cache
-        if [ $CLEAR_PERSISTENCE_CACHE -ne 0 ] ; then
-            echo "clearing persistence cache for genie portal ..."
-            if ! clearPersistenceCachesForGeniePortals ; then
-                sendClearCacheFailureMessage genie import-genie-data.sh
-            fi
-        else
-            echo "No studies have been updated, skipping redeployment of genie portal pods"
         fi
     fi
 


### PR DESCRIPTION
- add blue/green variants for genie functions
- remove import script calls for clearing the persistence cache (moving into the manual step automation work)