### PR TITLE
add script to set chosen environment variables

### DIFF
--- a/import-scripts/knowledgesystems-importer/automation-environment.sh
+++ b/import-scripts/knowledgesystems-importer/automation-environment.sh
@@ -1,55 +1,10 @@
 #!/bin/bash
 
 #######################
-# helper functions
-#######################
-
-function autodetect_and_export_java_home() {
-    # to locate JAVA_HOME, we can trace the path using the readlink program
-    # as an example, a recently deployed node had java installed here:
-    #    /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.342.b07-1.amzn2.0.1.x86_64
-    # and the /usr/bin/java symlink pointed (through two links) to:
-    #    /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.342.b07-1.amzn2.0.1.x86_64/jre/bin/java
-    # This function determines the (canonical) installation path from the java executable link
-    java_exec_path=$(which java)
-    if [ -z $java_exec_path ] ; then
-        echo "failed to set JAVA_HOME because no java executable can be found in PATH" >&2
-        return
-    fi
-    java_canonical_path=$(readlink -f $java_exec_path)
-    java_canonical_path_len=${#java_canonical_path}
-    RELATIVE_SUBPATH_CANIDATES="/jre/bin/java /bin/java"
-    unset matching_relative_subpath
-    for relative_subpath in $RELATIVE_SUBPATH_CANIDATES; do
-        suffix_regex="${relative_subpath}$"
-        if [[ $java_canonical_path =~ $suffix_regex ]]; then
-            matching_relative_subpath="$relative_subpath"
-            relative_subpath_len=${#relative_subpath}
-            break
-        fi
-    done
-    if [ -z $matching_relative_subpath ] ; then
-        echo "failed to set JAVA_HOME because the java executable $java_canonical_path did not end with a recognized subpath"
-        return
-    fi
-    stripped_java_path_len=$(($java_canonical_path_len - $relative_subpath_len))
-    stripped_java_path=${java_canonical_path:0:$stripped_java_path_len}
-    export JAVA_HOME="$stripped_java_path"
-}
-
-function export_java_home() {
-    if [[ -z $1 || "$1" == "AUTODETECT" ]] ; then
-        autodetect_and_export_java_home
-        return
-    fi
-    export JAVA_HOME="$1"
-}
-
-#######################
 # general paths/options for system executables
 #######################
-export_java_home "AUTODETECT"
 export JAVA_PROXY_ARGS="-Dhttp.proxyPort=8080 -Dhttp.nonProxyHosts=draco.mskcc.org|pidvudb1.mskcc.org|phcrdbd2.mskcc.org|dashi-dev.cbio.mskcc.org|pipelines.cbioportal.mskcc.org|localhost"
+export JAVA_HOME="/usr/lib/jdk-21.0.2"
 export JAVA_BINARY="$JAVA_HOME/bin/java"
 export PYTHON_BINARY=/usr/bin/python
 export PYTHON3_BINARY=/usr/bin/python3
@@ -57,7 +12,7 @@ export MAVEN_BINARY=/opt/apache-maven-3.8.6/bin/mvn
 export HG_BINARY=/usr/bin/hg
 export GIT_BINARY=/usr/bin/git
 export YQ_BINARY=/home/cbioportal_importer/bin/yq
-export PATH=$(bash --login -c 'echo $PATH')
+export PATH="/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/usr/local/bin:/opt/apache-maven-3.8.6/bin:/usr/local/go/bin:/home/cbioportal_importer/.local/bin:/home/cbioportal_importer/bin:/home/cbioportal_importer/tools/go/bin:/home/cbioportal_importer/tools/sling-cli:/home/cbioportal_importer/tools/clickhouse/bin"
 
 #######################
 # environment variables for top-level data repositories / code bases
@@ -192,3 +147,9 @@ export CRDB_FETCHER_PDX_HOME=$PDX_DATA_HOME/crdb_pdx_raw_data
 # environment variables used for oncokb annotator script
 #######################
 export ONCOKB_TOKEN_FILE=$PORTAL_HOME/pipelines-credentials/oncokb.token
+
+#######################
+# environment variables needed for openssl certificate verification with self-signed certificate
+#######################
+export SSL_CERT_FILE="/etc/pki/tls/certs/ca-bundle.crt" # needed to use the clickhouse CLI
+export GIT_SSL_CAINFO="/etc/pki/tls/certs/ca-bundle.crt" # needed to use git

--- a/import-scripts/pipelines_eks/automation-environment.sh
+++ b/import-scripts/pipelines_eks/automation-environment.sh
@@ -1,55 +1,8 @@
 #!/bin/bash
 
 #######################
-# helper functions
-#######################
-
-function autodetect_and_export_java_home() {
-    # to locate JAVA_HOME, we can trace the path using the readlink program
-    # as an example, a recently deployed node had java installed here:
-    #    /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.342.b07-1.amzn2.0.1.x86_64
-    # and the /usr/bin/java symlink pointed (through two links) to:
-    #    /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.342.b07-1.amzn2.0.1.x86_64/jre/bin/java
-    # This function determines the (canonical) installation path from the java executable link
-    java_exec_path=$(which java)
-    if [ -z $java_exec_path ] ; then
-        echo "failed to set JAVA_HOME because no java executable can be found in PATH" >&2
-        return
-    fi
-    java_canonical_path=$(readlink -f $java_exec_path)
-    java_canonical_path_len=${#java_canonical_path}
-    RELATIVE_SUBPATH_CANIDATES="/jre/bin/java /bin/java"
-    unset matching_relative_subpath
-    for relative_subpath in $RELATIVE_SUBPATH_CANIDATES; do
-        suffix_regex="${relative_subpath}$"
-        if [[ $java_canonical_path =~ $suffix_regex ]]; then
-            matching_relative_subpath="$relative_subpath"
-            relative_subpath_len=${#relative_subpath}
-            break
-        fi
-    done
-    if [ -z $matching_relative_subpath ] ; then
-        echo "failed to set JAVA_HOME because the java executable $java_canonical_path did not end with a recognized subpath"
-        return
-    fi
-    stripped_java_path_len=$(($java_canonical_path_len - $relative_subpath_len))
-    stripped_java_path=${java_canonical_path:0:$stripped_java_path_len}
-    export JAVA_HOME="$stripped_java_path"
-}
-
-function export_java_home() {
-    if [[ -z $1 || "$1" == "AUTODETECT" ]] ; then
-        autodetect_and_export_java_home
-        return
-    fi
-    export JAVA_HOME="$1"
-}
-
-#######################
 # general paths/options for system executables
 #######################
-# JAVA_HOME / JAVA_BINARY are set below explicitly now (rather than adjusting PATH)
-#export_java_home "AUTODETECT"
 export JAVA_PROXY_ARGS="-Dhttp.proxyHost=jxi2.mskcc.org -Dhttp.proxyPort=8080 -Dhttp.nonProxyHosts=draco.mskcc.org|pidvudb1.mskcc.org|phcrdbd2.mskcc.org|dashi-dev.cbio.mskcc.org|pipelines.cbioportal.mskcc.org|localhost"
 export JAVA_HOME="/usr/lib/jdk-21.0.2"
 export JAVA_BINARY="$JAVA_HOME/bin/java"
@@ -58,8 +11,8 @@ export PYTHON3_BINARY=/usr/bin/python3
 export MAVEN_BINARY=/opt/apache-maven-3.8.3/bin/mvn
 export HG_BINARY=/usr/bin/hg
 export GIT_BINARY=/usr/bin/git
-export YQ_BINARY=/usr/local/bin/yq
-export PATH=$(bash --login -c 'echo $PATH')
+export YQ_BINARY=/home/cbioportal_importer/bin/yq
+export PATH="/usr/local/sbin:/usr/sbin:/usr/local/bin:/usr/bin:/bin:/opt/apache-maven-3.8.3/bin:/usr/local/go/bin:/home/cbioportal_importer/.local/bin:/home/cbioportal_importer/bin:/home/cbioportal_importer/tools/go/bin:/home/cbioportal_importer/tools/sling-cli:/home/cbioportal_importer/tools/clickhouse/bin"
 
 #######################
 # environment variables for top-level data repositories / code bases
@@ -85,10 +38,10 @@ export AWS_SSL_TRUSTSTORE_PASSWORD_FILE=$PORTAL_HOME/pipelines-credentials/AwsSs
 export GMAIL_CREDS_FILE=$PORTAL_HOME/pipelines-credentials/gmail.credentials
 export MAIL_SMTP_SERVER=$PORTAL_HOME/pipelines-credentials/mail.smtp.server
 export PUBLIC_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/public-eks-config
-#export PUBLIC_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/public-cluster-kubeconfig
-#export PUBLICARGOCD_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/publicargocd-cluster-kubeconfig
+export PUBLIC_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/public-cluster-kubeconfig
+export PUBLICARGOCD_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/publicargocd-cluster-kubeconfig
 export EKS_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/eks-cluster-kubeconfig
-#export EKSARGOCD_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/eksargocd-cluster-kubeconfig
+export EKSARGOCD_CLUSTER_KUBECONFIG=$PORTAL_HOME/pipelines-credentials/eksargocd-cluster-kubeconfig
 export SLACK_URL_FILE=$PORTAL_HOME/pipelines-credentials/slack.url
 
 #######################
@@ -210,3 +163,9 @@ export ONCOKB_TOKEN_FILE=$PORTAL_HOME/pipelines-credentials/oncokb.token
 export AZ_SFTP_USER_FILE=$PORTAL_HOME/pipelines-credentials/astrazeneca_sftp.user
 export AZ_SERVICE_ENDPOINT_FILE=$PORTAL_HOME/pipelines-credentials/astrazeneca_sftp.service_endpoint
 export DATABRICKS_CREDS_FILE=$PORTAL_HOME/pipelines-credentials/databricks.credentials
+
+#######################
+# environment variables needed for openssl certificate verification with self-signed certificate
+#######################
+export SSL_CERT_FILE="/etc/pki/tls/certs/ca-bundle.crt" # needed to use the clickhouse CLI
+export GIT_SSL_CAINFO="/etc/pki/tls/certs/ca-bundle.crt" # needed to use git

--- a/import-scripts/set-environment-vars-from-automation-script.sh
+++ b/import-scripts/set-environment-vars-from-automation-script.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# file scope variables
+THIS_SCRIPT_FILEPATH="/data/portal-cron/scripts/set-environment-vars-from-automation-script.sh"
+unset user_specified_parameter_names
+declare -a user_specified_parameter_names
+
+function script_was_directly_executed() {
+    [ "$0" == "$THIS_SCRIPT_FILEPATH" ]
+}
+
+function output_you_must_source_warning() {
+    echo "this script fails to function when you directly execute it as a new process."
+    echo "Instead you must use bash's 'source' or '.' to alter your current environment."
+    echo "try :"
+    echo "  source $THIS_SCRIPT_FILEPATH VARNAME1 VARNAME2 ... (or 'all')"
+}
+
+function set_user_selections() {
+    while [ $# -gt 0 ] ; do
+        user_specified_parameter_names+=("$1")
+        shift
+    done
+}
+
+function expression_contains_subshell() {
+    [[ "$1" == *\$\(* ]] || [[ "$1" == *\`* ]]
+}
+
+function should_set_variable_with_name() {
+    local varname=$1
+    if [ ${user_specified_parameter_names[0]} == "all" ] ; then
+        return 0
+    fi
+    local pos=0
+    while [ $pos -lt ${#user_specified_parameter_names[*]} ] ; do
+        if [ "${user_specified_parameter_names[$pos]}" == "$varname" ] ; then
+            return 0
+        fi
+        pos=$(($pos+1))
+    done
+    return 1
+}
+
+function find_and_source_simple_environment_variable_settings() {
+    local AUTOMATION_ENVIRONMENT_SCRIPT="/data/portal-cron/scripts/automation-environment.sh"
+    if ! [ -r "$AUTOMATION_ENVIRONMENT_SCRIPT" ] ; then
+        return 0 # no script found
+    fi
+    while IFS= read -r line; do
+        local SIMPLE_ENV_ASSIGN_REGEX='^export[[:space:]]*([[:alnum:]_]*)[[:space:]]*=[[:space:]]*(.*)'
+        if ! [[ "$line" =~ $SIMPLE_ENV_ASSIGN_REGEX ]] ; then
+            continue # skip non-simple or indented assignments
+        fi
+        local varname="${BASH_REMATCH[1]}"
+        local right_hand_side="${BASH_REMATCH[2]}"
+        if ! should_set_variable_with_name "$varname" ; then
+            continue # skip variables user does not want
+        fi
+        if expression_contains_subshell "$right_hand_side" ; then
+            continue
+        fi
+        export $varname="$(eval "echo $right_hand_side")"
+    done < "$AUTOMATION_ENVIRONMENT_SCRIPT"
+    return 0
+}
+
+function cleanup_file_scope() {
+    unset -f script_was_directly_executed
+    unset -f output_you_must_source_warning
+    unset -f set_user_selections
+    unset -f expression_contains_subshell
+    unset -f should_set_variable_with_name
+    unset -f find_and_source_simple_environment_variable_settings
+    unset -f main
+    unset -f cleanup_file_scope
+    unset THIS_SCRIPT_FILEPATH
+    unset user_specified_parameter_names
+}
+
+function main() {
+    if script_was_directly_executed ; then
+        output_you_must_source_warning
+        return 1
+    fi
+    set_user_selections $@
+    find_and_source_simple_environment_variable_settings
+}
+
+if main $@ ; then
+    echo "done"
+    cleanup_file_scope
+    [ 0 -eq 0 ] # generate zero exit status without using variables
+else
+    echo "error detected - check environment"
+    cleanup_file_scope
+    [ 0 -eq 1 ] # generate non-zero exit status without using variables
+fi


### PR DESCRIPTION
This is a workaround which will set chosen environment variables defined in automation-environment.sh

Why : some variables are needed for command line use, but when the automation-environment.sh is sourced from the .bash_profile login script, it winds up in an infinite loop because the automation-environment.sh script kicks off a subshell (which re-calls .bash_profile).

Using this script users can select the variables they want to set (perhaps automatically on login) or can create simple functions for setting the variables they want, such as with this (from the current .bash_profile):

```
function set_ssl_vars() {
    source /data/portal-cron/scripts/set-environment-vars-from-automation-script.sh SSL_CERT_FILE GIT_SSL_CAINFO
}
function set_auto_vars() {
    source /data/portal-cron/scripts/automation-environment.sh
}
echo "type 'set_ssl_vars' to enable use of clickhouse client and git at the command line"
echo "type 'set_auto_vars' to source the entire automation-environment.sh script"

```