### PR TITLE
Fix biobank clinical merge when ALIQUOT_STATUS already exists

### DIFF
--- a/import-scripts/combine_files_py3.py
+++ b/import-scripts/combine_files_py3.py
@@ -40,7 +40,24 @@ def write_tsv(df, path, **opts):
     )
 
 
-def combine_files(input_files, output_file, sep="\t", columns=None, merge_type="inner", drop_na=False):
+def combine_files(
+    input_files,
+    output_file,
+    sep="\t",
+    columns=None,
+    merge_type="inner",
+    drop_na=False,
+    prefer_right_columns=False,
+):
+    """Merge tabular files. When prefer_right_columns is True and join keys are
+    given (-c), overlapping non-key columns use values from later files instead
+    of pandas ALIQUOT_STATUS_x / ALIQUOT_STATUS_y suffix columns.
+
+    TODO: prefer_right_columns may be the right default for all callers, but
+    other uses of this script (timeline merges, age-at-seq, Sophia) have never
+    hit overlapping column names before biobank. Audit those call sites before
+    making this the default behavior.
+    """
     data_frames = []
     for file in input_files:
         # Determine which line to start reading from
@@ -63,9 +80,15 @@ def combine_files(input_files, output_file, sep="\t", columns=None, merge_type="
         )
         data_frames.append(df)
 
-    df_merged = reduce(
-        lambda left, right: pd.merge(left, right, on=columns, how=merge_type), data_frames
-    )
+    def merge_pair(left, right):
+        if prefer_right_columns and columns is not None:
+            join_cols = columns if isinstance(columns, list) else [columns]
+            overlap = (set(left.columns) & set(right.columns)) - set(join_cols)
+            if overlap:
+                left = left.drop(columns=list(overlap))
+        return pd.merge(left, right, on=columns, how=merge_type)
+
+    df_merged = reduce(merge_pair, data_frames)
 
     # Drop rows with blank/NA values if specified
     if drop_na:
@@ -136,6 +159,18 @@ def main():
         default=False,
         help="Whether to drop rows with empty/NA values",
     )
+    parser.add_argument(
+        "-p",
+        "--prefer-right-columns",
+        dest="prefer_right_columns",
+        action="store_true",
+        default=False,
+        help=(
+            "When joining on -c keys, overlapping non-key columns keep values "
+            "from later input files (avoids pandas _x/_y suffix columns). "
+            "Opt-in only; see combine_files() TODO before changing the default."
+        ),
+    )
 
     args = parser.parse_args()
     input_files = args.input_files
@@ -144,6 +179,7 @@ def main():
     columns = args.columns
     merge_type = args.merge_type
     drop_na = args.drop_na
+    prefer_right_columns = args.prefer_right_columns
 
     # Check that the input files exist
     for file in input_files:
@@ -152,7 +188,15 @@ def main():
             parser.print_help()
 
     # Combine the files
-    combine_files(input_files, output_file, sep=sep, columns=columns, merge_type=merge_type, drop_na=drop_na)
+    combine_files(
+        input_files,
+        output_file,
+        sep=sep,
+        columns=columns,
+        merge_type=merge_type,
+        drop_na=drop_na,
+        prefer_right_columns=prefer_right_columns,
+    )
 
 
 if __name__ == "__main__":

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -24,7 +24,14 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         local merged_clinical_file="$study_data_home/data_clinical_patient_merged.txt"
 
         if [ -f "$biobank_clinical_file" ]; then
-            $PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$input_clinical_file" "$biobank_clinical_file" -o "$merged_clinical_file" -c "PATIENT_ID" -m left
+            # -p / --prefer-right-columns: data_clinical_patient.txt may already
+            # contain ALIQUOT_STATUS from a prior S3 round-trip. Without -p,
+            # pandas emits ALIQUOT_STATUS_x and ALIQUOT_STATUS_y instead of one
+            # column with fresh biobank values.
+            # TODO: prefer-right-columns may be right for all combine_files_py3
+            # callers, but other merges have never had overlapping column names
+            # before biobank; audit before making -p the default.
+            $PYTHON3_BINARY $PORTAL_HOME/scripts/combine_files_py3.py -i "$input_clinical_file" "$biobank_clinical_file" -o "$merged_clinical_file" -c "PATIENT_ID" -m left -p
             if [ $? -gt 0 ]; then
                 echo "`date`: Warning: failed to merge biobank patient clinical data for ${study_data_home}; skipping biobank clinical merge for this import."
                 rm -f "$merged_clinical_file"

--- a/import-scripts/test-py3/resources/combine_files/biobank_clinical/both_overlap/biobank_clinical.txt
+++ b/import-scripts/test-py3/resources/combine_files/biobank_clinical/both_overlap/biobank_clinical.txt
@@ -1,0 +1,3 @@
+PATIENT_ID	ALIQUOT_STATUS
+P-001	Collected in biobank and likely available
+P-002	Not collected in biobank

--- a/import-scripts/test-py3/resources/combine_files/biobank_clinical/both_overlap/clinical_patient.txt
+++ b/import-scripts/test-py3/resources/combine_files/biobank_clinical/both_overlap/clinical_patient.txt
@@ -1,0 +1,3 @@
+PATIENT_ID	OTHER_FIELD	ALIQUOT_STATUS
+P-001	old-value-1	stale-status-1
+P-002	old-value-2	stale-status-2

--- a/import-scripts/test-py3/resources/combine_files/biobank_clinical/both_overlap/expected.txt
+++ b/import-scripts/test-py3/resources/combine_files/biobank_clinical/both_overlap/expected.txt
@@ -1,0 +1,3 @@
+PATIENT_ID	OTHER_FIELD	ALIQUOT_STATUS
+P-001	old-value-1	Collected in biobank and likely available
+P-002	old-value-2	Not collected in biobank

--- a/import-scripts/test-py3/resources/combine_files/biobank_clinical/both_overlap/expected_without_prefer_right.txt
+++ b/import-scripts/test-py3/resources/combine_files/biobank_clinical/both_overlap/expected_without_prefer_right.txt
@@ -1,0 +1,3 @@
+PATIENT_ID	OTHER_FIELD	ALIQUOT_STATUS_x	ALIQUOT_STATUS_y
+P-001	old-value-1	stale-status-1	Collected in biobank and likely available
+P-002	old-value-2	stale-status-2	Not collected in biobank

--- a/import-scripts/test-py3/resources/combine_files/biobank_clinical/left_only/biobank_clinical.txt
+++ b/import-scripts/test-py3/resources/combine_files/biobank_clinical/left_only/biobank_clinical.txt
@@ -1,0 +1,3 @@
+PATIENT_ID
+P-001
+P-002

--- a/import-scripts/test-py3/resources/combine_files/biobank_clinical/left_only/clinical_patient.txt
+++ b/import-scripts/test-py3/resources/combine_files/biobank_clinical/left_only/clinical_patient.txt
@@ -1,0 +1,3 @@
+PATIENT_ID	OTHER_FIELD	ALIQUOT_STATUS
+P-001	old-value-1	stale-status-1
+P-002	old-value-2	stale-status-2

--- a/import-scripts/test-py3/resources/combine_files/biobank_clinical/left_only/expected.txt
+++ b/import-scripts/test-py3/resources/combine_files/biobank_clinical/left_only/expected.txt
@@ -1,0 +1,3 @@
+PATIENT_ID	OTHER_FIELD	ALIQUOT_STATUS
+P-001	old-value-1	stale-status-1
+P-002	old-value-2	stale-status-2

--- a/import-scripts/test-py3/resources/combine_files/biobank_clinical/right_only/biobank_clinical.txt
+++ b/import-scripts/test-py3/resources/combine_files/biobank_clinical/right_only/biobank_clinical.txt
@@ -1,0 +1,3 @@
+PATIENT_ID	ALIQUOT_STATUS
+P-001	Collected in biobank and likely available
+P-002	Not collected in biobank

--- a/import-scripts/test-py3/resources/combine_files/biobank_clinical/right_only/clinical_patient.txt
+++ b/import-scripts/test-py3/resources/combine_files/biobank_clinical/right_only/clinical_patient.txt
@@ -1,0 +1,3 @@
+PATIENT_ID	OTHER_FIELD
+P-001	old-value-1
+P-002	old-value-2

--- a/import-scripts/test-py3/resources/combine_files/biobank_clinical/right_only/expected.txt
+++ b/import-scripts/test-py3/resources/combine_files/biobank_clinical/right_only/expected.txt
@@ -1,0 +1,3 @@
+PATIENT_ID	OTHER_FIELD	ALIQUOT_STATUS
+P-001	old-value-1	Collected in biobank and likely available
+P-002	old-value-2	Not collected in biobank

--- a/import-scripts/test-py3/test_combine_files.py
+++ b/import-scripts/test-py3/test_combine_files.py
@@ -57,6 +57,69 @@ class TestCombineFiles(unittest.TestCase):
         merge_type='outer'
         self.compare_expected_output_to_actual(sub_dir, ddp_files, merge_type)
 
+    def test_biobank_merge_both_have_aliquot_status_with_prefer_right(self):
+        self._assert_biobank_merge_matches_expected(
+            'biobank_clinical/both_overlap',
+            prefer_right_columns=True,
+        )
+
+    def test_biobank_merge_aliquot_status_only_on_right_with_prefer_right(self):
+        self._assert_biobank_merge_matches_expected(
+            'biobank_clinical/right_only',
+            prefer_right_columns=True,
+        )
+
+    def test_biobank_merge_aliquot_status_only_on_left_with_prefer_right(self):
+        self._assert_biobank_merge_matches_expected(
+            'biobank_clinical/left_only',
+            prefer_right_columns=True,
+        )
+
+    def test_biobank_merge_both_have_aliquot_status_without_prefer_right_uses_suffixes(self):
+        sub_dir = os.path.join(TestCombineFiles.base_dir, 'biobank_clinical/both_overlap')
+        output_file = os.path.join(sub_dir, 'merged_without_prefer_right.txt')
+
+        combine_files(
+            [
+                os.path.join(sub_dir, 'clinical_patient.txt'),
+                os.path.join(sub_dir, 'biobank_clinical.txt'),
+            ],
+            output_file,
+            merge_type='left',
+            columns=['PATIENT_ID'],
+            prefer_right_columns=False,
+        )
+
+        with open(output_file, 'r') as actual_out:
+            header = actual_out.readline().strip().split('\t')
+            self.assertIn('ALIQUOT_STATUS_x', header)
+            self.assertIn('ALIQUOT_STATUS_y', header)
+            self.assertNotIn('ALIQUOT_STATUS', header)
+
+        os.remove(output_file)
+
+    def _assert_biobank_merge_matches_expected(self, fixture_subdir, prefer_right_columns):
+        sub_dir = os.path.join(TestCombineFiles.base_dir, fixture_subdir)
+        output_file = os.path.join(sub_dir, 'merged.txt')
+        expected_file = os.path.join(sub_dir, 'expected.txt')
+
+        combine_files(
+            [
+                os.path.join(sub_dir, 'clinical_patient.txt'),
+                os.path.join(sub_dir, 'biobank_clinical.txt'),
+            ],
+            output_file,
+            merge_type='left',
+            columns=['PATIENT_ID'],
+            prefer_right_columns=prefer_right_columns,
+        )
+
+        with open(expected_file, 'r') as expected_out:
+            with open(output_file, 'r') as actual_out:
+                self.assertEqual(expected_out.read(), actual_out.read())
+
+        os.remove(output_file)
+
     def compare_expected_output_to_actual(self, sub_dir, ddp_files, merge_type='inner', columns=None):
         output_file = os.path.join(TestCombineFiles.base_dir, sub_dir, 'merged.txt')
         expected_file = os.path.join(TestCombineFiles.base_dir, sub_dir, 'expected.txt')

--- a/import-scripts/test-py3/test_combine_files.py
+++ b/import-scripts/test-py3/test_combine_files.py
@@ -75,33 +75,45 @@ class TestCombineFiles(unittest.TestCase):
             prefer_right_columns=True,
         )
 
-    def test_biobank_merge_both_have_aliquot_status_without_prefer_right_uses_suffixes(self):
-        sub_dir = os.path.join(TestCombineFiles.base_dir, 'biobank_clinical/both_overlap')
-        output_file = os.path.join(sub_dir, 'merged_without_prefer_right.txt')
-
-        combine_files(
-            [
-                os.path.join(sub_dir, 'clinical_patient.txt'),
-                os.path.join(sub_dir, 'biobank_clinical.txt'),
-            ],
-            output_file,
-            merge_type='left',
-            columns=['PATIENT_ID'],
+    def test_biobank_merge_both_have_aliquot_status_without_prefer_right(self):
+        """Legacy pandas behavior when both files have ALIQUOT_STATUS (no -p)."""
+        self._assert_biobank_merge_matches_expected(
+            'biobank_clinical/both_overlap',
             prefer_right_columns=False,
+            expected_filename='expected_without_prefer_right.txt',
         )
 
-        with open(output_file, 'r') as actual_out:
-            header = actual_out.readline().strip().split('\t')
-            self.assertIn('ALIQUOT_STATUS_x', header)
-            self.assertIn('ALIQUOT_STATUS_y', header)
-            self.assertNotIn('ALIQUOT_STATUS', header)
+    def test_biobank_merge_right_only_without_prefer_right_matches_with_prefer_right(self):
+        """No overlapping non-key columns; -p should not change output."""
+        self._assert_biobank_merge_matches_expected(
+            'biobank_clinical/right_only',
+            prefer_right_columns=False,
+        )
+        self._assert_biobank_merge_matches_expected(
+            'biobank_clinical/right_only',
+            prefer_right_columns=True,
+        )
 
-        os.remove(output_file)
+    def test_biobank_merge_left_only_without_prefer_right_matches_with_prefer_right(self):
+        """Biobank file has no ALIQUOT_STATUS column; -p should not change output."""
+        self._assert_biobank_merge_matches_expected(
+            'biobank_clinical/left_only',
+            prefer_right_columns=False,
+        )
+        self._assert_biobank_merge_matches_expected(
+            'biobank_clinical/left_only',
+            prefer_right_columns=True,
+        )
 
-    def _assert_biobank_merge_matches_expected(self, fixture_subdir, prefer_right_columns):
+    def _assert_biobank_merge_matches_expected(
+        self,
+        fixture_subdir,
+        prefer_right_columns,
+        expected_filename='expected.txt',
+    ):
         sub_dir = os.path.join(TestCombineFiles.base_dir, fixture_subdir)
         output_file = os.path.join(sub_dir, 'merged.txt')
-        expected_file = os.path.join(sub_dir, 'expected.txt')
+        expected_file = os.path.join(sub_dir, expected_filename)
 
         combine_files(
             [


### PR DESCRIPTION
*** This has already been deployed. *** 

Old scripts were kept and should be cleaned up: 

```
cd /data/portal-cron/scripts

$ ls -lthr *BK_DELETE_ME
-rwxrw-r-- 1 cbioportal_importer cbioportal_importer 4.6K Dec 11  2025 combine_files_py3.py.BK_DELETE_ME
-rwxrwxr-x 1 cbioportal_importer cbioportal_importer  80K Jun 19 17:25 fetch-dmp-data-for-import.sh.BK_DELETE_ME
```

If `combine_files_py3.py` was given two files with the same non-key column it would create two columns, one with _x on the end and one with _y.  I assume we never want that, and that until now no two files being merged had the same columns (besides key columns like PATIENT_ID).  We should review this further, but for now let biobank use a -p option to say we want to use the column from the right hand file and replace the one in the left hand file.

Add opt-in -p to combine_files_py3 so overlapping columns use biobank values instead of pandas _x/_y suffixes.

I tested this on pipelines3.

Old problem `combine_files_py3.py`:
```
cd /data/portal-cron/cbio-portal-data/pipelines-testing/studies/msk_impact_biobank

$ python3 $PORTAL_HOME/scripts/combine_files_py3.py \
>   -i data_clinical_patient.txt data_clinical_patient_biobank.txt \
>   -o /tmp/data_clinical_patient_merged_test.txt \
>   -c PATIENT_ID -m left

[cbioportal_importer@pipelines3 msk_impact_biobank]$ head -1 /tmp/data_clinical_patient_merged_test.txt
PATIENT_ID	STAGE_HIGHEST_RECORDED	NUM_ICDO_DX	OS_MONTHS	OS_STATUS	YOST_INDEX_IMPUTED_MEDIAN	GENDER	RACE	ETHNICITY	CURRENT_AGE_DEID	ADRENAL_GLANDS	BONE	CNS_BRAIN	INTRA_ABDOMINAL	LIVER	LUNG	LYMPH_NODES	OTHER	PLEURA	REPRODUCTIVE_ORGANS	GLEASON_FIRST_REPORTED	GLEASON_HIGHEST_REPORTED	HISTORY_OF_PDL1	PRIOR_MED_TO_MSK	SMOKING_PREDICTIONS_3_CLASSES	OTHER_PATIENT_ID	PARTA_CONSENTED_12_245	PARTC_CONSENTED_12_245	ALIQUOT_STATUS_x	ALIQUOT_STATUS_y
```

Fixed `combine_files_py3.py`:
```
$ python3 $PORTAL_HOME/scripts/combine_files_py3.py \
> -i data_clinical_patient.txt data_clinical_patient_biobank.txt \
> -o /tmp/data_clinical_patient_merged_test.txt \
> -c PATIENT_ID -m left -p
[cbioportal_importer@pipelines3 msk_impact_biobank]$ head -1 /tmp/data_clinical_patient_merged_test.txt
PATIENT_ID	STAGE_HIGHEST_RECORDED	NUM_ICDO_DX	OS_MONTHS	OS_STATUS	YOST_INDEX_IMPUTED_MEDIAN	GENDER	RACE	ETHNICITY	CURRENT_AGE_DEID	ADRENAL_GLANDS	BONE	CNS_BRAIN	INTRA_ABDOMINAL	LIVER	LUNG	LYMPH_NODES	OTHER	PLEURA	REPRODUCTIVE_ORGANS	GLEASON_FIRST_REPORTED	GLEASON_HIGHEST_REPORTED	HISTORY_OF_PDL1	PRIOR_MED_TO_MSK	SMOKING_PREDICTIONS_3_CLASSES	OTHER_PATIENT_ID	PARTA_CONSENTED_12_245	PARTC_CONSENTED_12_245	ALIQUOT_STATUS
```
