### PR TITLE
Standardize comments field in mutation files

### DIFF
--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataProcessor.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataProcessor.java
@@ -138,6 +138,8 @@ public class CVRMutationDataProcessor implements ItemProcessor<AnnotatedRecord, 
             case "T_ALT_COUNT": return record.getT_ALT_COUNT();
             case "N_REF_COUNT": return record.getN_REF_COUNT();
             case "N_ALT_COUNT": return record.getN_ALT_COUNT();
+            // COMMENTS: sensitive free-text may arrive from the API; emit empty for staging TSV output.
+            case "COMMENTS": return "";
             default:
                 return record.getAdditionalProperties().getOrDefault(field, "");
         }

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
@@ -118,8 +118,16 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                 throw new ItemStreamException(e);
             }
         }
-        // filter out non-uppercase COMMENTS variants; keep only uppercase COMMENTS if present
-        header.removeIf(field -> field.equalsIgnoreCase("COMMENTS") && !field.equals("COMMENTS"));
+        // Remove case-variant duplicates of all column names, keeping first occurrence
+        Set<String> seenLowercase = new HashSet<>();
+        header.removeIf(field -> {
+            String lowercase = field.toLowerCase();
+            if (seenLowercase.contains(lowercase)) {
+                return true; // Remove if we've already seen this field in a different case
+            }
+            seenLowercase.add(lowercase);
+            return false;
+        });
         // add header and filename to write to for writer
         ec.put("mutationHeader", new ArrayList(header));
         ec.put("mafFilename", CVRUtilities.MUTATION_FILE);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRMutationDataReader.java
@@ -118,6 +118,8 @@ public class CVRMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                 throw new ItemStreamException(e);
             }
         }
+        // filter out non-uppercase COMMENTS variants; keep only uppercase COMMENTS if present
+        header.removeIf(field -> field.equalsIgnoreCase("COMMENTS") && !field.equals("COMMENTS"));
         // add header and filename to write to for writer
         ec.put("mutationHeader", new ArrayList(header));
         ec.put("mafFilename", CVRUtilities.MUTATION_FILE);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRNonSignedoutMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRNonSignedoutMutationDataReader.java
@@ -114,6 +114,8 @@ public class CVRNonSignedoutMutationDataReader implements ItemStreamReader<Annot
                 throw new ItemStreamException(e);
             }
         }
+        // filter out non-uppercase COMMENTS variants; keep only uppercase COMMENTS if present
+        header.removeIf(field -> field.equalsIgnoreCase("COMMENTS") && !field.equals("COMMENTS"));
         // add header and filename to write to for writer
         ec.put("mutationHeader", new ArrayList(header));
         ec.put("mafFilename", CVRUtilities.NONSIGNEDOUT_MUTATION_FILE);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRNonSignedoutMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/CVRNonSignedoutMutationDataReader.java
@@ -114,8 +114,16 @@ public class CVRNonSignedoutMutationDataReader implements ItemStreamReader<Annot
                 throw new ItemStreamException(e);
             }
         }
-        // filter out non-uppercase COMMENTS variants; keep only uppercase COMMENTS if present
-        header.removeIf(field -> field.equalsIgnoreCase("COMMENTS") && !field.equals("COMMENTS"));
+        // Remove case-variant duplicates of all column names, keeping first occurrence
+        Set<String> seenLowercase = new HashSet<>();
+        header.removeIf(field -> {
+            String lowercase = field.toLowerCase();
+            if (seenLowercase.contains(lowercase)) {
+                return true; // Remove if we've already seen this field in a different case
+            }
+            seenLowercase.add(lowercase);
+            return false;
+        });
         // add header and filename to write to for writer
         ec.put("mutationHeader", new ArrayList(header));
         ec.put("mafFilename", CVRUtilities.NONSIGNEDOUT_MUTATION_FILE);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/GMLMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/GMLMutationDataReader.java
@@ -116,8 +116,16 @@ public class GMLMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                 throw new ItemStreamException(e);
             }
         }
-        // filter out non-uppercase COMMENTS variants; keep only uppercase COMMENTS if present
-        header.removeIf(field -> field.equalsIgnoreCase("COMMENTS") && !field.equals("COMMENTS"));
+        // Remove case-variant duplicates of all column names, keeping first occurrence
+        Set<String> seenLowercase = new HashSet<>();
+        header.removeIf(field -> {
+            String lowercase = field.toLowerCase();
+            if (seenLowercase.contains(lowercase)) {
+                return true; // Remove if we've already seen this field in a different case
+            }
+            seenLowercase.add(lowercase);
+            return false;
+        });
         // add header and filename to write to for writer
         ec.put("mutationHeader", new ArrayList(header));
         ec.put("mafFilename", CVRUtilities.MUTATION_FILE);

--- a/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/GMLMutationDataReader.java
+++ b/cvr/src/main/java/org/cbioportal/cmo/pipelines/cvr/mutation/GMLMutationDataReader.java
@@ -116,6 +116,8 @@ public class GMLMutationDataReader implements ItemStreamReader<AnnotatedRecord> 
                 throw new ItemStreamException(e);
             }
         }
+        // filter out non-uppercase COMMENTS variants; keep only uppercase COMMENTS if present
+        header.removeIf(field -> field.equalsIgnoreCase("COMMENTS") && !field.equals("COMMENTS"));
         // add header and filename to write to for writer
         ec.put("mutationHeader", new ArrayList(header));
         ec.put("mafFilename", CVRUtilities.MUTATION_FILE);

--- a/import-scripts/merge.py
+++ b/import-scripts/merge.py
@@ -82,6 +82,7 @@ CLINICAL_SAMPLE_META_PATTERN = 'meta_clinical_sample.txt'
 # Cleared on every merge row so REDCap/other cohort files cannot repopulate free-text after CVR emits blanks.
 CLINICAL_SAMPLE_SENSITIVE_TEXT_COLUMNS = frozenset(['SO_COMMENTS', 'MSI_COMMENT'])
 SV_SENSITIVE_TEXT_COLUMNS = frozenset(['Comments'])
+MAF_SENSITIVE_TEXT_COLUMNS = frozenset(['COMMENTS'])
 
 GENE_MATRIX_FILE_PATTERN = 'data_gene_matrix.txt'
 GENE_MATRIX_META_PATTERN = 'meta_gene_matrix.txt'
@@ -524,6 +525,10 @@ def normal_row(line, header, file_type=None):
     elif file_type == SV_META_PATTERN:
         for index, attribute in enumerate(header):
             if attribute in SV_SENSITIVE_TEXT_COLUMNS:
+                row[index] = ''
+    elif file_type == MUTATION_META_PATTERN:
+        for index, attribute in enumerate(header):
+            if attribute in MAF_SENSITIVE_TEXT_COLUMNS:
                 row[index] = ''
 
     return row


### PR DESCRIPTION
For all mutation files:
- Remove case-variant duplicates of all column names in mutation files, keeping first occurrence
- Set the value of "COMMENTS" to an empty string to avoid PHI leaks