### PR TITLE
Added Query Type to OncoKB MAF Annotator Script

### DIFF
--- a/import-scripts/oncokb-annotator.sh
+++ b/import-scripts/oncokb-annotator.sh
@@ -148,6 +148,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/oncokb-annotator.sh"
     ONCOKB_MAF_FILE_ZIPPED="${ONCOKB_MAF_FILE}.gz"
     ONCOKB_PREVIOUS_MAF_FILE="$ONCOKB_OUT_DIR/data_mutations_extended.oncokb.previous.txt"
     ONCOKB_SOMATIC_MAF_FILE="$ONCOKB_OUT_DIR/data_mutations_extended_somatic.oncokb.txt"
+    ONCOKB_MAF_QUERY_TYPE="Genomic_Change"
 
     SOURCE_SV_FILE="$MSK_SOLID_HEME_DATA_HOME/data_sv.txt"
     STAGING_SV_FILE="$STAGING_DIR/data_sv.txt"
@@ -246,7 +247,7 @@ FLOCK_FILEPATH="/data/portal-cron/cron-lock/oncokb-annotator.sh"
             fi
         fi
 
-        $PYTHON3_BINARY $MAF_ANNOTATOR_SCRIPT -b $ONCOKB_TOKEN -i $STAGING_MAF_FILE -o $ONCOKB_MAF_FILE -c $STAGING_SAMPLE_FILE -a $PREVIOUS_ANNOTATED_MAF_ARGS
+        $PYTHON3_BINARY $MAF_ANNOTATOR_SCRIPT -b $ONCOKB_TOKEN -i $STAGING_MAF_FILE -o $ONCOKB_MAF_FILE -c $STAGING_SAMPLE_FILE -a $PREVIOUS_ANNOTATED_MAF_ARGS -q $ONCOKB_MAF_QUERY_TYPE
         if [ $? -ne 0 ] ; then
             echo "Failed to annotate MAF, exiting..."
             ONCOKB_ANNOTATION_SUCCESS=0


### PR DESCRIPTION
# Introduction

This is a fix to get the TERT gene mutations annotated.

## Work Done

It looks like the OncoKB MAF annotator is picking the wrong query type for the MAF file.

Here is the [OncoKB annotator code](https://github.com/jfkonecn/oncokb-annotator/blob/09ff7e9614990747ff0f9132dad1b1e9825ac68d/AnnotatorCore.py#L448-L479) that tries to resolve the query type automatically. It searches for [these headers](https://github.com/jfkonecn/oncokb-annotator/blob/09ff7e9614990747ff0f9132dad1b1e9825ac68d/AnnotatorCore.py#L199-L206) to determine if the query type should be a `GENOMIC_CHANGE`. It looks like it's picking `HGVSP_SHORT` instead. Since most of the mutations do not have HGVSP_SHORT mutations, they end up not getting annotated.

It's unclear to me why the code stopped working after November 2023 (which is when Tomin's last known good file is dated at) since there doesn't appear to be any relevant code changes made past that date.


## Side Note

For this error: 
```sh
WARNING:AnnotatorCore:Unexpected reference genome, only GRCh37 and GRCh38 are supported. Skipping.`
```

`NCBI_Build` sometimes just has a number in it. For example instead of `GRCh37`, the column has a value of `37`.

