### PR TITLE
halt/fail dmp imports on a git push failure

### DIFF
--- a/cvr/pom.xml
+++ b/cvr/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.github.mskcc</groupId>
       <artifactId>smile-messaging-java</artifactId>
-      <version>1.3.1.RELEASE</version>
+      <version>2.1.2.RELEASE</version>
       <exclusions>
         <exclusion>
           <groupId>ch.qos.logback</groupId>

--- a/import-scripts/fetch-and-import-dmp-data-wrapper.sh
+++ b/import-scripts/fetch-and-import-dmp-data-wrapper.sh
@@ -68,15 +68,18 @@ function output_whether_preimport_steps_successfully_completed() {
         # Launch the preimport setup script as a background process. This runs for about 2 hours and can run in parallel with fetches.
         rm "$MSK_PREIMPORT_STEPS_STATUS_FILEPATH"
         nohup "$MSK_PREIMPORT_STEPS_SCRIPT_FILEPATH" "$MSK_PREIMPORT_STEPS_STATUS_FILEPATH" > $MSK_PREIMPORT_STEPS_OUTPUT_FILEPATH 2>&1 &
+        fetch_dmp_data_fail=0
         if [[ -z "$SKIP_OVER_ALL_DMP_COHORT_PROCESSING" || "$SKIP_OVER_ALL_DMP_COHORT_PROCESSING" == 0 ]] ; then
             date
             echo executing fetch-dmp-data-for-import.sh
             oldwd=$(pwd)
             cd $PORTAL_HOME/tmp/separate_working_directory_for_dmp
-            $PORTAL_HOME/scripts/fetch-dmp-data-for-import.sh
+            if ! $PORTAL_HOME/scripts/fetch-dmp-data-for-import.sh ; then
+                fetch_dmp_data_fail=1
+            fi
             databases_are_prepared_for_import=$(output_whether_preimport_steps_successfully_completed)
             IMPORT_FAIL=0
-            if [ "$databases_are_prepared_for_import" == "yes" ] ; then
+            if [ "$fetch_dmp_data_fail" -eq 0 ] && [ "$databases_are_prepared_for_import" == "yes" ] ; then
                 echo "executing import-dmp-impact-data.sh"
                 $PORTAL_HOME/scripts/import-dmp-impact-data.sh
                 if [ $? -ne 0 ] ; then IMPORT_FAIL=1 ; fi

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -59,7 +59,15 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     DROP_DEAD_INSTANT_END_TO_END=$(date --date="+18hours" -Iseconds)
 
     # -----------------------------------------------------------------------------------------------------------
+    # RESET DMP CLONE TO HEAD OF ORIGIN
+
+    echo $(date)
+    echo "resetting repository $PORTAL_DATA_HOME/dmp to discard any unpushed changesets from clone"
+    bash $PORTAL_HOME/scripts/datasource-repo-cleanup.sh $DMP_DATA_HOME
+
+    # -----------------------------------------------------------------------------------------------------------
     # START DMP DATA FETCHING
+
     echo $(date)
 
     if [[ -d "$MSK_DMP_TMPDIR" && "$MSK_DMP_TMPDIR" != "/" ]] ; then
@@ -1385,5 +1393,15 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     if [ $LYMPHOMA_SUPER_COHORT_SUBSET_FAIL -gt 0 ] ; then
         echo -e "Sending email $EMAIL_BODY"
         echo -e "$EMAIL_BODY" | mail -s "LYMPHOMASUPERCOHORT Subset Failure: Study will not be updated." $PIPELINES_EMAIL_LIST
+    fi
+    if [ "$GIT_PUSH_FAIL" -ne 0 ] ; then
+        # a failure status is sent to the wrapper script here, so:
+        #     * the import-dmp-impact-data.sh script will not be executed
+        #     * changes were pushed to the s3 bucket today, but will not be "used" today .. and new samples will be re-fetched tomorrow
+        #     * only one git changeset is pushed each day, and push failed, so we have added one unpushed changeset to the head of our local clone
+        #         so we will (tomorrow) discard that changeset at the start of the execution of this script by calling datasource-repo-cleanup.sh
+        exit $GIT_PUSH_FAIL
+    else
+        exit 0
     fi
 ) {my_flock_fd}>$MY_FLOCK_FILEPATH


### PR DESCRIPTION
If a git push does not complete successfully, we do not have a good basis for later on doing a git reset/purge to clean the repository followed by a s3 push (with delete) to clean up the s3 bucket as part of import-dmp-impact-data.sh