### PR TITLE
Fix race condition in PausingHttpHandler

### DIFF
--- a/common/src/test/java/org/cbioportal/cmo/pipelines/common/util/PausingHttpHandler.java
+++ b/common/src/test/java/org/cbioportal/cmo/pipelines/common/util/PausingHttpHandler.java
@@ -40,7 +40,7 @@ import java.io.OutputStream;
 
 public class PausingHttpHandler implements HttpHandler {
 
-    private long pausePeriodMillis;
+    private volatile long pausePeriodMillis;
     private String expectedResponseContentType;
     private String expectedResponseBody;
     private boolean requestCausesServerError;


### PR DESCRIPTION
Make pausePeriodMillis volatile so that writes from the test thread are immediately visible to the server's handler thread. Without this, concurrent test execution (or retry-loop overlap between tests) can cause the handler to read a stale value and return immediately instead of pausing