### PR TITLE
Fix ALIQUOT_STATUS missing from msk_solid_heme by re-fetching biobank clinical patient file from S3

### DIFF
--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -13,15 +13,38 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
     # localize global variables / jar names and functions
     source $PORTAL_HOME/scripts/dmp-import-vars-functions.sh
 
-    # Merge biobank patient clinical data when present (already synced via downloadFromS3AllStudies).
+    # Merge biobank patient clinical data when present.
     # Clinical merge failure is non-fatal; an existing biobank timeline file is kept for CDM timeline merge.
+    #
+    # Args:
+    #   $1  study_data_home  Local directory for the study.
+    #   $2  s3_prefix        Optional. If provided, the biobank clinical patient file is fetched
+    #                        fresh from S3 at this prefix (e.g. "msk_solid_heme") before merging.
+    #                        Use this when the file is written by an external process (e.g. Databricks)
+    #                        and deleted locally after each successful merge.
     function merge_biobank_clinical_data() {
         local study_data_home="$1"
+        local s3_prefix="$2"
 
         local input_clinical_file="$study_data_home/data_clinical_patient.txt"
         local biobank_clinical_file="$study_data_home/data_clinical_patient_biobank.txt"
         local biobank_timeline_file="$study_data_home/data_timeline_biobank_specimen.txt"
         local merged_clinical_file="$study_data_home/data_clinical_patient_merged.txt"
+
+        if [ -n "$s3_prefix" ]; then
+            # Re-fetch the biobank clinical patient file fresh from S3 before merging.
+            # The file is deleted locally after each successful merge and must be
+            # retrieved each run rather than relying on it surviving in S3 overnight.
+            # touch creates the file so try_download_from_s3 can accept a file path;
+            # the -s check ensures we clean up if S3 had no file to download.
+            touch "$biobank_clinical_file"
+            if ! try_download_from_s3 "$biobank_clinical_file" \
+                    "${s3_prefix}/data_clinical_patient_biobank.txt" "mskimpact-databricks" \
+                || [ ! -s "$biobank_clinical_file" ] ; then
+                rm -f "$biobank_clinical_file"
+                echo "`date`: Warning: could not fetch biobank clinical patient file from S3 for ${study_data_home}; biobank merge will be skipped."
+            fi
+        fi
 
         if [ -f "$biobank_clinical_file" ]; then
             # -p / --prefer-right-columns: data_clinical_patient.txt may already
@@ -847,7 +870,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
         echo "MSKSOLIDHEME merge successful! Creating cancer type case lists..."
         echo $(date)
 
-        merge_biobank_clinical_data "$MSK_SOLID_HEME_DATA_HOME"
+        merge_biobank_clinical_data "$MSK_SOLID_HEME_DATA_HOME" "msk_solid_heme"
 
         # add metadata headers and overrides before importing
         $PYTHON_BINARY $PORTAL_HOME/scripts/add_clinical_attribute_metadata_headers.py -s mskimpact -f $MSK_SOLID_HEME_DATA_HOME/data_clinical_sample.txt -i $PORTAL_HOME/scripts/cdm_metadata.json

--- a/import-scripts/s3_functions.sh
+++ b/import-scripts/s3_functions.sh
@@ -60,6 +60,7 @@ function try_upload_to_s3() {
             --exclude ".gitattributes" \
             --exclude ".gitignore" \
             --exclude "*parquet*" \
+            --exclude "*data_clinical_patient_biobank.txt" \
             --profile saml
     else
         echo "`date`: '$PATH_TO_UPLOAD' is neither a file nor a directory, exiting..."


### PR DESCRIPTION
## Problem

`ALIQUOT_STATUS` was missing from `msk_solid_heme/data_clinical_patient.txt` after import. The root cause was a race condition between `import-dmp-impact-data.sh` and the Databricks `write_msk_impact_biobank_to_s3` task.

Each night, fetch-dmp merges `data_clinical_patient_biobank.txt` into `data_clinical_patient.txt` then deletes the file locally. The next morning, Databricks writes the file back to S3, then `import-dmp-impact-data.sh` runs a full-bucket `aws s3 sync --delete`. Because the file is absent locally at that point, `--delete` removes it from S3 — undoing what Databricks just wrote. That night's fetch-dmp finds no file in S3, skips the biobank merge non-fatally, and imports without `ALIQUOT_STATUS`.

## Fix

Two changes:

1. **`s3_functions.sh`**: Add `--exclude "*data_clinical_patient_biobank.txt"` to the directory sync in `try_upload_to_s3`. This prevents any shell-side `aws s3 sync --delete` from ever deleting the file from S3. The file is exclusively written by Databricks and should never be managed by the shell sync.

2. **`fetch-dmp-data-for-import.sh`**: `merge_biobank_clinical_data` now accepts an optional `s3_prefix` argument. When provided, it fetches `data_clinical_patient_biobank.txt` fresh from S3 immediately before merging, ensuring the file is present locally regardless of what happened earlier in the script run. The msk_solid_heme call site passes `"msk_solid_heme"` as the prefix. All other call sites are unchanged.