### PR TITLE
allow per-host ingress specification

### DIFF
--- a/import-scripts/color-config-parsing-functions.sh
+++ b/import-scripts/color-config-parsing-functions.sh
@@ -1,0 +1,116 @@
+# bash functions for parsing values from a color swap config file
+#
+# these functions are intended for use in other scripts which require access to values in a color swap config file, which is in a yaml-like format
+# this file should be "sourced" in the client script with a command such as "source color-config-parsing-functions.sh"
+# correct behavior requires the definition of environment variable YQ_BINARY containing a filepath to executable tool 'yq'
+
+#######################################
+# Exit process if YQ_BINARY does not point to an executable.
+# Gobals:
+#   YQ_BINARY
+# Arguments:
+#   None
+# Side effects:
+#   process terminated on error
+#######################################
+function exit_with_error_if_yq_unavailable() {
+    if [ -z "$YQ_BINARY" ] ; then
+        echo "Error : environment YQ_BINARY is undefined. This must contain a valid filepath to the yq executable."
+        exit 1
+    fi
+    if ! [ -f "$YQ_BINARY" ] ; then
+        echo "Error : environment YQ_BINARY does not contain a valid filepath to the yq executable."
+        exit 1
+    fi
+    if ! [ -x "$YQ_BINARY" ] ; then
+        echo "Error : environment YQ_BINARY contains a path to a file which is not executable."
+        exit 1
+    fi
+}
+
+#######################################
+# Use yq to find a scalar value.
+# Gobals:
+#   YQ_BINARY
+# Arguments:
+#   filepath to the config file
+#   yq element_path specifier to find the value
+# Output:
+#   the scalar value as a string to stdout
+# Side effects:
+#   process terminated on error
+#######################################
+function read_scalar_from_yaml() {
+    local filepath="$1"
+    local element_path="$2"
+    exit_with_error_if_yq_unavailable
+    local value=$("$YQ_BINARY" -r "$element_path" "$filepath")
+    if [ "$value" == "null" ] || [ -z "$value" ] ; then
+        echo "Error : missing required scalar '$element_path' in $filepath" >&2
+        exit 1
+    fi
+    printf '%s\n' "$value"
+}
+
+#######################################
+# Use yq to find an array of values and return them in a global array variable
+# Gobals:
+#   YQ_BINARY
+#   a global variable with a name provided by the caller
+# Arguments:
+#   the name of a global variable to return the retrieved array values in
+#   filepath to the config file
+#   yq element_path specifier to find the array of values
+# Side effects:
+#   process terminated on error
+#######################################
+function read_array_from_yaml() {
+    local dest_var="$1"
+    local filepath="$2"
+    local element_path="$3"
+    exit_with_error_if_yq_unavailable
+    local array_path="${element_path}[]"
+    local type=$("$YQ_BINARY" -r "$element_path | type" "$filepath")
+    if [ "$type" != "!!seq" ] ; then
+        echo "Error : expected array at '$element_path' in $filepath" >&2
+        exit 1
+    fi
+    unset "$dest_var"
+    declare -g -a "$dest_var"
+    readarray -t "$dest_var" < <("$YQ_BINARY" -r "$array_path" "$filepath")
+}
+
+#######################################
+# Use yq to find an dictionary/map of values and return them in a global array variable
+# Gobals:
+#   YQ_BINARY
+#   a global variable with a name provided by the caller
+# Arguments:
+#   the name of a global variable to return the retrieved key/value pairs in
+#   filepath to the config file
+#   yq element_path specifier to find the dictionary of key/value pairs
+# Side effects:
+#   process terminated on error
+#######################################
+function read_map_from_yaml() {
+    local dest_var="$1"
+    local filepath="$2"
+    local element_path="$3"
+    exit_with_error_if_yq_unavailable
+    local type=$("$YQ_BINARY" -r "$element_path | type" "$filepath")
+    if [ "$type" != "!!map" ] ; then
+        echo "Error : expected map at '$element_path' in $filepath" >&2
+        exit 1
+    fi
+    unset "$dest_var"
+    declare -gA "$dest_var"
+    local has_entries=0
+    while IFS=$'\t' read -r entry_key entry_value ; do
+        printf -v "$dest_var[$entry_key]" '%s' "$entry_value"
+        has_entries=1
+    done < <("$YQ_BINARY" -r "$element_path | to_entries[] | [.key, .value] | @tsv" "$filepath")
+    if [ "$has_entries" -eq 0 ] ; then
+        echo "Error : map at '$element_path' in $filepath must contain at least one entry" >&2
+        exit 1
+    fi
+}

--- a/import-scripts/color-swap-configs/genie-db-color-swap-config.yaml.example
+++ b/import-scripts/color-swap-configs/genie-db-color-swap-config.yaml.example
@@ -23,8 +23,15 @@ host_to_service_map:
   green:
     genie.cbioportal.org: cbioportal-backend-genie-public-green
     genie-private.cbioportal.org: cbioportal-backend-genie-private-green
-ingress_name: genie-ingress
-ingress_yaml_filepath: argocd/aws/203403084713/clusters/cbioportal-prod/apps/ingress/genie-ingress.yml
+host_to_ingress_name_map:
+    genie.cbioportal.org: genie-ingress
+    genie-private.cbioportal.org: genie-ingress
+host_to_ingress_type_map:
+    genie.cbioportal.org: ingress
+    genie-private.cbioportal.org: ingress
+host_to_ingress_yaml_filepath_map:
+    genie.cbioportal.org: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/genie-ingress.yml
+    genie-private.cbioportal.org: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/genie-ingress.yml
 replica_ready_check_pause_seconds: 20
 replica_ready_check_max_checkcount: 30
 temp_dir_path: /data/portal-cron/tmp/import-cron-genie
@@ -34,3 +41,6 @@ synchronize_user_tables: true
 clear_persistence_caches_blue_function: clearPersistenceCachesForGenieBluePortals
 clear_persistence_caches_green_function: clearPersistenceCachesForGenieGreenPortals
 git_commit_msg: "genie import"
+rds_scale_down_class: "db.t3.micro"
+rds_scale_up_class: "db.r5.2xlarge"
+updates_disabled: false

--- a/import-scripts/color-swap-configs/msk-db-color-swap-config.yaml.example
+++ b/import-scripts/color-swap-configs/msk-db-color-swap-config.yaml.example
@@ -62,8 +62,33 @@ host_to_service_map:
     private.cbioportal.aws.mskcc.org: eks-private-green
     sclc.cbioportal.mskcc.org: eks-sclc-green
     sclc.cbioportal.aws.mskcc.org: eks-sclc-green
-ingress_name: msk-eks-prod-ingress
-ingress_yaml_filepath: digits-eks/eks-prod/shared-services/ingress/eks-msk-ingress.yaml
+host_to_ingress_name_map:
+    cbioportal.mskcc.org: msk-eks-prod-ingress
+    cbioportal.aws.mskcc.org: msk-eks-prod-ingress
+    beta.cbioportal.mskcc.org: msk-eks-prod-ingress
+    beta.cbioportal.aws.mskcc.org: msk-eks-prod-ingress
+    private.cbioportal.mskcc.org: msk-eks-prod-ingress
+    private.cbioportal.aws.mskcc.org: msk-eks-prod-ingress
+    sclc.cbioportal.mskcc.org: msk-eks-prod-ingress
+    sclc.cbioportal.aws.mskcc.org: msk-eks-prod-ingress
+host_to_ingress_type_map:
+    cbioportal.mskcc.org: ingress
+    cbioportal.aws.mskcc.org: ingress
+    beta.cbioportal.mskcc.org: ingress
+    beta.cbioportal.aws.mskcc.org: ingress
+    private.cbioportal.mskcc.org: ingress
+    private.cbioportal.aws.mskcc.org: ingress
+    sclc.cbioportal.mskcc.org: ingress
+    sclc.cbioportal.aws.mskcc.org: ingress
+host_to_ingress_yaml_filepath_map:
+    cbioportal.mskcc.org: digits-eks/eks-prod/shared-services/ingress/eks-msk-ingress.yaml
+    cbioportal.aws.mskcc.org: digits-eks/eks-prod/shared-services/ingress/eks-msk-ingress.yaml
+    beta.cbioportal.mskcc.org: digits-eks/eks-prod/shared-services/ingress/eks-msk-ingress.yaml
+    beta.cbioportal.aws.mskcc.org: digits-eks/eks-prod/shared-services/ingress/eks-msk-ingress.yaml
+    private.cbioportal.mskcc.org: digits-eks/eks-prod/shared-services/ingress/eks-msk-ingress.yaml
+    private.cbioportal.aws.mskcc.org: digits-eks/eks-prod/shared-services/ingress/eks-msk-ingress.yaml
+    sclc.cbioportal.mskcc.org: digits-eks/eks-prod/shared-services/ingress/eks-msk-ingress.yaml
+    sclc.cbioportal.aws.mskcc.org: digits-eks/eks-prod/shared-services/ingress/eks-msk-ingress.yaml
 replica_ready_check_pause_seconds: 20
 replica_ready_check_max_checkcount: 30
 temp_dir_path: /data/portal-cron/tmp/import-cron-dmp-msk
@@ -77,3 +102,4 @@ clear_persistence_caches_green_function: clearPersistenceCachesForMskGreenPortal
 git_commit_msg: "msk import"
 cache_warming_username: "<REDACTED>"
 cache_warming_password: "<REDACTED>"
+updates_disabled: false

--- a/import-scripts/color-swap-configs/public-db-color-swap-config.yaml.example
+++ b/import-scripts/color-swap-configs/public-db-color-swap-config.yaml.example
@@ -2,15 +2,19 @@ service_account: public
 cluster_cfg: /data/portal-cron/pipelines-credentials/publicargocd-cluster-kubeconfig
 blue_deployment_list:
   - cbioportal-backend-public-blue
+  - cbioportal-backend-public-api-blue
   - cbioportal-backend-public-beta-blue
   - cbioportal-backend-master-blue
 green_deployment_list:
   - cbioportal-backend-public-green
+  - cbioportal-backend-public-api-green
   - cbioportal-backend-public-beta-green
   - cbioportal-backend-master-green
 deployment_to_full_replica_count_map:
-  cbioportal-backend-public-blue: 4
-  cbioportal-backend-public-green: 4
+  cbioportal-backend-public-blue: 2
+  cbioportal-backend-public-green: 2
+  cbioportal-backend-public-api-blue: 2
+  cbioportal-backend-public-api-green: 2
 #  cbioportal-backend-public-beta-blue: 1
 #  cbioportal-backend-public-beta-green: 1
   cbioportal-backend-public-beta-blue: 0
@@ -19,24 +23,41 @@ deployment_to_full_replica_count_map:
   cbioportal-backend-master-green: 1
 deployment_to_yaml_filepath_map:
   cbioportal-backend-public-blue: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbioportal_backend_public_blue.yaml
+  cbioportal-backend-public-api-blue: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal-api/cbioportal_backend_public_api_blue.yaml
   cbioportal-backend-public-beta-blue: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbioportal_backend_public_beta_blue.yaml
   cbioportal-backend-master-blue: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbioportal_backend_master_blue.yaml
   cbioportal-backend-public-green: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbioportal_backend_public_green.yaml
+  cbioportal-backend-public-api-green: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal-api/cbioportal_backend_public_api_green.yaml
   cbioportal-backend-public-beta-green: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbioportal_backend_public_beta_green.yaml
   cbioportal-backend-master-green: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbioportal_backend_master_green.yaml
 host_to_service_map:
   blue:
     www.cbioportal.org: cbioportal-backend-public-blue
+    api.cbioportal.org: cbioportal-backend-public-api-blue
 #    beta.cbioportal.org: cbioportal-backend-public-beta-blue
     beta.cbioportal.org: cbioportal-backend-public-beta-offline
     master.cbioportal.org: cbioportal-backend-master-blue
   green:
     www.cbioportal.org: cbioportal-backend-public-green
+    api.cbioportal.org: cbioportal-backend-public-api-green
 #    beta.cbioportal.org: cbioportal-backend-public-beta-green
     beta.cbioportal.org: cbioportal-backend-public-beta-offline
     master.cbioportal.org: cbioportal-backend-master-green
-ingress_name: cbioportal-ingress
-ingress_yaml_filepath: argocd/aws/203403084713/clusters/cbioportal-prod/apps/ingress/cbio-ingress.yml
+host_to_ingress_name_map:
+    www.cbioportal.org: cbioportal-www-ingressroute
+    api.cbioportal.org: cbioportal-api-ingress
+    beta.cbioportal.org: cbioportal-ingress
+    master.cbioportal.org: cbioportal-ingress
+host_to_ingress_type_map:
+    www.cbioportal.org: ingressroute
+    api.cbioportal.org: ingress
+    beta.cbioportal.org: ingress
+    master.cbioportal.org: ingress
+host_to_ingress_yaml_filepath_map:
+    www.cbioportal.org: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbio-www-ingressroute.yml
+    api.cbioportal.org: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal-api/cbioportal-api-ingress.yaml
+    beta.cbioportal.org: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbio-ingress.yml
+    master.cbioportal.org: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbio-ingress.yml
 replica_ready_check_pause_seconds: 20
 replica_ready_check_max_checkcount: 30
 temp_dir_path: /data/portal-cron/tmp/import-cron-public
@@ -46,3 +67,6 @@ synchronize_user_tables: false
 clear_persistence_caches_blue_function: clearPersistenceCachesForPublicBluePortals
 clear_persistence_caches_green_function: clearPersistenceCachesForPublicGreenPortals
 git_commit_msg: "public import"
+rds_scale_down_class: "db.t3.micro"
+rds_scale_up_class: "db.r5.4xlarge"
+updates_disabled: false

--- a/import-scripts/scale-rds.sh
+++ b/import-scripts/scale-rds.sh
@@ -11,6 +11,7 @@ SKIP_PRE_VALIDATION="${4:-}"
 [[ -f "$COLOR_SWAP_CONFIG_FILEPATH" ]]
 
 source /data/portal-cron/scripts/automation-environment.sh
+source /data/portal-cron/scripts/color-config-parsing-functions.sh
 source /data/portal-cron/scripts/rds_functions.sh
 
 # Authenticate with AWS
@@ -22,17 +23,6 @@ else
     /data/portal-cron/scripts/authenticate_service_account.sh public
     aws_profile="automation_public"
 fi
-
-function read_scalar() {
-    local key="$1"
-    local value
-    value=$("$YQ_BINARY" -r "$key" "$COLOR_SWAP_CONFIG_FILEPATH")
-    if [ "$value" == "null" ] || [ -z "$value" ] ; then
-        echo "Error : missing required scalar '$key' in $COLOR_SWAP_CONFIG_FILEPATH" >&2
-        exit 1
-    fi
-    printf '%s\n' "$value"
-}
 
 get_node_id() {
     # NOTE: the color names in these RDS nodes do *not* have anything to do
@@ -74,8 +64,8 @@ function warn_already_at_desired_class_and_exit() {
 
 # Get the scale up / scale down classes for this portal
 echo "Reading configuration knobs from $COLOR_SWAP_CONFIG_FILEPATH"
-scale_up_class=$(read_scalar '.rds_scale_up_class')
-scale_down_class=$(read_scalar '.rds_scale_down_class')
+scale_up_class=$(read_scalar_from_yaml "$COLOR_SWAP_CONFIG_FILEPATH" '.rds_scale_up_class')
+scale_down_class=$(read_scalar_from_yaml "$COLOR_SWAP_CONFIG_FILEPATH" '.rds_scale_down_class')
 rds_node_id=$(get_node_id)
 current_class=$(rds_current_class "$rds_node_id" "$aws_profile")
 

--- a/import-scripts/transfer-deployment-color.sh
+++ b/import-scripts/transfer-deployment-color.sh
@@ -15,95 +15,116 @@
 # - scale down the prior production deployment fully, scale up the new production deployment fully. Allow time for pod readiness.
 # - construct and check in to github repo the altered kubernetes configuration files
 
-declare -a BLUE_DEPLOYMENT_LIST=()
-declare -a GREEN_DEPLOYMENT_LIST=()
-declare -A DEPLOYMENT_TO_FULL_REPLICA_COUNT_MAP=()
-declare -A DEPLOYMENT_TO_CACHE_WARMING_POLICY=()
-declare -A DEPLOYMENT_TO_YAML_FILEPATH_MAP=()
-declare -A HOST_TO_SERVICE_MAP_BLUE=()
-declare -A HOST_TO_SERVICE_MAP_GREEN=()
+#######################################
+# Global Variable Definitions
+#######################################
+declare -a BLUE_DEPLOYMENT_LIST=() # kubernetes deployment names for all connected blue deployments
+declare -a GREEN_DEPLOYMENT_LIST=() # kubernetes deployment names for all connected green deployments
+declare -A DEPLOYMENT_TO_FULL_REPLICA_COUNT_MAP=() # { cbioportal-backend-public-blue: 2 } means 2 replicas when fully deployed
+declare -A DEPLOYMENT_TO_CACHE_WARMING_POLICY=() # how much to warm the cache (e.g. 'initial', 'studylist') per deployment
+declare -A DEPLOYMENT_TO_YAML_FILEPATH_MAP=() # relative path from KS_K8S_DEPL_REPO_DIRPATH to a yaml file specifying the deployment resource for each named deployment
+declare -A HOST_TO_SERVICE_MAP_BLUE=() # the name of the blue service connected to each deployed host/website
+declare -A HOST_TO_SERVICE_MAP_GREEN=() # see prior comment
+declare -A HOST_TO_INGRESS_NAME_MAP=() # for each host connected to the database, the name of the ingress resource it uses
+declare -A HOST_TO_INGRESS_TYPE_MAP=() # the type of each ingress resource mapped (either 'ingress' or 'ingressroute')
+declare -A HOST_TO_INGRESS_YAML_FILEPATH_MAP=() # relative path from KS_K8S_DEPL_REPO_DIRPATH to a yaml file specifying the primary ingress resource related to the host
+#######################################
+# Other Global Variable List
+#######################################
+# set in automation-environment.sh
+#   YQ_BINARY
+# set in color swap config file (see load_color_swap_config())
+#   SERVICE_ACCOUNT
+#   CLUSTER_KUBECONFIG
+#   TEMP_DIR_PATH
+#   KS_K8S_DEPL_REPO_DIRPATH
+#   REPLICA_READY_CHECK_PAUSE_SECONDS
+#   REPLICA_READY_CHECK_MAX_CHECKCOUNT
+#   WARM_CACHES
+#   SYNCHRONIZE_USER_TABLES
+#   CLEAR_PERSISTENCE_CACHES_BLUE_FUNCTION
+#   CLEAR_PERSISTENCE_CACHES_GREEN_FUNCTION
+#   GIT_COMMIT_MSG
+#   CACHE_WARMING_POD_LIST_FILEPATH
+#   CACHE_WARMING_POD_SUBLIST_FILEPATH
+#   CACHE_WARMING_USERNAME
+#   CACHE_WARMING_PASSWORD
 
-function read_scalar() {
-    local key="$1"
-    local value
-    value=$("$YQ_BINARY" -r "$key" "$COLOR_SWAP_CONFIG_FILEPATH")
-    if [ "$value" == "null" ] || [ -z "$value" ] ; then
-        echo "Error : missing required scalar '$key' in $COLOR_SWAP_CONFIG_FILEPATH" >&2
-        exit 1
-    fi
-    printf '%s\n' "$value"
-}
-
-function read_array() {
-    local dest_var="$1"
-    local path="$2"
-    local array_path="${path}[]"
-    local file="$COLOR_SWAP_CONFIG_FILEPATH"
-    local type=$("$YQ_BINARY" -r "$path | type" "$file")
-    if [ "$type" != "!!seq" ] ; then
-        echo "Error : expected array at '$path' in $file" >&2
-        exit 1
-    fi
-    unset "$dest_var"
-    declare -g -a "$dest_var"
-    readarray -t "$dest_var" < <("$YQ_BINARY" -r "$array_path" "$file")
-}
-
-function read_map() {
-    local dest_var="$1"
-    local path="$2"
-    local file="$COLOR_SWAP_CONFIG_FILEPATH"
-    local type=$("$YQ_BINARY" -r "$path | type" "$file")
-    if [ "$type" != "!!map" ] ; then
-        echo "Error : expected map at '$path' in $file" >&2
-        exit 1
-    fi
-    unset "$dest_var"
-    declare -gA "$dest_var"
-    local has_entries=0
-    while IFS=$'\t' read -r entry_key entry_value ; do
-        printf -v "$dest_var[$entry_key]" '%s' "$entry_value"
-        has_entries=1
-    done < <("$YQ_BINARY" -r "$path | to_entries[] | [.key, .value] | @tsv" "$file")
-    if [ "$has_entries" -eq 0 ] ; then
-        echo "Error : map at '$path' in $file must contain at least one entry" >&2
-        exit 1
-    fi
-}
-
+#######################################
+# Load needed config properties into global variables
+# Globals:
+#   YQ_BINARY path to yq executable
+#   SERVICE_ACCOUNT the name of the service account selector for use with aws authentication
+#   CLUSTER_KUBECONFIG path to a .kube/config style function defining the kubectl cluster to interact with
+#   TEMP_DIR_PATH
+#   KS_K8S_DEPL_REPO_DIRPATH the path to the directory contain the clone of knowledgesystems-k8s-deployments.
+#           This repository clone is used and also updated (changes are checked in to github with `git push`)
+#   REPLICA_READY_CHECK_PAUSE_SECONDS pause period between checks if deployment changes are complete
+#   REPLICA_READY_CHECK_MAX_CHECKCOUNT maximum limit of deployment change completion check cycles
+#   WARM_CACHES 'true' if this database requires cache warming during blue/green color swapping
+#   SYNCHRONIZE_USER_TABLES 'true' if this database requires the user and authorities tables to be synchronized
+#           During blue/green color swapping. (records will be copied from old to new color at time of swap)
+#   CLEAR_PERSISTENCE_CACHES_BLUE_FUNCTION bash function (e.g. clearPersistenceCachesForPublicBluePortals) to be
+#           called to clear the blue caches. These are defined in clear-persistence-cache-shell-functions.sh
+#   CLEAR_PERSISTENCE_CACHES_GREEN_FUNCTION see prior comment
+#   GIT_COMMIT_MSG text to be prepended to the date in the git commit log message when pushing changes to github
+#           (e.g. "public import" becomes "public import 2026-03-16")
+#   BLUE_DEPLOYMENT_LIST an array holding all the blue deployment/service names connected to a database
+#   GREEN_DEPLOYMENT_LIST an array holding all the green deployment/service names connected to a database
+#   DEPLOYMENT_TO_FULL_REPLICA_COUNT_MAP # { cbioportal-backend-public-blue: 2 } means 2 replicas when fully deployed
+#   DEPLOYMENT_TO_YAML_FILEPATH_MAP relative path from KS_K8S_DEPL_REPO_DIRPATH to a yaml file specifying the
+#           deployment resource for each named deployment
+#   HOST_TO_SERVICE_MAP_BLUE the name of the blue service connected to each deployed host/website
+#   HOST_TO_SERVICE_MAP_GREEN see prior comment
+#   HOST_TO_INGRESS_NAME_MAP for each host connected to the database, the name of the ingress resource it uses
+#   HOST_TO_INGRESS_TYPE_MAP the type of each ingress resource mapped (either 'ingress' or 'ingressroute')
+#   HOST_TO_INGRESS_YAML_FILEPATH_MAP relative path from KS_K8S_DEPL_REPO_DIRPATH to a yaml file specifying the
+#           primary ingress resource related to the host
+#   CACHE_WARMING_POD_LIST_FILEPATH a temporary file location for dumping/reading all pods
+#   CACHE_WARMING_POD_SUBLIST_FILEPATH a temporary file location for dumping/reading deployment pods
+#   CACHE_WARMING_USERNAME username for basic authentication allowing queries to warm caches
+#   CACHE_WARMING_PASSWORD password for basic authentication allowing queries to warm caches
+#   DEPLOYMENT_TO_CACHE_WARMING_POLICY # how much to warm the cache (e.g. 'initial', 'studylist') per deployment
+#   UPDATES_DISABLED when this is not 'false', verify-management-state.sh will exit early with a failure code
+# Arguments:
+#   path to color swap config file to access kubernetes cluster configuration resources
+# Output:
+#   none, except for error messages to stderr
+# Side effects:
+#   global variables set
+#######################################
 function load_color_swap_config() {
     local config_path="$1"
     if ! [ -f "$config_path" ] || ! [ -r "$config_path" ] ; then
         echo "Error : unable to read config file '$config_path'" >&2
         exit 1
     fi
-
-    SERVICE_ACCOUNT=$(read_scalar '.service_account')
-    CLUSTER_KUBECONFIG=$(read_scalar '.cluster_cfg')
-    TEMP_DIR_PATH=$(read_scalar '.temp_dir_path')
-    KS_K8S_DEPL_REPO_DIRPATH=$(read_scalar '.ks_k8s_depl_repo_dirpath')
-    INGRESS_YAML_FILEPATH=$(read_scalar '.ingress_yaml_filepath')
-    REPLICA_READY_CHECK_PAUSE_SECONDS=$(read_scalar '.replica_ready_check_pause_seconds')
-    REPLICA_READY_CHECK_MAX_CHECKCOUNT=$(read_scalar '.replica_ready_check_max_checkcount')
-    WARM_CACHES=$(read_scalar '.warm_caches')
-    SYNCHRONIZE_USER_TABLES=$(read_scalar '.synchronize_user_tables')
-    CLEAR_PERSISTENCE_CACHES_BLUE_FUNCTION=$(read_scalar '.clear_persistence_caches_blue_function')
-    CLEAR_PERSISTENCE_CACHES_GREEN_FUNCTION=$(read_scalar '.clear_persistence_caches_green_function')
-    GIT_COMMIT_MSG=$(read_scalar '.git_commit_msg')
-
-    read_array BLUE_DEPLOYMENT_LIST '.blue_deployment_list'
-    read_array GREEN_DEPLOYMENT_LIST '.green_deployment_list'
-    read_map DEPLOYMENT_TO_FULL_REPLICA_COUNT_MAP '.deployment_to_full_replica_count_map'
-    read_map DEPLOYMENT_TO_YAML_FILEPATH_MAP '.deployment_to_yaml_filepath_map'
-    read_map HOST_TO_SERVICE_MAP_BLUE '.host_to_service_map.blue'
-    read_map HOST_TO_SERVICE_MAP_GREEN '.host_to_service_map.green'
-
+    SERVICE_ACCOUNT=$(read_scalar_from_yaml "$config_path" '.service_account')
+    CLUSTER_KUBECONFIG=$(read_scalar_from_yaml "$config_path" '.cluster_cfg')
+    TEMP_DIR_PATH=$(read_scalar_from_yaml "$config_path" '.temp_dir_path')
+    KS_K8S_DEPL_REPO_DIRPATH=$(read_scalar_from_yaml "$config_path" '.ks_k8s_depl_repo_dirpath')
+    REPLICA_READY_CHECK_PAUSE_SECONDS=$(read_scalar_from_yaml "$config_path" '.replica_ready_check_pause_seconds')
+    REPLICA_READY_CHECK_MAX_CHECKCOUNT=$(read_scalar_from_yaml "$config_path" '.replica_ready_check_max_checkcount')
+    WARM_CACHES=$(read_scalar_from_yaml "$config_path" '.warm_caches')
+    SYNCHRONIZE_USER_TABLES=$(read_scalar_from_yaml "$config_path" '.synchronize_user_tables')
+    CLEAR_PERSISTENCE_CACHES_BLUE_FUNCTION=$(read_scalar_from_yaml "$config_path" '.clear_persistence_caches_blue_function')
+    CLEAR_PERSISTENCE_CACHES_GREEN_FUNCTION=$(read_scalar_from_yaml "$config_path" '.clear_persistence_caches_green_function')
+    GIT_COMMIT_MSG=$(read_scalar_from_yaml "$config_path" '.git_commit_msg')
+    read_array_from_yaml BLUE_DEPLOYMENT_LIST "$config_path" '.blue_deployment_list'
+    read_array_from_yaml GREEN_DEPLOYMENT_LIST "$config_path" '.green_deployment_list'
+    read_map_from_yaml DEPLOYMENT_TO_FULL_REPLICA_COUNT_MAP "$config_path" '.deployment_to_full_replica_count_map'
+    read_map_from_yaml DEPLOYMENT_TO_YAML_FILEPATH_MAP "$config_path" '.deployment_to_yaml_filepath_map'
+    read_map_from_yaml HOST_TO_SERVICE_MAP_BLUE "$config_path" '.host_to_service_map.blue'
+    read_map_from_yaml HOST_TO_SERVICE_MAP_GREEN "$config_path" '.host_to_service_map.green'
+    read_map_from_yaml HOST_TO_INGRESS_NAME_MAP "$config_path" '.host_to_ingress_name_map'
+    read_map_from_yaml HOST_TO_INGRESS_TYPE_MAP "$config_path" '.host_to_ingress_type_map'
+    read_map_from_yaml HOST_TO_INGRESS_YAML_FILEPATH_MAP "$config_path" '.host_to_ingress_yaml_filepath_map'
     if [ "$WARM_CACHES" == "true" ]; then
-        CACHE_WARMING_POD_LIST_FILEPATH=$(read_scalar '.cache_warming_pod_list_filepath')
-        CACHE_WARMING_POD_SUBLIST_FILEPATH=$(read_scalar '.cache_warming_pod_sublist_filepath')
-        CACHE_WARMING_USERNAME=$(read_scalar '.cache_warming_username')
-        CACHE_WARMING_PASSWORD=$(read_scalar '.cache_warming_password')
-        read_map DEPLOYMENT_TO_CACHE_WARMING_POLICY '.deployment_to_cache_warming_policy'
+        CACHE_WARMING_POD_LIST_FILEPATH=$(read_scalar_from_yaml "$config_path" '.cache_warming_pod_list_filepath')
+        CACHE_WARMING_POD_SUBLIST_FILEPATH=$(read_scalar_from_yaml "$config_path" '.cache_warming_pod_sublist_filepath')
+        CACHE_WARMING_USERNAME=$(read_scalar_from_yaml "$config_path" '.cache_warming_username')
+        CACHE_WARMING_PASSWORD=$(read_scalar_from_yaml "$config_path" '.cache_warming_password')
+        read_map_from_yaml DEPLOYMENT_TO_CACHE_WARMING_POLICY "$config_path" '.deployment_to_cache_warming_policy'
     fi
 }
 
@@ -113,6 +134,21 @@ function usage() {
     exit 1
 }
 
+#######################################
+# Exit with error if main() was called with inappropriate arguments
+# Gobals:
+#   none
+# Arguments:
+#   all arguements received by main(), 3 expected:
+#     MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH
+#     COLOR_SWAP_CONFIG_FILEPATH
+#     DESTINATION_COLOR
+# Output:
+#   none, except for error messages to stderr
+# Side effects:
+#   process exit if argument count is wrong or file paths are not readable
+#   or color is outside of {'blue', 'green'}
+#######################################
 function validate_arguments() {
     if [ $# -ne "3" ] ; then
         usage
@@ -131,11 +167,23 @@ function validate_arguments() {
     fi
 }
 
+#######################################
+# Exit with error if production database color does not match argument
+# Gobals:
+#   none
+# Arguments:
+#   MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH
+#   SOURCE_COLOR
+# Output:
+#   none, except for error messages to stderr
+# Side effects:
+#   process exit if SOURCE_COLOR is not the production database
+#######################################
 function check_current_color_is() {
-    MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH=$1
-    SOURCE_COLOR=$2
-    GET_DATABASE_CURRENTLY_IN_PRODUCTION_SCRIPT="/data/portal-cron/scripts/get_database_currently_in_production.sh"
-    CURRENT_DATABASE_OUTPUT_FILEPATH="$TEMP_DIR_PATH/get_current_database_output_before_switch.txt"
+    local MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH=$1
+    local SOURCE_COLOR=$2
+    local GET_DATABASE_CURRENTLY_IN_PRODUCTION_SCRIPT="/data/portal-cron/scripts/get_database_currently_in_production.sh"
+    local CURRENT_DATABASE_OUTPUT_FILEPATH="$TEMP_DIR_PATH/get_current_database_output_before_switch.txt"
     rm -f $CURRENT_DATABASE_OUTPUT_FILEPATH
     if ! $GET_DATABASE_CURRENTLY_IN_PRODUCTION_SCRIPT $MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH > $CURRENT_DATABASE_OUTPUT_FILEPATH; then
         echo "Error during determination of the source database color" >&2
@@ -161,6 +209,19 @@ function check_current_color_is() {
     fi
 }
 
+#######################################
+# Detects if git repo clone is up to date with origin/master
+# Gobals:
+#   KS_K8S_DEPL_REPO_DIRPATH
+# Arguments:
+#   none
+# Output:
+#   none, except for error messages to stderr
+# Side effects:
+#   none
+# Returns:
+#   0 if current, 1 otherwise
+#######################################
 function git_repo_clone_is_current() {
     # note : the next statement defines a multi-line string
     expected_up_to_date_status_report="On branch master
@@ -181,17 +242,32 @@ Your branch is up to date with 'origin/master'."
     fi
 }
 
+#######################################
 function check_that_git_repo_clone_is_current() {
     if ! git_repo_clone_is_current ; then
         exit 1
     fi
 }
 
+#######################################
+# Detects if one kubernetes yaml file matches what is configured in the cluster
+# Gobals:
+#   KS_K8S_DEPL_REPO_DIRPATH
+#   CLUSTER_KUBECONFIG
+# Arguments:
+#   yaml_filepath (relative to the root directory of the repository clone)
+# Output:
+#   none, except for error messages to stderr
+# Side effects:
+#   none
+# Returns:
+#   0 if no differences detected, 1 otherwise
+#######################################
 function yaml_file_is_current_with_production() {
-    yaml_filepath=$1
-    full_yaml_filepath="$KS_K8S_DEPL_REPO_DIRPATH/$yaml_filepath"
+    local yaml_filepath=$1
+    local full_yaml_filepath="$KS_K8S_DEPL_REPO_DIRPATH/$yaml_filepath"
     kubectl --kubeconfig $CLUSTER_KUBECONFIG diff -f "$full_yaml_filepath" > /dev/null 2>&1
-    diff_status=$?
+    local diff_status=$?
     if [ $diff_status -eq 1 ] ; then
         # mismatch
         echo "when checking for currency of yaml specificiations in file '$full_yaml_filepath', these differences were found:"
@@ -207,15 +283,35 @@ function yaml_file_is_current_with_production() {
     return 0
 }
 
+#######################################
+# Detects if all relevant kubernetes yaml files match what is configured in the cluster
+# Gobals:
+#   BLUE_DEPLOYMENT_LIST
+#   GREEN_DEPLOYMENT_LIST
+#   KS_K8S_DEPL_REPO_DIRPATH
+#   DEPLOYMENT_TO_YAML_FILEPATH_MAP
+#   HOST_TO_INGRESS_YAML_FILEPATH_MAP
+# Arguments:
+#   yaml_filepath (relative to the root directory of the repository clone)
+# Output:
+#   none, except for error messages to stderr
+# Side effects:
+#   none
+# Returns:
+#   0 if no differences detected, 1 otherwise
+#######################################
 function git_repo_clone_matches_cluster_config() {
+    local all_yaml_files_are_current="yes"
+    local pos=0
+    local deployment
+    local yaml_filepath
     pos=0
     while [ $pos -lt ${#BLUE_DEPLOYMENT_LIST[@]} ] ; do
         deployment=${BLUE_DEPLOYMENT_LIST[$pos]}
         yaml_filepath="${DEPLOYMENT_TO_YAML_FILEPATH_MAP[$deployment]}"
         if ! yaml_file_is_current_with_production "$yaml_filepath" ; then
-            echo "current master branch of kubernetes yaml repo does not match the production environment"
             echo "mismatch exists in file $KS_K8S_DEPL_REPO_DIRPATH/$yaml_filepath"
-            return 1
+            all_yaml_files_are_current="no"
         fi
         pos=$(($pos+1))
     done
@@ -224,52 +320,76 @@ function git_repo_clone_matches_cluster_config() {
         deployment=${GREEN_DEPLOYMENT_LIST[$pos]}
         yaml_filepath="${DEPLOYMENT_TO_YAML_FILEPATH_MAP[$deployment]}"
         if ! yaml_file_is_current_with_production "$yaml_filepath" ; then
-            echo "current master branch of kubernetes yaml repo does not match the production environment"
             echo "mismatch exists in file $KS_K8S_DEPL_REPO_DIRPATH/$yaml_filepath"
-            return 1
+            all_yaml_files_are_current="no"
         fi
         pos=$(($pos+1))
     done
-    if ! yaml_file_is_current_with_production "$INGRESS_YAML_FILEPATH" ; then
+    for yaml_filepath in ${HOST_TO_INGRESS_YAML_FILEPATH_MAP[*]} ; do
+        if ! yaml_file_is_current_with_production "$yaml_filepath" ; then
+            echo "mismatch exists in file $KS_K8S_DEPL_REPO_DIRPATH/$yaml_filepath"
+            all_yaml_files_are_current="no"
+        fi
+    done
+    if ! [ "$all_yaml_files_are_current" == "yes" ] ; then
         echo "current master branch of kubernetes yaml repo does not match the production environment"
-        echo "mismatch exists in file $KS_K8S_DEPL_REPO_DIRPATH/$INGRESS_YAML_FILEPATH"
         return 1
     fi
     return 0
 }
 
+#######################################
 function check_that_git_repo_clone_matches_cluster_config() {
     if ! git_repo_clone_matches_cluster_config ; then
         exit 1
     fi
 }
 
+#######################################
+# Detects if all relevant deployments in the kubernetes cluster show all replicas "ready"
+# Gobals:
+#   BLUE_DEPLOYMENT_LIST
+#   GREEN_DEPLOYMENT_LIST
+#   TEMP_DIR_PATH
+#   CLUSTER_KUBECONFIG
+#   BASH_REMATCH (shell built-in global for RE processing)
+# Arguments:
+#   deployment_color to test (only deployments of this color are tested)
+# Output:
+#   none, except for error messages to stderr
+# Side effects:
+#   none
+# Returns:
+#   0 if all deployments fully 'ready', 1 otherwise
+#######################################
 function all_replicas_ready() {
-    DEPLOYMENT_COLOR=$1
-    DEPLOYMENT_CHECK_OUTPUT_FILEPATH="$TEMP_DIR_PATH/all_replicas_ready_output.txt"
-    if [ $DEPLOYMENT_COLOR == 'blue' ] ; then
+    local deployment_color=$1
+    local DEPLOYMENT_CHECK_OUTPUT_FILEPATH="$TEMP_DIR_PATH/all_replicas_ready_output.txt"
+    # query relevant deployments with kubectl and capture output
+    if [ $deployment_color == 'blue' ] ; then
         kubectl --kubeconfig $CLUSTER_KUBECONFIG get deployments ${BLUE_DEPLOYMENT_LIST[@]} > $DEPLOYMENT_CHECK_OUTPUT_FILEPATH
     else
-        if [ $DEPLOYMENT_COLOR == 'green' ] ; then
+        if [ $deployment_color == 'green' ] ; then
             kubectl --kubeconfig $CLUSTER_KUBECONFIG get deployments ${GREEN_DEPLOYMENT_LIST[@]} > $DEPLOYMENT_CHECK_OUTPUT_FILEPATH
         else
-            echo "Error : invalid argument '$DEPLOYMENT_COLOR' passed to all_replicas_ready()" >&2
+            echo "Error : invalid argument '$deployment_color' passed to all_replicas_ready()" >&2
             exit 1
         fi
     fi
-    headers_read=0
+    # analyze captured output
+    local headers_read=0
     while IFS='' read -r line || [ -n "$line" ] ; do # -n "$line" will allow processing of lines which reach EOF before encountering newline
         if [ $headers_read -eq 0 ] ; then
             headers_read=1
         else
-            parse_line_regex='^([[:graph:]]*)[[:space:]]*([[:digit:]]*)/([[:digit:]])*.*'
-            if ! [[ $line =~ $parse_line_regex ]] ; then
+            local PARSE_LINE_REGEX='^([[:graph:]]*)[[:space:]]*([[:digit:]]*)/([[:digit:]])*.*'
+            if ! [[ $line =~ $PARSE_LINE_REGEX ]] ; then
                 echo "Error : failure to parse format of get deployment output : $line" >&2
                 exit 1
             fi
-            deployment_name=${BASH_REMATCH[1]}
-            ready_pods=${BASH_REMATCH[2]}
-            total_pods=${BASH_REMATCH[3]}
+            local deployment_name=${BASH_REMATCH[1]}
+            local ready_pods=${BASH_REMATCH[2]}
+            local total_pods=${BASH_REMATCH[3]}
             if [ $ready_pods -ne $total_pods ] ; then
                 rm -f $DEPLOYMENT_CHECK_OUTPUT_FILEPATH
                 return 1 # not all ready yet
@@ -280,15 +400,35 @@ function all_replicas_ready() {
     return 0 # all ready
 }
 
-# returns count as return value
-# 0 -> 0,0,0,0
-# 1 -> 0,0,1,1
-# 2 -> 0,1,1,2
-# 3 -> 0,1,2,3
+#######################################
+# Detects if all relevant deployments in the kubernetes cluster show all replicas "ready"
+# Gobals:
+#   DEPLOYMENT_TO_FULL_REPLICA_COUNT_MAP
+# Arguments:
+#   deployment_name
+#   replica_count_string from among {'none', 'almost_none', 'almost_full', 'full'}
+# Output:
+#   none
+# Side effects:
+#   none
+# Returns:
+#   the number of desired replicas for the specified deployment
+#    full -> none,almost_none,almost_full,full
+#     0 -> 0,0,0,0
+#     1 -> 0,0,1,1
+#     2 -> 0,1,1,2
+#     3 -> 0,1,2,3
+#     4 -> 0,1,3,4
+#     5 -> 0,1,4,5
+#######################################
 function replica_count_string_to_integer() {
-    deployment_name=$1
-    replica_count_string=$2
-    full_replica_count=${DEPLOYMENT_TO_FULL_REPLICA_COUNT_MAP[$deployment_name]}
+    local deployment_name=$1
+    local replica_count_string=$2
+    local full_replica_count=${DEPLOYMENT_TO_FULL_REPLICA_COUNT_MAP[$deployment_name]}
+    if [ "$full_replica_count" -gt 255 ] || [ "$full_replica_count" -lt 0 ] ; then
+        echo "Error : full replica count $full_replica_count for deployment $deployment_name is out of range [0,255]" >&2
+        exit 1
+    fi
     if [ "$replica_count_string" == "none" ] ; then
         return 0
     fi
@@ -313,46 +453,82 @@ function replica_count_string_to_integer() {
     return -1
 }
 
+#######################################
+# Scale all kuberenets deployments related to a color and wait for ready
+# Gobals:
+#   BLUE_DEPLOYMENT_LIST
+#   GREEN_DEPLOYMENT_LIST
+#   CLUSTER_KUBECONFIG
+#   REPLICA_READY_CHECK_MAX_CHECKCOUNT
+#   REPLICA_READY_CHECK_PAUSE_SECONDS
+# Arguments:
+#   deployment_name
+#   replica_count_string from among {'none', 'almost_none', 'almost_full', 'full'}
+# Output:
+#   none if successful, errors to stderr if encountered
+# Side effects:
+#   kubernetes cluster configuration changed, pods killed or launched
+#######################################
 function scale_deployment_to_N_replicas() {
-    DEPLOYMENT_COLOR=$1
-    NUM_REPLICAS=$2 # "none", "almost_none", "almost_full, or "full"
-    if [ $DEPLOYMENT_COLOR == 'blue' ] ; then
-        local pos=0
+    local deployment_color=$1
+    local num_replicas=$2 # "none", "almost_none", "almost_full, or "full"
+    # scale all deployments with kubectl
+    local deployment
+    local replica_count
+    local pos
+    if [ $deployment_color == 'blue' ] ; then
+        pos=0
         while [ "$pos" -lt "${#BLUE_DEPLOYMENT_LIST[@]}" ] ; do
             deployment="${BLUE_DEPLOYMENT_LIST[$pos]}"
-            replica_count_string_to_integer "$deployment" "$NUM_REPLICAS"
+            replica_count_string_to_integer "$deployment" "$num_replicas"
             replica_count=$?
             kubectl --kubeconfig $CLUSTER_KUBECONFIG scale deployment --replicas $replica_count "$deployment"
             pos=$(($pos+1))
         done
     else
-        if [ $DEPLOYMENT_COLOR == 'green' ] ; then
-            local pos=0
+        if [ $deployment_color == 'green' ] ; then
+            pos=0
             while [ "$pos" -lt "${#GREEN_DEPLOYMENT_LIST[@]}" ] ; do
                 deployment="${GREEN_DEPLOYMENT_LIST[$pos]}"
-                replica_count_string_to_integer "$deployment" "$NUM_REPLICAS"
+                replica_count_string_to_integer "$deployment" "$num_replicas"
                 replica_count=$?
                 kubectl --kubeconfig $CLUSTER_KUBECONFIG scale deployment --replicas $replica_count "$deployment"
                 pos=$(($pos+1))
             done
         else
-            echo "Error : invalid argument '$DEPLOYMENT_COLOR' passed to scale_deployment_to_N_replicas()" >&2
+            echo "Error : invalid argument '$deployment_color' passed to scale_deployment_to_N_replicas()" >&2
             exit 1
         fi
     fi
     # now wait for replicas to become ready
-    check_count=0
+    local check_count=0
     while [ $check_count -lt $REPLICA_READY_CHECK_MAX_CHECKCOUNT ] ; do
         sleep $REPLICA_READY_CHECK_PAUSE_SECONDS
-        if all_replicas_ready $DEPLOYMENT_COLOR ; then
+        if all_replicas_ready $deployment_color ; then
             return 0
         fi
         check_count=$(($check_count+1))
     done
-    echo "Error : scaling for '$DEPLOYMENT_COLOR' deployments failed to reach the ready state after $REPLICA_READY_CHECK_MAX_CHECKCOUNT iterations with a period of $REPLICA_READY_CHECK_PAUSE_SECONDS seconds. Exiting" >&2
+    echo "Error : scaling for '$deployment_color' deployments failed to reach the ready state after $REPLICA_READY_CHECK_MAX_CHECKCOUNT iterations with a period of $REPLICA_READY_CHECK_PAUSE_SECONDS seconds. Exiting" >&2
     exit 1
 }
 
+#######################################
+# predicate function : should cache warming phase occur under specified policy?
+# Gobals:
+#   none
+# Arguments:
+#   cache_warming_policy from among {'initial', 'studylist'}
+#   current_phase from among {'initial', 'study_list'}
+# Output:
+#   none
+# Side effects:
+#   none
+# Returns:
+#   0 when cache warming phase is necessary by policy, otherwise 1
+# Note:
+#   this function supports planned expansion of cache warming to new phases
+#######################################
 function cache_warming_stage_should_happen() {
     local cache_warming_policy="$1"
     local current_phase="$2"
@@ -377,9 +553,25 @@ function cache_warming_stage_should_happen() {
     esac
 }
 
+#######################################
+# make api requests to warm backend cache of a single pod - wait for resopnse only if asked to do so
+# Gobals:
+#   CLUSTER_KUBECONFIG
+#   CACHE_WARMING_USERNAME
+#   CACHE_WARMING_PASSWORD
+#   BASH_REMATCH (shell built-in global for RE processing)
+# Arguments:
+#   podname (target of curl requests)
+#   should_wait_for_response (value 'wait_for_response' causes wait, otherwise no wait)
+# Output:
+#   none
+# Side effects:
+#   pods receive http requests for study list, which launches response thread in replica
+#           persistence level caches are automatically populated by pods
+#######################################
 function run_cache_warming_study_query() {
-    podname="$1"
-    should_wait_for_response="$2"
+    local podname="$1"
+    local should_wait_for_response="$2"
     if [ "$should_wait_for_response" == "wait_for_response" ] ; then
         kubectl --kubeconfig "$CLUSTER_KUBECONFIG" exec "$podname" -- /bin/bash -c 'session_header=$(curl "http://localhost:8888/j_spring_security_check?j_username='"$CACHE_WARMING_USERNAME"'&j_password='"$CACHE_WARMING_PASSWORD"'" -I 2>/dev/null | grep "Set-Cookie") ; COOKIE_RE="Set-Cookie: ([[:graph:]]+);.*" ; [[ $session_header =~ $COOKIE_RE ]] ; header_value="Cookie: ${BASH_REMATCH[1]}" ; cacheoutfile="/tmp/cachewarmer.txt" ; cache_is_warm="no" ; attempts_remaining=4 ; while true ; do rm -f $cacheoutfile ; curl --fail --max-time 10 --connect-timeout 3 --header "$header_value" "http://localhost:8888/api/studies" > $cacheoutfile 2>/dev/null ; if grep -q mskimpact $cacheoutfile ; then cache_is_warm="yes" ; break ; fi ; if [ $attempts_remaining -eq 0 ] ; then break ; fi ; attempts_remaining=$(($attempts_remaining-1)) ; sleep 60 ; done ; curl --header "$header_value" "https://cbioportal.mskcc.org/j_spring_security_logout/" 2>/dev/null ; if [ $cache_is_warm == "yes" ] ; then echo "cache is warm" ; exit 0 ; fi ; echo "cache is cold" ; exit 1'
     else
@@ -387,16 +579,37 @@ function run_cache_warming_study_query() {
     fi
 }
 
+#######################################
+# perform multi(now 2)-phase cache warming based on per-deployment policies
+# Gobals:
+#   CLUSTER_KUBECONFIG
+#   BLUE_DEPLOYMENT_LIST
+#   GREEN_DEPLOYMENT_LIST
+#   DEPLOYMENT_TO_CACHE_WARMING_POLICY
+#   CACHE_WARMING_POD_LIST_FILEPATH
+#   CACHE_WARMING_POD_SUBLIST_FILEPATH
+# Arguments:
+#   DESTINATION_COLOR
+# Output:
+#   timestamped progress messages to stdout
+# Side effects:
+#   pods receive http requests for study list, which launches response thread in replica
+#           persistence level caches are automatically populated by pods
+#######################################
 function attempt_to_warm_caches_of_incoming_deployments() {
-    DESTINATION_COLOR=$1
+    local DESTINATION_COLOR=$1
     echo "attempting to warm caches"
     rm -f "$CACHE_WARMING_POD_LIST_FILEPATH"
     kubectl --kubeconfig "$CLUSTER_KUBECONFIG" get pods > "$CACHE_WARMING_POD_LIST_FILEPATH"
+    local deployment_name
+    local cache_warming_policy
+    local podname
+    local pos
     # initial stage of warming - make study list query without waiting for reply
     pos=0
     while [ $pos -lt ${#BLUE_DEPLOYMENT_LIST[@]} ] ; do
         # this code assumes that the blue deployment list length is equal to the green length
-        local deployment_name=${BLUE_DEPLOYMENT_LIST[$pos]}
+        deployment_name=${BLUE_DEPLOYMENT_LIST[$pos]}
         if [ $DESTINATION_COLOR == "green" ] ; then
             deployment_name=${GREEN_DEPLOYMENT_LIST[$pos]}
         fi
@@ -438,9 +651,115 @@ function attempt_to_warm_caches_of_incoming_deployments() {
     done
 }
 
+#######################################
+# modify an ingressroute yaml file to set all services connected to a route to the destination color
+# Gobals:
+#   YQ_BINARY 
+# Arguments:
+#   yaml filepath to file which should be updated
+#   destination color ('blue' or 'green')
+# Output:
+#   none if successful, errors to stderr if encountered
+# Side effects:
+#   file at the designated path is modified on the filesystem <servicebasename>-blue replaced with <servicebasename>-green or vice versa
+#######################################
+function rewrite_ingressroute_file_for_new_color() {
+    local ingress_yaml_filepath=$1
+    local DESTINATION_COLOR=$2
+    # get the full list of routes based on the "match" property
+    unset route_match_array
+    declare -a route_match_array
+    readarray -t route_match_array < <($YQ_BINARY "select(documentIndex == 0) | .spec.routes[].match" $ingress_yaml_filepath)
+    # rewrite each route's service to switch it to the destination color
+    local source_color='blue' # the other color which is not destination
+    if [ "$DESTINATION_COLOR" == "blue" ] ; then
+        source_color='green'
+    fi
+    local pos=0
+    while [ $pos -lt ${#route_match_array[*]} ] ; do
+        route_match="${route_match_array[$pos]}"
+        # get the service linked to the route match
+        IFS='' read -r existing_service_name < <($YQ_BINARY "select(documentIndex == 0) | .spec.routes[] | select(.match == \"$route_match\" ) | .services[].name" $ingress_yaml_filepath | head -n 1)
+        pos=$(($pos+1))
+        if [ -z $existing_service_name ] ; then
+            continue # skip cases where no service is defined for the route
+        fi
+        local service_without_color=${existing_service_name//"$source_color"}
+        local length_difference=$((${#existing_service_name}-${#service_without_color}))
+        if [ $length_difference -ne ${#source_color} ] ; then
+            continue # skip cases where zero or more than one instances of the color appear in the service name
+        fi
+        # overwrite the service name
+        local rewritten_service_name=${existing_service_name//$source_color/$DESTINATION_COLOR}
+        if ! "$YQ_BINARY" --inplace "(select(documentIndex == 0) | .spec.routes[] | select(.match == \"$route_match\") | .services[0].name) = \"$rewritten_service_name\"" "$ingress_yaml_filepath" ; then
+            echo "Error : failed to update service mapping for route match '$route_match' in $ingress_yaml_filepath" >&2
+            exit 1
+        fi
+    done
+    unset route_match_array
+}
+
+#######################################
+# modify an ingress yaml file to set a specified host's service to a specifie service
+# Gobals:
+#   YQ_BINARY 
+# Arguments:
+#   yaml filepath to file which should be updated
+#   name of host which will be updated with a new service
+#   name of service to which the updated host should route traffic
+# Output:
+#   none if successful, errors to stderr if encountered
+# Side effects:
+#   file at the designated path is modified on the filesystem
+#   process exit if error occurs
+#######################################
+function rewrite_ingress_file_for_new_host_service() {
+    local ingress_yaml_filepath=$1
+    local host=$2
+    local service=$3
+    if ! "$YQ_BINARY" --inplace "(.spec.rules[] | select(.host == \"$host\") | .http.paths[].backend.service.name) = \"$service\"" "$ingress_yaml_filepath" ; then
+        echo "Error : failed to update service mapping for host '$host' in $ingress_yaml_filepath" >&2
+        exit 1
+    fi
+    local rule_count
+    rule_count=$("$YQ_BINARY" "[.spec.rules[] | select(.host == \"$host\")] | length" "$ingress_yaml_filepath")
+    if [ "$rule_count" -eq 0 ]; then
+        echo "Error : expected to find host '$host' in $ingress_yaml_filepath" >&2
+        exit 1
+    fi
+    local name_count
+    name_count=$("$YQ_BINARY" "[.spec.rules[] | select(.host == \"$host\") | .http.paths[].backend.service.name] | length" "$ingress_yaml_filepath")
+    if [ "$name_count" -eq 0 ]; then
+        echo "Error : expected at least one service entry for host '$host' in $ingress_yaml_filepath" >&2
+        exit 1
+    fi
+    local mismatch_count
+    mismatch_count=$("$YQ_BINARY" "[.spec.rules[] | select(.host == \"$host\") | .http.paths[].backend.service.name | select(. != \"$service\")] | length" "$ingress_yaml_filepath")
+    if [ "$mismatch_count" -gt 0 ]; then
+        echo "Error : service name update for host '$host' did not complete as expected in $ingress_yaml_filepath" >&2
+        exit 1
+    fi
+}
+
+#######################################
+# modify all related ingress resources to route traffic to the services of the specified destination color
+# Gobals:
+#   YQ_BINARY 
+#   HOST_TO_SERVICE_MAP_BLUE
+#   HOST_TO_SERVICE_MAP_GREEN
+#   KS_K8S_DEPL_REPO_DIRPATH
+#   HOST_TO_INGRESS_YAML_FILEPATH_MAP
+#   HOST_TO_INGRESS_TYPE_MAP
+# Arguments:
+#   destination color ('blue' or 'green')
+# Output:
+#   none if successful, errors to stderr if encountered
+# Side effects:
+#   all related ingress resource yaml files are udpated appropriately to route traffic to the specified destination color
+#   the kubernetes cluster is reconfigured using "kubectl apply -f <file>" for all related ingress resource yaml files
+#######################################
 function switchover_ingress_rules_to_destination_database_deployment() {
     local DESTINATION_COLOR=$1
-    local ingress_yaml_filepath="$KS_K8S_DEPL_REPO_DIRPATH/$INGRESS_YAML_FILEPATH"
     local host_map_name="HOST_TO_SERVICE_MAP_BLUE"
 
     if [ "$DESTINATION_COLOR" == "green" ] ; then
@@ -457,40 +776,52 @@ function switchover_ingress_rules_to_destination_database_deployment() {
         exit 1
     fi
 
+    local ingress_yaml_filepath_relative
+    local ingress_yaml_filepath
+    local ingress_type
     local host
+    local escaped_host
+    local service
     for host in "${host_map_keys[@]}"; do
-        local escaped_host
-        escaped_host=$(printf '%q' "$host")
-        local service
-        eval "service=\${${host_map_name}[$escaped_host]}"
-        if ! "$YQ_BINARY" --inplace "(.spec.rules[] | select(.host == \"$host\") | .http.paths[].backend.service.name) = \"$service\"" "$ingress_yaml_filepath" ; then
-            echo "Error : failed to update service mapping for host '$host' in $ingress_yaml_filepath" >&2
-            exit 1
-        fi
-        local rule_count
-        rule_count=$("$YQ_BINARY" "[.spec.rules[] | select(.host == \"$host\")] | length" "$ingress_yaml_filepath")
-        if [ "$rule_count" -eq 0 ]; then
-            echo "Error : expected to find host '$host' in $ingress_yaml_filepath" >&2
-            exit 1
-        fi
-        local name_count
-        name_count=$("$YQ_BINARY" "[.spec.rules[] | select(.host == \"$host\") | .http.paths[].backend.service.name] | length" "$ingress_yaml_filepath")
-        if [ "$name_count" -eq 0 ]; then
-            echo "Error : expected at least one service entry for host '$host' in $ingress_yaml_filepath" >&2
-            exit 1
-        fi
-        local mismatch_count
-        mismatch_count=$("$YQ_BINARY" "[.spec.rules[] | select(.host == \"$host\") | .http.paths[].backend.service.name | select(. != \"$service\")] | length" "$ingress_yaml_filepath")
-        if [ "$mismatch_count" -gt 0 ]; then
-            echo "Error : service name update for host '$host' did not complete as expected in $ingress_yaml_filepath" >&2
-            exit 1
+        ingress_yaml_filepath_relative="${HOST_TO_INGRESS_YAML_FILEPATH_MAP[$host]}"
+        ingress_yaml_filepath="$KS_K8S_DEPL_REPO_DIRPATH/$ingress_yaml_filepath_relative"
+        ingress_type="${HOST_TO_INGRESS_TYPE_MAP[$host]}"
+        if [ "$ingress_type" == "ingressroute" ] ; then
+            rewrite_ingressroute_file_for_new_color "$ingress_yaml_filepath" "$DESTINATION_COLOR"
+        else
+            escaped_host=$(printf '%q' "$host")
+            eval "service=\${${host_map_name}[$escaped_host]}"
+            rewrite_ingress_file_for_new_host_service "$ingress_yaml_filepath" "$host" "$service"
         fi
     done
 
     echo "switching traffic over to the updated database deployment"
-    kubectl --kubeconfig $CLUSTER_KUBECONFIG apply -f "$ingress_yaml_filepath"
+    unset yaml_files_already_applied
+    declare -A yaml_files_already_applied
+    for ingress_yaml_filepath_relative in ${HOST_TO_INGRESS_YAML_FILEPATH_MAP[*]} ; do
+        if [ -z ${yaml_files_already_applied[$ingress_yaml_filepath_relative]} ] ; then
+            ingress_yaml_filepath="$KS_K8S_DEPL_REPO_DIRPATH/$ingress_yaml_filepath_relative"
+            if ! kubectl --kubeconfig $CLUSTER_KUBECONFIG apply -f "$ingress_yaml_filepath" ; then
+                echo "Warning : received non-zero exit status for command kubectl --kubeconfig $CLUSTER_KUBECONFIG apply -f $ingress_yaml_filepath"
+            fi
+            yaml_files_already_applied[$ingress_yaml_filepath_relative]="done"
+        fi
+    done
+    unset yaml_files_already_applied
 }
 
+#######################################
+# modify a deployment yaml file to set the count for replicas
+# Gobals:
+#   YQ_BINARY 
+# Arguments:
+#   yaml filepath to file which should be updated
+#   desired replica count
+# Output:
+#   none if successful, errors to stderr if encountered
+# Side effects:
+#   file at the designated path is modified on the filesystem
+#######################################
 function adjust_replica_count_in_deployment_yaml_file() {
     local yaml_filepath=$1
     local replica_count=$2
@@ -504,11 +835,27 @@ function adjust_replica_count_in_deployment_yaml_file() {
     if [ "$updated_value" != "$replica_count" ]; then
         echo "Warning : backend deployment has been scaled in the kubernetes cluster, but corresponding changes have not successfully been made to $yaml_filepath." >&2
         echo "          The repository is now out of sync and must be manually corrected, and the cause of the failure to update must be addressed in code." >&2
+        return
     fi
 }
 
+#######################################
+# modify all related deployment yaml files to have the appropriate count of replicas based on destination color
+# Gobals:
+#   KS_K8S_DEPL_REPO_DIRPATH
+#   BLUE_DEPLOYMENT_LIST
+#   GREEN_DEPLOYMENT_LIST
+#   DEPLOYMENT_TO_YAML_FILEPATH_MAP
+# Arguments:
+#   destination color ('blue' or 'green')
+# Output:
+#   none
+# Side effects:
+#   all related deployment yaml files are updated on the filesystem
+#######################################
 function adjust_replica_counts_in_deployment_yaml_files() {
-    local destination_color=$1
+    local DESTINATION_COLOR=$1
+    # the destination color will receive "full" replicas and the other will receive "none" replicas
     local blue_replica_count="none"
     local green_replica_count="none"
     if [ "$DESTINATION_COLOR" == "blue" ] ; then
@@ -517,6 +864,10 @@ function adjust_replica_counts_in_deployment_yaml_files() {
     if [ "$DESTINATION_COLOR" == "green" ] ; then
         green_replica_count="full"
     fi
+    local pos
+    local deployment
+    local yaml_filepath
+    local replicas_int
     pos=0
     while [ $pos -lt ${#BLUE_DEPLOYMENT_LIST[@]} ] ; do
         deployment="${BLUE_DEPLOYMENT_LIST[$pos]}"
@@ -537,8 +888,27 @@ function adjust_replica_counts_in_deployment_yaml_files() {
     done
 }
 
+#######################################
+# all involved yaml file changes (ingress, deployment, ...) are committed to a git changeset, which is pushed to the remote repo
+# Gobals:
+#   KS_K8S_DEPL_REPO_DIRPATH
+#   BLUE_DEPLOYMENT_LIST
+#   GREEN_DEPLOYMENT_LIST
+#   DEPLOYMENT_TO_YAML_FILEPATH_MAP
+#   HOST_TO_INGRESS_YAML_FILEPATH_MAP
+#   GIT_COMMIT_MSG 
+# Arguments:
+#   destination color ('blue' or 'green')
+# Output:
+#   none if successful, errors to stderr if encountered
+# Side effects:
+#   the local git repository clone is updated with all changes.
+#   the changes are pushed to github.
+#######################################
 function check_in_changes_to_kubernetes_into_github() {
-    echo "checking in configuration changes to github"
+    local pos
+    local deployment
+    local yaml_filepath
     pos=0
     while [ $pos -lt ${#BLUE_DEPLOYMENT_LIST[@]} ] ; do
         deployment=${BLUE_DEPLOYMENT_LIST[$pos]}
@@ -557,12 +927,13 @@ function check_in_changes_to_kubernetes_into_github() {
         fi
         pos=$(($pos+1))
     done
-    yaml_filepath="$INGRESS_YAML_FILEPATH"
-    if ! $GIT_BINARY -C $KS_K8S_DEPL_REPO_DIRPATH add "$yaml_filepath" >/dev/null 2>&1 ; then
-        echo "warning : failure when adding file $yaml_filepath to changeset" >&2
-    fi
-    date_string=$(date +%Y-%m-%d)
-    commit_message_string="$GIT_COMMIT_MSG $date_string"
+    for ingress_yaml_filepath_relative in ${HOST_TO_INGRESS_YAML_FILEPATH_MAP[*]} ; do
+        if ! $GIT_BINARY -C $KS_K8S_DEPL_REPO_DIRPATH add "$ingress_yaml_filepath_relative" >/dev/null 2>&1 ; then
+            echo "warning : failure when adding file $ingress_yaml_filepath_relative to changeset" >&2
+        fi
+    done
+    local date_string=$(date +%Y-%m-%d)
+    local commit_message_string="$GIT_COMMIT_MSG $date_string"
     if ! $GIT_BINARY -C $KS_K8S_DEPL_REPO_DIRPATH commit -m "$commit_message_string" >/dev/null 2>&1 ; then
         echo "warning : failure when committing changes to git repository clone" >&2
     fi
@@ -575,23 +946,50 @@ function check_in_changes_to_kubernetes_into_github() {
     return 0
 }
 
+#######################################
+# execute a staged switchover of the kubernetes cluster to the destination color and push changes to github repo
+# Gobals:
+#   SERVICE_ACCOUNT
+#   SYNCHRONIZE_USER_TABLES
+#   CLEAR_PERSISTENCE_CACHES_BLUE_FUNCTION
+#   CLEAR_PERSISTENCE_CACHES_GREEN_FUNCTION
+#   WARM_CACHES
+# Arguments:
+#   filepath to the datatbase managment tool properties file
+#   filepath to the datatbase database color swap properties file
+#   destination color ('blue' or 'green')
+# Output:
+#   progress messages as stages progress. errors to stderr if encountered
+# Side effects:
+#   the kubernetes cluster is gradually switched to deployments using the destination color database
+#   persistence caches are cleared appropriately during switchover
+#   warming of the persistence caches may be attempted in the destination color database deployments
+#   the destination color database is modified to add any new users who registered while the transfer was being prepared
+#   network traffic is switched to flow to the destination color deployments when ready
+#   the local git repository clone is updated with all changes.
+#   the changes are pushed to github.
+# Returns:
+#   0 if process runs to completion successfully, otherwise non-zero
+# Note:
+#   once the ingress traffic switch is going to happen, problems are reported but script completion is attempted despite errors
+#######################################
 function main() {
-    MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH=$1
-    COLOR_SWAP_CONFIG_FILEPATH=$2
-    DESTINATION_COLOR=$3
+    local MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH=$1
+    local COLOR_SWAP_CONFIG_FILEPATH=$2
+    local DESTINATION_COLOR=$3
 
     # phase : initialize environment and validate arguments and current state
     validate_arguments $@
-    if [ "$DESTINATION_COLOR" == "blue" ] ; then
-        SOURCE_COLOR="green"
-    else
-        SOURCE_COLOR="blue"
-    fi
     source /data/portal-cron/scripts/automation-environment.sh
     source /data/portal-cron/scripts/clear-persistence-cache-shell-functions.sh
+    source /data/portal-cron/scripts/color-config-parsing-functions.sh
     load_color_swap_config "$COLOR_SWAP_CONFIG_FILEPATH"
 
     echo "starting transfer-deployment-color.sh"
+    local SOURCE_COLOR="blue"
+    if [ "$DESTINATION_COLOR" == "blue" ] ; then
+        SOURCE_COLOR="green"
+    fi
     check_current_color_is $MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH $SOURCE_COLOR
     check_that_git_repo_clone_is_current
     /data/portal-cron/scripts/authenticate_service_account.sh "$SERVICE_ACCOUNT"
@@ -612,7 +1010,7 @@ function main() {
     fi
     if [ "$DESTINATION_COLOR" == "blue" ] ; then
         "$CLEAR_PERSISTENCE_CACHES_BLUE_FUNCTION" skip-slack
-    else 
+    else
         "$CLEAR_PERSISTENCE_CACHES_GREEN_FUNCTION" skip-slack
     fi
     # TODO program a smart wait for cache clearing to complete
@@ -624,7 +1022,7 @@ function main() {
     /data/portal-cron/scripts/set_update_process_state.sh "$MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH" complete
     if [ "$SOURCE_COLOR" == "blue" ] ; then
         "$CLEAR_PERSISTENCE_CACHES_BLUE_FUNCTION" send-slack
-    else 
+    else
         "$CLEAR_PERSISTENCE_CACHES_GREEN_FUNCTION" send-slack
     fi
 

--- a/import-scripts/verify-management-state.sh
+++ b/import-scripts/verify-management-state.sh
@@ -12,33 +12,29 @@
 
 declare -a BLUE_SERVICE_LIST=()
 declare -a GREEN_SERVICE_LIST=()
+declare -A HOST_TO_INGRESS_NAME_MAP=()
+declare -A HOST_TO_INGRESS_TYPE_MAP=()
 
-function read_scalar() {
-    local key="$1"
-    local value
-    value=$("$YQ_BINARY" -r "$key" "$COLOR_SWAP_CONFIG_FILEPATH")
-    if [ "$value" == "null" ] || [ -z "$value" ] ; then
-        echo "Error : missing required scalar '$key' in $COLOR_SWAP_CONFIG_FILEPATH" >&2
-        exit 1
-    fi
-    printf '%s\n' "$value"
-}
-
-function read_array() {
-    local dest_var="$1"
-    local path="$2"
-    local array_path="${path}[]"
-    local file="$COLOR_SWAP_CONFIG_FILEPATH"
-    local type=$("$YQ_BINARY" -r "$path | type" "$file")
-    if [ "$type" != "!!seq" ] ; then
-        echo "Error : expected array at '$path' in $file" >&2
-        exit 1
-    fi
-    unset "$dest_var"
-    declare -g -a "$dest_var"
-    readarray -t "$dest_var" < <("$YQ_BINARY" -r "$array_path" "$file")
-}
-
+#######################################
+# Load needed config properties into global variables
+# Gobals:
+#   COLOR_SWAP_CONFIG_FILEPATH 
+#   YQ_BINARY path to yq executable
+#   SERVICE_ACCOUNT the name of the service account selector for use with aws authentication
+#   CLUSTER_KUBECONFIG path to a .kube/config style function defining the kubectl cluster to interact with
+#   TEMP_DIR_PATH
+#   HOST_TO_INGRESS_NAME_MAP for each host connected to the database, the name of the ingress resource it uses
+#   HOST_TO_INGRESS_TYPE_MAP the type of each ingress resource mapped (either 'ingress' or 'ingressroute')
+#   BLUE_SERVICE_LIST an array holding all the blue deployment/service names connected to a database
+#   GREEN_SERVICE_LIST an array holding all the green deployment/service names connected to a database
+#   UPDATES_DISABLED when this is not 'false', verify-management-state.sh will exit early with a failure code
+# Arguments:
+#   none
+# Output:
+#   none, except for error messages to stderr
+# Side effects:
+#   a directory at the provided TEMP_DIR_PATH location will be created if not yet existing
+#######################################
 function load_color_swap_config() {
     if ! [ -f "$COLOR_SWAP_CONFIG_FILEPATH" ] || ! [ -r "$COLOR_SWAP_CONFIG_FILEPATH" ] ; then
         echo "Error : unable to read config file '$COLOR_SWAP_CONFIG_FILEPATH'" >&2
@@ -48,12 +44,14 @@ function load_color_swap_config() {
         echo "Error : unable to locate yq binary '$YQ_BINARY' required to read config file" >&2
         exit 1
     fi
-    SERVICE_ACCOUNT=$(read_scalar '.service_account')
-    CLUSTER_KUBECONFIG=$(read_scalar '.cluster_cfg')
-    TEMP_DIR_PATH=$(read_scalar '.temp_dir_path')
-    INGRESS_NAME=$(read_scalar '.ingress_name')
-    read_array BLUE_SERVICE_LIST '.blue_deployment_list'
-    read_array GREEN_SERVICE_LIST '.green_deployment_list'
+    SERVICE_ACCOUNT=$(read_scalar_from_yaml "$COLOR_SWAP_CONFIG_FILEPATH" '.service_account')
+    CLUSTER_KUBECONFIG=$(read_scalar_from_yaml "$COLOR_SWAP_CONFIG_FILEPATH" '.cluster_cfg')
+    TEMP_DIR_PATH=$(read_scalar_from_yaml "$COLOR_SWAP_CONFIG_FILEPATH" '.temp_dir_path')
+    read_map_from_yaml HOST_TO_INGRESS_NAME_MAP "$COLOR_SWAP_CONFIG_FILEPATH" '.host_to_ingress_name_map'
+    read_map_from_yaml HOST_TO_INGRESS_TYPE_MAP "$COLOR_SWAP_CONFIG_FILEPATH" '.host_to_ingress_type_map'
+    read_array_from_yaml BLUE_SERVICE_LIST "$COLOR_SWAP_CONFIG_FILEPATH" '.blue_deployment_list'
+    read_array_from_yaml GREEN_SERVICE_LIST "$COLOR_SWAP_CONFIG_FILEPATH" '.green_deployment_list'
+    UPDATES_DISABLED=$(read_scalar_from_yaml "$COLOR_SWAP_CONFIG_FILEPATH" '.updates_disabled')
     mkdir -p "$TEMP_DIR_PATH"
 }
 
@@ -62,6 +60,19 @@ function usage() {
     exit 1
 }
 
+#######################################
+# Exit with error if main() was called with inappropriate arguments
+# Gobals:
+#   none
+# Arguments:
+#   all arguements received by main(), 2 expected:
+#     MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH
+#     COLOR_SWAP_CONFIG_FILEPATH
+# Output:
+#   none, except for error messages to stderr
+# Side effects:
+#   process exit if argument count is wrong or file paths are not readable
+#######################################
 function validate_arguments() {
     if [ $# -ne "2" ] ; then
         usage
@@ -76,10 +87,21 @@ function validate_arguments() {
     fi
 }
 
+#######################################
+# Output current in-production color based on update management database content
+# Gobals:
+#   none
+# Arguments:
+#   MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH path to file with properties for accessing update management database
+# Output:
+#   'blue' or 'green' depending on database contents
+# Side effects:
+#   process exit if color cannot be determined
+#######################################
 function output_production_color_from_management_database() {
     MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH=$1
-    GET_DATABASE_CURRENTLY_IN_PRODUCTION_SCRIPT="/data/portal-cron/scripts/get_database_currently_in_production.sh"
-    CURRENT_DATABASE_OUTPUT_FILEPATH="$TEMP_DIR_PATH/get_current_database_output.txt"
+    local GET_DATABASE_CURRENTLY_IN_PRODUCTION_SCRIPT="/data/portal-cron/scripts/get_database_currently_in_production.sh"
+    local CURRENT_DATABASE_OUTPUT_FILEPATH="$TEMP_DIR_PATH/get_current_database_output.txt"
     rm -f "$CURRENT_DATABASE_OUTPUT_FILEPATH"
     if ! $GET_DATABASE_CURRENTLY_IN_PRODUCTION_SCRIPT $MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH > "$CURRENT_DATABASE_OUTPUT_FILEPATH"; then
         echo "Error during determination of the production database color from management database" >&2
@@ -102,10 +124,59 @@ function output_production_color_from_management_database() {
     echo "$current_database_color"
 }
 
+#######################################
+# Exit process if UPDATES_DISABLED is not 'false'
+# Gobals:
+#   UPDATES_DISABLED a property from the color swap config file
+# Arguments:
+#   none
+# Output:
+#   none, except for error messages to stderr
+# Side effects:
+#   none
+#######################################
+function exit_if_updates_are_disabled() {
+    if ! [ "$UPDATES_DISABLED" == "false" ] ; then
+        echo "Updates are currently disabled for this database. When the maintenance period is over, 'updates_disabled' will be set to false in the color swap config file." >&2
+        exit 1
+    fi
+}
+
+#######################################
+# Output current in-production color based on kubernetes cluster configuration
+# Gobals:
+#   SERVICE_ACCOUNT
+#   TEMP_DIR_PATH
+#   HOST_TO_INGRESS_NAME_MAP
+#   BLUE_SERVICE_LIST
+#   GREEN_SERVICE_LIST
+# Arguments:
+#   none
+# Output:
+#   'blue' or 'green' depending on output of all relevant ingress resources for database-linked portals
+# Side effects:
+#   process exit if color cannot be determined
+#######################################
 function output_production_color_from_kubernetes_cluster() {
+    # dump all ingress rules into common file
     /data/portal-cron/scripts/authenticate_service_account.sh "$SERVICE_ACCOUNT" >&2
-    ingress_output_filepath="$(mktemp "$TEMP_DIR_PATH/ingress_output_XXXXXXXX.yaml")"
-    kubectl --kubeconfig "$CLUSTER_KUBECONFIG" get ingress --output=yaml "$INGRESS_NAME" > "$ingress_output_filepath"
+    # all related ingress files are concatenated into a common file, which will later be scanned for blue or green service names
+    local ingress_output_filepath="$(mktemp "$TEMP_DIR_PATH/ingress_output_XXXXXXXX.yaml")"
+    rm -f "$ingress_output_filepath"
+    unset ingress_name_already_output
+    declare -A ingress_name_already_output
+    for host_name in ${!HOST_TO_INGRESS_NAME_MAP[*]} ; do
+        local ingress_name="${HOST_TO_INGRESS_NAME_MAP[$host_name]}"
+        local ingress_type="${HOST_TO_INGRESS_TYPE_MAP[$host_name]}"
+        if [ -z ${ingress_name_already_output[$ingress_name]} ] ; then
+            if !  kubectl --kubeconfig "$CLUSTER_KUBECONFIG" get $ingress_type --output=yaml "$ingress_name" >> "$ingress_output_filepath" ; then
+                echo "Warning : received non-zero exit status for command kubectl --kubeconfig $CLUSTER_KUBECONFIG get $ingress_type --output=yaml $ingress_name" >&2
+            fi
+            ingress_name_already_output[$ingress_name]="done"
+        fi
+    done
+    unset ingress_name_already_output
+    # examine services in dump file
     found_blue_services="false"
     found_green_services="false"
     pos=0
@@ -138,13 +209,25 @@ function output_production_color_from_kubernetes_cluster() {
         echo "error : neither blue nor green services are used in the ingress rules for the portal cluster" >&2
         exit 1
     fi
-    rm "$ingress_output_filepath"
+    rm -f "$ingress_output_filepath"
     return 0
 }
 
+#######################################
+# Compare production color from management database to color of kubernetes config and output report
+# Gobals:
+#   none
+# Arguments:
+#   actual_production_color from kubernetes ("blue" or "green")
+#   management_database_color ("blue" or "green")
+# Output:
+#   success if colors match or warning/failure if colors mismatch
+# Side effects:
+#   none
+#######################################
 function compare_state_and_report() {
-    actual_production_color="$1"
-    management_database_color="$2"
+    local actual_production_color="$1"
+    local management_database_color="$2"
     if ! [ "$management_database_color" == "$actual_production_color" ] ; then
         echo "Warning : management database state DOES NOT MATCH actual cluster ingress." >&2
         echo "              management database color is : $management_database_color" >&2
@@ -155,13 +238,25 @@ function compare_state_and_report() {
     return 0
 }
 
+#######################################
+# Verify that production color (based on update management database) matches production color (based on ingress rules in kubernetes cluster)
+# Gobals / Arguments:
+#   MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH path to database properties file to access the update management database
+#   COLOR_SWAP_CONFIG_FILEPATH path to color swap config file to access kubernetes cluster configuration resources
+# Output:
+#   success if colors match or warning/failure if colors mismatch. also fail quickly if UPDATES_DISABLED property is not false
+# Side effects:
+#   none
+#######################################
 function main() {
     MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH=$1
     COLOR_SWAP_CONFIG_FILEPATH=$2
     validate_arguments $@
     source /data/portal-cron/scripts/automation-environment.sh
+    source /data/portal-cron/scripts/color-config-parsing-functions.sh
     load_color_swap_config
     echo "starting verify-management-state.sh"
+    exit_if_updates_are_disabled
     actual_production_color=$(output_production_color_from_kubernetes_cluster)
     management_database_color=$(output_production_color_from_management_database $MANAGE_DATABASE_TOOL_PROPERTIES_FILEPATH)
     compare_state_and_report "$actual_production_color" "$management_database_color"


### PR DESCRIPTION
color swap config files changed : ingress name and path now specified per host
transfer-deployment-color and verify-management-state script parse ingress map from config and use map during per-host operations

The code changes are:

yaml parsing tool 'yq' was used in duplicated functions "read_scalar" "read_array" and "read_map" ... these functions are moved to a common function definition file, which now take an argument for the yaml filename to parse (rather than hardcoding an environment variable to hold the name)
maps are read instead of scalars for the ingress name(s) and ingress yaml filename(s)
in the transfer script
when checking if the cluster and git repo are in sync, all ingress yaml files are now looped through. Also, the function was changed to not exit at the first encountered error, but to detect all mismatches before returning with an error
when altering the ingress yaml files we now look up the relevant yaml file on a per-portal (i.e. host) basis, and then after yaml files are all updated, we loop through the full set of yaml files involved when doing kubectl apply -f <filename>  .  A check is made to only apply each config file one time.
when staging files for the git commit, we loop through all the ingress yaml filenames involved when doing git add

in the verify script
when getting the ingress rules from the kubernetes cluster to find out what color is currently in production, we loop through all relevant ingress names in use and concatenate the yaml into a common file (which later is searched using grep to look for green/blue service names)

in the transfer-deployment-color.sh
the per-host ingress files are visited and updated. The type of file (wither plain 'ingress' resource or 'ingressroute' resource') determined the kind of update received. ingressroute files mix services across different hosts, so these are updated using a "change all service references found which contain the source color string into the same service name with the source color string replaced with the destination color string" approach. Files are only transformed one time (sometimes multiple hosts are specified in a single ingress file ... but a single transformation of the file covers all hosts)