### PR TITLE
fix problem with nonsignedout file split

### DIFF
--- a/import-scripts/import-dmp-impact-data.sh
+++ b/import-scripts/import-dmp-impact-data.sh
@@ -477,6 +477,14 @@ echo $(date)
 echo "Cleaning up any untracked files in $PORTAL_DATA_HOME/dmp..."
 bash $PORTAL_HOME/scripts/datasource-repo-cleanup.sh $DMP_DATA_HOME
 
+echo "purging split parts of nonsignedout_mutations before s3 upload"
+find -L "$DMP_DATA_HOME" -name "data_nonsignedout_mutations.txt_part[12]forcat" -delete
+
+echo "Restoring the cleaned up nonsignedout mutation files to $portal_data_home/dmp before s3 upload"
+if ! restoreNonsignedoutMutationFilesForDMP ; then
+    echo "Error restoring nonsignedout mutation files before S3 upload" >&2
+fi
+
 # Convert data_CNA.txt to narrow format
 # Copy this to S3, then remove the file
 $PORTAL_HOME/scripts/convert_cna_to_narrow_py3.py "$MSK_SOLID_HEME_DATA_HOME/data_CNA.txt" "$MSK_SOLID_HEME_DATA_HOME/data_CNA_narrow.txt"
@@ -488,5 +496,8 @@ uploadToS3OrSendFailureMessage "$DMP_DATA_HOME" "" "mskimpact-databricks"
 
 # now remove the narrow format data cna file we just created
 rm "$MSK_SOLID_HEME_DATA_HOME/data_CNA_narrow.txt"
+
+# leave the full sized data_nonsignedout_mutations.txt files in place even though they are not checked into github 
+# they will be reset when the next cycle begins
 
 exit $(( DB_VERSION_FAIL | IMPORT_FAIL_MSKSOLIDHEME | IMPORT_FAIL_ARCHER | IMPORT_FAIL_KINGS | IMPORT_FAIL_LEHIGH | IMPORT_FAIL_QUEENS | IMPORT_FAIL_MCI | IMPORT_FAIL_HARTFORD | IMPORT_FAIL_RALPHLAUREN | IMPORT_FAIL_RIKENGENESISJAPAN | IMPORT_FAIL_MSKIMPACT_PED | IMPORT_FAIL_SCLC_MSKIMPACT | IMPORT_FAIL_LYMPHOMA ))


### PR DESCRIPTION
full size nonsignedout files must be backed up and restored for repo push / clean

backup call to backupNonsignedoutMutationFilesForDMP is already in place in fetch-dmp-impact-data.sh script. This adds the restore functionality to the import script before the S3 push