### PR TITLE
fix: mount host CA bundle into saml2aws Docker container at runtime

### DIFF
--- a/import-scripts/authenticate_service_account.sh
+++ b/import-scripts/authenticate_service_account.sh
@@ -189,6 +189,7 @@ function authenticate_with_saml2aws() {
         -u "$(id -u):$(id -g)" \
         -v "$HOME/.saml2aws:/saml2aws/.saml2aws" \
         -v "$HOME/.aws:/saml2aws/.aws" \
+        -v "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro" \
         saml2aws login --force --skip-prompt --mfa=Auto --profile=$saml2aws_profile \
         --role="$saml2aws_role" --username="$saml2aws_username" --password="$saml2aws_password" \
         --session-duration=$SESSION_DURATION_FOR_TOKEN_SECONDS
@@ -206,6 +207,7 @@ function authenticate_with_saml2aws() {
         -u "$(id -u):$(id -g)" \
         -v "$HOME/.saml2aws:/saml2aws/.saml2aws" \
         -v "$HOME/.aws:/saml2aws/.aws" \
+        -v "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro" \
         saml2aws login --force --skip-prompt --mfa=Auto \
         --role="$saml2aws_role" --username="$saml2aws_username" --password="$saml2aws_password" \
         --session-duration=$SESSION_DURATION_FOR_TOKEN_SECONDS


### PR DESCRIPTION
## Problem

The `saml2aws` Docker image was built on `debian:stable-slim` in October 2021. The SecTigo Public Server Authentication Root R46 certificate — which signs `ssofed.mskcc.org`'s renewed cert (as of June 2026) — isn't in its CA bundle.

This causes `authenticate_service_account.sh` to fail with:

```
x509: certificate signed by unknown authority
```

## Fix

Mount the host's up-to-date CA bundle into the container at `/etc/ssl/certs/ca-certificates.crt` (the Debian CA bundle path). The host is Amazon Linux 2 where the bundle lives at `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` with 143 roots including SecTigo R46.

The mount is added to both `docker run` invocations in `authenticate_with_saml2aws()` — the primary profile-based auth and the backwards-compatibility default-profile auth.

## Alternative Considered

Rebuilding the Docker image with a fresh `debian:stable-slim` would also fix this permanently. That requires one-off access to the build directory on each machine but means zero config/script changes. This mount approach was chosen instead for immediate effect without needing to touch the Docker build.

## Test Plan

1. Deploy to pipelines3 and pipelines5
2. Run `authenticate_service_account.sh eks` on pipelines3
3. Run `authenticate_service_account.sh public` on pipelines5
4. Verify both return exit code 0 with valid AWS credentials