### PR TITLE
Requeue consent granted samples and run consent status checker script on all cohorts

### DIFF
--- a/import-scripts/cvr_consent_status_checker.py
+++ b/import-scripts/cvr_consent_status_checker.py
@@ -126,6 +126,11 @@ def cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expect
             record = dict(zip(header, map(str.strip, line.split('\t'))))
 
             for field in CVR_CONSENT_STATUS_ENDPOINTS.keys():
+                # If the API returned no data for this field, skip it entirely to avoid
+                # treating every patient as having revoked consent (the .get() default of 'NO'
+                # would otherwise cause all current-YES patients to appear as revoked).
+                if not expected_consent_status_values[field]:
+                    continue
                 current_consent_status = record[field]
                 expected_consent_status = expected_consent_status_values[field].get(record['PATIENT_ID'], 'NO')
                 # if current and expected values are the same then skip
@@ -145,9 +150,13 @@ def cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expect
                     samples_to_remove[field] = remove_list
 
     removed_germline_mutations = False
-    if cvr_mutation_file and samples_to_remove.get(PARTC_FIELD_NAME, set()):
-        # Attempt to remove germline mutation records where the Part C consent status has changed from YES => NO
-        removed_germline_mutations = remove_germline_revoked_samples(cvr_mutation_file, samples_to_remove.get(PARTC_FIELD_NAME))
+    if samples_to_remove.get(PARTC_FIELD_NAME, set()):
+        if not cvr_mutation_file:
+            # No mutation file was provided; germline records cannot be removed for Part C revocations.
+            print >> ERROR_FILE, "WARNING: Part C consent was revoked for %d sample(s) but no mutation file was provided; germline records will not be removed." % len(samples_to_remove[PARTC_FIELD_NAME])
+        else:
+            # Attempt to remove germline mutation records where the Part C consent status has changed from YES => NO
+            removed_germline_mutations = remove_germline_revoked_samples(cvr_mutation_file, samples_to_remove.get(PARTC_FIELD_NAME))
 
     if samples_to_requeue and portal_properties_file and session_data_file and study_id:
         requeue_consent_granted_samples(samples_to_requeue, portal_properties_file, session_data_file, study_id)
@@ -158,6 +167,7 @@ def cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expect
             samples_to_remove,
             expected_consent_status_values,
             removed_germline_mutations,
+            cvr_mutation_file,
             gmail_username,
             gmail_password)
 
@@ -193,6 +203,10 @@ def remove_germline_revoked_samples(cvr_mutation_file, revoked_germline_samples)
             tmpfile.write(line)
     tmpfile.close()
 
+    if num_germline_records == 0:
+        os.remove(tmpfile_name)
+        return True
+
     pct_removed = 100*(float(num_removed_records) / float(num_germline_records))
     cutoff = 20 # If we're trying to remove too many records, then something's probably wrong with the server response. 20% is an arbitrary cutoff
     if pct_removed >= cutoff:
@@ -216,6 +230,7 @@ def email_consent_status_report(
         samples_to_remove,
         expected_consent_status_values,
         removed_germline_mutations,
+        cvr_mutation_file,
         gmail_username,
         gmail_password):
     '''
@@ -241,8 +256,14 @@ def email_consent_status_report(
             if missing_data:
                 summary += '\n\t%s:\tNo action. No response from Part %s server.' % (field, "A" if field == PARTA_FIELD_NAME else "C")
             elif field == PARTC_FIELD_NAME and not removed_germline_mutations:
-                # If too many samples had their Part C cosent status changed, there is probably an issue with the upstream server, so we didn't remove any records.
-                summary += '\n\t%s:\tConsent was revoked for an abnormally large number of samples-- no germline records were removed from the mutation file. Please double-check the response of the Part C server.' % (field)
+                if not cvr_mutation_file:
+                    # No mutation file was provided, so germline records could not be removed. Still report the samples.
+                    summary += '\n\t%s:\t%s samples (no mutation file provided; germline records not removed)' % (field, len(samples))
+                    filename = field.lower() + '_consent_revoked_report.txt'
+                    generate_attachment(message, filename, samples)
+                else:
+                    # If too many samples had their Part C consent status changed, there is probably an issue with the upstream server, so we didn't remove any records.
+                    summary += '\n\t%s:\tConsent was revoked for an abnormally large number of samples-- no germline records were removed from the mutation file. Please double-check the response of the Part C server.' % (field)
             else:
                 summary += '\n\t%s:\t%s samples' % (field, len(samples))
                 filename = field.lower() + '_consent_revoked_report.txt'
@@ -314,11 +335,16 @@ def main():
     else:
         expected_consent_status_values = fetch_expected_consent_status_values()
         if consent_cache_file:
-            try:
-                with open(consent_cache_file, 'w') as f:
-                    json.dump(expected_consent_status_values, f)
-            except Exception as e:
-                print >> ERROR_FILE, 'WARNING: failed to write consent cache file %s: %s' % (consent_cache_file, str(e))
+            if any(not expected_consent_status_values[f] for f in CVR_CONSENT_STATUS_ENDPOINTS):
+                # Don't cache if any field returned empty data -- a bad cache would propagate
+                # the API failure silently to all subsequent cohort invocations in this run.
+                print >> ERROR_FILE, 'WARNING: consent API returned empty data for one or more fields; skipping cache write to %s' % (consent_cache_file)
+            else:
+                try:
+                    with open(consent_cache_file, 'w') as f:
+                        json.dump(expected_consent_status_values, f)
+                except Exception as e:
+                    print >> ERROR_FILE, 'WARNING: failed to write consent cache file %s: %s' % (consent_cache_file, str(e))
 
     cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expected_consent_status_values, gmail_username, gmail_password, portal_properties_file, session_data_file, study_id)
 

--- a/import-scripts/cvr_consent_status_checker.py
+++ b/import-scripts/cvr_consent_status_checker.py
@@ -169,7 +169,8 @@ def cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expect
             removed_germline_mutations,
             cvr_mutation_file,
             gmail_username,
-            gmail_password)
+            gmail_password,
+            study_id)
 
 def remove_germline_revoked_samples(cvr_mutation_file, revoked_germline_samples):
     '''
@@ -232,7 +233,8 @@ def email_consent_status_report(
         removed_germline_mutations,
         cvr_mutation_file,
         gmail_username,
-        gmail_password):
+        gmail_password,
+        study_id=None):
     '''
         Constructs and sends email reporting consent status updates.
     '''
@@ -272,7 +274,10 @@ def email_consent_status_report(
     body = MIMEText(summary, 'plain')
     message.attach(body)
 
-    message['Subject'] = CONSENT_STATUS_EMAIL_SUBJECT
+    subject = CONSENT_STATUS_EMAIL_SUBJECT
+    if study_id:
+        subject = '[%s] %s' % (study_id, CONSENT_STATUS_EMAIL_SUBJECT)
+    message['Subject'] = subject
     message['From'] = MESSAGE_SENDER
     message['To'] = COMMASPACE.join(MESSAGE_RECIPIENTS)
     message['Date'] = formatdate(localtime=True)

--- a/import-scripts/cvr_consent_status_checker.py
+++ b/import-scripts/cvr_consent_status_checker.py
@@ -272,6 +272,7 @@ def main():
     parser.add_option('-f', '--portal-properties-file', action = 'store', dest = 'portal_properties_file', help = 'CVR portal properties file for requeue [optional; enables automatic requeue of NO->YES samples]')
     parser.add_option('-s', '--session-data-file', action = 'store', dest = 'session_data_file', help = 'File to store CVR session data for requeue [optional; required with -f]')
     parser.add_option('-i', '--study-id', action = 'store', dest = 'study_id', help = 'DMP study ID for requeue (e.g. mskimpact) [optional; required with -f]')
+    parser.add_option('-e', '--consent-cache-file', action = 'store', dest = 'consent_cache_file', help = 'JSON file to cache consent API values across cohort invocations [optional]')
 
     (options, args) = parser.parse_args()
 
@@ -282,6 +283,7 @@ def main():
     portal_properties_file = options.portal_properties_file
     session_data_file = options.session_data_file
     study_id = options.study_id
+    consent_cache_file = options.consent_cache_file
 
     if not cvr_clinical_file or not os.path.exists(cvr_clinical_file):
         print >> ERROR_FILE, "Invalid CVR clinical file: %s, exiting..." % (cvr_clinical_file)
@@ -302,7 +304,22 @@ def main():
         print >> ERROR_FILE, "Options --session-data-file/-s and --study-id/-i are required when --portal-properties-file/-f is provided, exiting..."
         sys.exit(2)
 
-    expected_consent_status_values = fetch_expected_consent_status_values()
+    if consent_cache_file and os.path.exists(consent_cache_file):
+        try:
+            with open(consent_cache_file, 'r') as f:
+                expected_consent_status_values = json.load(f)
+        except Exception as e:
+            print >> ERROR_FILE, 'WARNING: failed to load consent cache file %s, fetching from API: %s' % (consent_cache_file, str(e))
+            expected_consent_status_values = fetch_expected_consent_status_values()
+    else:
+        expected_consent_status_values = fetch_expected_consent_status_values()
+        if consent_cache_file:
+            try:
+                with open(consent_cache_file, 'w') as f:
+                    json.dump(expected_consent_status_values, f)
+            except Exception as e:
+                print >> ERROR_FILE, 'WARNING: failed to write consent cache file %s: %s' % (consent_cache_file, str(e))
+
     cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expected_consent_status_values, gmail_username, gmail_password, portal_properties_file, session_data_file, study_id)
 
 if __name__ == '__main__':

--- a/import-scripts/cvr_consent_status_checker.py
+++ b/import-scripts/cvr_consent_status_checker.py
@@ -2,7 +2,9 @@
 
 import ssl
 import os
+import subprocess
 import sys
+import tempfile
 import urllib
 import json
 from email.Utils import COMMASPACE, formatdate
@@ -57,7 +59,45 @@ def fetch_expected_consent_status_values():
         expected_consent_status_values[field] = consent_values
     return expected_consent_status_values
 
-def cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expected_consent_status_values, gmail_username, gmail_password):
+def requeue_consent_granted_samples(samples_to_requeue, portal_properties_file, session_data_file, study_id):
+    '''
+        Requeues samples with NO -> YES consent status changes via cvr_dmp_endpoint_utility.py
+        so they are re-fetched from CVR with the updated consent value in the next nightly run.
+    '''
+    all_samples = set()
+    for field_samples in samples_to_requeue.values():
+        all_samples.update(field_samples)
+    if not all_samples:
+        return
+
+    tmpfile_path = None
+    try:
+        fd, tmpfile_path = tempfile.mkstemp(prefix='consent_requeue_', suffix='.txt')
+        with os.fdopen(fd, 'w') as f:
+            f.write('\n'.join(sorted(all_samples)))
+
+        utility_script = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cvr_dmp_endpoint_utility.py')
+        cmd = [
+            sys.executable,
+            utility_script,
+            '-p', portal_properties_file,
+            '-s', session_data_file,
+            '-i', study_id,
+            '-f', tmpfile_path,
+            '-r'
+        ]
+        print >> ERROR_FILE, 'Requeueing %d consent-granted sample(s) for study %s: %s' % (
+            len(all_samples), study_id, ', '.join(sorted(all_samples)))
+        ret = subprocess.call(cmd)
+        if ret != 0:
+            print >> ERROR_FILE, 'WARNING: cvr_dmp_endpoint_utility.py requeue exited with code %d for study %s' % (ret, study_id)
+    except Exception as e:
+        print >> ERROR_FILE, 'WARNING: failed to requeue consent-granted samples for study %s: %s' % (study_id, str(e))
+    finally:
+        if tmpfile_path and os.path.exists(tmpfile_path):
+            os.remove(tmpfile_path)
+
+def cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expected_consent_status_values, gmail_username, gmail_password, portal_properties_file=None, session_data_file=None, study_id=None):
     '''
         Checks the current consent status for
         Part A & C against the expected consent status values
@@ -67,7 +107,9 @@ def cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expect
         from data set is emailed to recipients.
 
         Samples are added to the requeue list if their expected consent
-        status is 'YES' and their current status is 'NO'.
+        status is 'YES' and their current status is 'NO'. If portal_properties_file,
+        session_data_file, and study_id are all provided, those samples are also
+        automatically requeued via cvr_dmp_endpoint_utility.py.
 
         Samples are added to the removal list if their expected consent
         status is 'NO' and their current status is 'YES'.
@@ -103,9 +145,12 @@ def cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expect
                     samples_to_remove[field] = remove_list
 
     removed_germline_mutations = False
-    if samples_to_remove.get(PARTC_FIELD_NAME, set()):
+    if cvr_mutation_file and samples_to_remove.get(PARTC_FIELD_NAME, set()):
         # Attempt to remove germline mutation records where the Part C consent status has changed from YES => NO
         removed_germline_mutations = remove_germline_revoked_samples(cvr_mutation_file, samples_to_remove.get(PARTC_FIELD_NAME))
+
+    if samples_to_requeue and portal_properties_file and session_data_file and study_id:
+        requeue_consent_granted_samples(samples_to_requeue, portal_properties_file, session_data_file, study_id)
 
     if samples_to_requeue != {} or samples_to_remove != {}:
         email_consent_status_report(
@@ -220,10 +265,13 @@ def email_consent_status_report(
 
 def main():
     parser = optparse.OptionParser()
-    parser.add_option('-c', '--clinical-file', action = 'store', dest = 'clinfile', help = 'CVR clinical file')
-    parser.add_option('-m', '--mutation-file', action = 'store', dest = 'maf', help = 'CVR MAF')
+    parser.add_option('-c', '--clinical-file', action = 'store', dest = 'clinfile', help = 'CVR clinical file [required]')
+    parser.add_option('-m', '--mutation-file', action = 'store', dest = 'maf', help = 'CVR MAF [optional; required only for Part C germline removal]')
     parser.add_option('-u', '--gmail-username', action = 'store', dest = 'gmail_username', help = 'Gmail username [required]')
     parser.add_option('-p', '--gmail-password', action = 'store', dest = 'gmail_password', help = 'Gmail SMTP password [required]')
+    parser.add_option('-f', '--portal-properties-file', action = 'store', dest = 'portal_properties_file', help = 'CVR portal properties file for requeue [optional; enables automatic requeue of NO->YES samples]')
+    parser.add_option('-s', '--session-data-file', action = 'store', dest = 'session_data_file', help = 'File to store CVR session data for requeue [optional; required with -f]')
+    parser.add_option('-i', '--study-id', action = 'store', dest = 'study_id', help = 'DMP study ID for requeue (e.g. mskimpact) [optional; required with -f]')
 
     (options, args) = parser.parse_args()
 
@@ -231,21 +279,31 @@ def main():
     cvr_mutation_file = options.maf
     gmail_username = options.gmail_username
     gmail_password = options.gmail_password
+    portal_properties_file = options.portal_properties_file
+    session_data_file = options.session_data_file
+    study_id = options.study_id
+
     if not cvr_clinical_file or not os.path.exists(cvr_clinical_file):
         print >> ERROR_FILE, "Invalid CVR clinical file: %s, exiting..." % (cvr_clinical_file)
         sys.exit(2)
-    if not cvr_mutation_file or not os.path.exists(cvr_mutation_file):
+    if cvr_mutation_file and not os.path.exists(cvr_mutation_file):
         print >> ERROR_FILE, "Invalid CVR mutation file: %s, exiting..." % (cvr_mutation_file)
         sys.exit(2)
     if not gmail_username:
-        print >> ERROR_FILE, "Required option --gmail-username/-u missing, exiting..." % (cvr_mutation_file)
+        print >> ERROR_FILE, "Required option --gmail-username/-u missing, exiting..."
         sys.exit(2)
     if not gmail_password:
-        print >> ERROR_FILE, "Required option --gmail-password/-p missing, exiting..." % (cvr_mutation_file)
+        print >> ERROR_FILE, "Required option --gmail-password/-p missing, exiting..."
+        sys.exit(2)
+    if portal_properties_file and not os.path.exists(portal_properties_file):
+        print >> ERROR_FILE, "Invalid portal properties file: %s, exiting..." % (portal_properties_file)
+        sys.exit(2)
+    if portal_properties_file and (not session_data_file or not study_id):
+        print >> ERROR_FILE, "Options --session-data-file/-s and --study-id/-i are required when --portal-properties-file/-f is provided, exiting..."
         sys.exit(2)
 
     expected_consent_status_values = fetch_expected_consent_status_values()
-    cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expected_consent_status_values, gmail_username, gmail_password)
+    cvr_consent_status_fetcher_main(cvr_clinical_file, cvr_mutation_file, expected_consent_status_values, gmail_username, gmail_password, portal_properties_file, session_data_file, study_id)
 
 if __name__ == '__main__':
     main()

--- a/import-scripts/cvr_dmp_endpoint_utility.py
+++ b/import-scripts/cvr_dmp_endpoint_utility.py
@@ -88,7 +88,7 @@ RETRIEVE_VARIANTS_DMP_SAMPLE_ID = 'dmp_sample_id'
 CONSUME_AFFECTED_ROWS = 'affectedRows'
 
 DMP_STUDY_IDS = ['mskimpact', 'mskimpact_heme', 'mskraindance', 'mskarcher', 'mskaccess']
-DMP_SAMPLE_ID_PATTERN = re.compile('P-\d+-(T|N)\d+-(IH|TB|TS|AH|AS|IM|XS)\d+')
+DMP_SAMPLE_ID_PATTERN = re.compile('P-\d+-(T|N)\d+-(IH|TB|TS|AH|AS|IM|XS|XH)\d+')
 
 MASTERLIST_CHECK_ARG_DESCRIPTION = '[optional] Fetches masterlist for study and reports samples from samples file that are missing from masterlist.'
 REQUEUE_SAMPLES_ARG_DESCRIPTION = '[optional] Requeues samples and reports whether requeue was successful or not. If requeue failed then attempts to determine if failure is due to sample(s) missing from study masterlist or if sample is already queued for next CVR fetch.'

--- a/import-scripts/cvr_dmp_endpoint_utility.py
+++ b/import-scripts/cvr_dmp_endpoint_utility.py
@@ -412,7 +412,7 @@ def run_requeue_samples_mode(portal_properties, session_data, study_id, study_ma
         print >> OUTPUT_FILE, 'All samples are already in the study queue; nothing to requeue.'
         return
 
-    requeue_success_samples = set(already_in_queue)  # treat pre-existing queue members as success
+    requeue_success_samples = set()
     requeue_failure_samples = set()
     for sample_id in sample_ids:
         if not requeue_sample(portal_properties, session_data, sample_id):

--- a/import-scripts/cvr_dmp_endpoint_utility.py
+++ b/import-scripts/cvr_dmp_endpoint_utility.py
@@ -35,6 +35,8 @@ MASTERLIST_ACCESS = 'dmp.tokens.retrieve_master_list.access'
 MASTERLIST_RAINDANCE = 'dmp.tokens.retrieve_master_list.rdts'
 
 RETRIEVE_VARIANTS_MSKIMPMACT = 'dmp.tokens.retrieve_variants.impact'
+
+CVR_QUEUE_MAX_SIZE = 300
 RETRIEVE_VARIANTS_HEMEPACT = 'dmp.tokens.retrieve_variants.heme'
 RETRIEVE_VARIANTS_ARCHER = 'dmp.tokens.retrieve_variants.archer'
 RETRIEVE_VARIANTS_ACCESS = 'dmp.tokens.retrieve_variants.access'
@@ -411,6 +413,15 @@ def run_requeue_samples_mode(portal_properties, session_data, study_id, study_ma
     if not sample_ids:
         print >> OUTPUT_FILE, 'All samples are already in the study queue; nothing to requeue.'
         return
+
+    # Cap requeue attempts to available queue slots to avoid futile API calls when queue is at capacity
+    available_slots = CVR_QUEUE_MAX_SIZE - len(current_study_sample_queue)
+    if available_slots <= 0:
+        print >> OUTPUT_FILE, 'CVR queue is at capacity (%d/%d); no slots available to requeue samples this run.' % (len(current_study_sample_queue), CVR_QUEUE_MAX_SIZE)
+        return
+    if len(sample_ids) > available_slots:
+        print >> OUTPUT_FILE, 'Capping requeue to %d available queue slot(s) (%d sample(s) deferred to subsequent runs).' % (available_slots, len(sample_ids) - available_slots)
+        sample_ids = set(list(sample_ids)[:available_slots])
 
     requeue_success_samples = set()
     requeue_failure_samples = set()

--- a/import-scripts/cvr_dmp_endpoint_utility.py
+++ b/import-scripts/cvr_dmp_endpoint_utility.py
@@ -403,7 +403,16 @@ def run_requeue_samples_mode(portal_properties, session_data, study_id, study_ma
                 signed out or is considered a failed sample. 
                 ** These cases must be reported to CVR. **
     '''
-    requeue_success_samples = set()
+    # Pre-filter: skip samples already in the current queue to avoid redundant API calls
+    already_in_queue = get_samples_in_queue(current_study_sample_queue, sample_ids)
+    if already_in_queue:
+        print >> OUTPUT_FILE, 'Skipping %d sample(s) already in the study queue:\n\t%s' % (len(already_in_queue), '\n\t'.join(already_in_queue))
+    sample_ids = sample_ids - set(already_in_queue)
+    if not sample_ids:
+        print >> OUTPUT_FILE, 'All samples are already in the study queue; nothing to requeue.'
+        return
+
+    requeue_success_samples = set(already_in_queue)  # treat pre-existing queue members as success
     requeue_failure_samples = set()
     for sample_id in sample_ids:
         if not requeue_sample(portal_properties, session_data, sample_id):

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -261,8 +261,6 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                     echo "pushing cvr data to s3"
                     upload_to_s3 "$MSK_IMPACT_DATA_HOME" "mskimpact" "mskimpact-databricks"
                 fi
-                # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
-                $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt -m $MSK_IMPACT_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_impact.json -i mskimpact -e $MSK_DMP_TMPDIR/cvr_consent_status_cache.json
             fi
         fi
 
@@ -292,6 +290,8 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                 echo "pushing CVR germline data to s3"
                 upload_to_s3 "$MSK_IMPACT_DATA_HOME" "mskimpact" "mskimpact-databricks"
             fi
+            # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
+            $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt -m $MSK_IMPACT_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_impact.json -i mskimpact -e $MSK_DMP_TMPDIR/cvr_consent_status_cache.json
         fi
 
         # Upload MSKIMPACT sample list to S3 for CDM use

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -262,7 +262,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                     upload_to_s3 "$MSK_IMPACT_DATA_HOME" "mskimpact" "mskimpact-databricks"
                 fi
                 # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
-                $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt -m $MSK_IMPACT_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_impact.json -i mskimpact
+                $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt -m $MSK_IMPACT_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_impact.json -i mskimpact -e $MSK_DMP_TMPDIR/cvr_consent_status_cache.json
             fi
         fi
 
@@ -334,8 +334,6 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                 echo "pushing cvr data for heme to s3"
                 upload_to_s3 "$MSK_HEMEPACT_DATA_HOME" "mskimpact_heme" "mskimpact-databricks"
             fi
-            # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
-            $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt -m $MSK_HEMEPACT_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_heme.json -i mskimpact_heme
         fi
         # fetch new/updated HEMEPACT germline samples using CVR Web service   (must come after normal cvr fetching)
         drop_dead_instant_step=$(date --date="+6hours" -Iseconds) # nearly 6 hours from now
@@ -363,6 +361,8 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                 echo "uploading CVR germline data to s3"
                 upload_to_s3 "$MSK_HEMEPACT_DATA_HOME" "mskimpact_heme" "mskimpact-databricks"
             fi
+            # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
+            $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt -m $MSK_HEMEPACT_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_heme.json -i mskimpact_heme -e $MSK_DMP_TMPDIR/cvr_consent_status_cache.json
         fi
 
         # Upload HEMEPACT sample list to S3 for CDM use
@@ -406,7 +406,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                 upload_to_s3 "$MSK_ARCHER_UNFILTERED_DATA_HOME" "mskarcher_unfiltered" "mskimpact-databricks"
             fi
             # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
-            $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_ARCHER_UNFILTERED_DATA_HOME/data_clinical_mskarcher_data_clinical.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_archer.json -i mskarcher
+            $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_ARCHER_UNFILTERED_DATA_HOME/data_clinical_mskarcher_data_clinical.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_archer.json -i mskarcher -e $MSK_DMP_TMPDIR/cvr_consent_status_cache.json
         fi
 
         # Upload ARCHER sample list to S3 for CDM use
@@ -451,7 +451,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                 upload_to_s3 "$MSK_ACCESS_DATA_HOME" "mskaccess" "mskimpact-databricks"
             fi
             # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
-            $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_ACCESS_DATA_HOME/data_clinical_mskaccess_data_clinical.txt -m $MSK_ACCESS_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_access.json -i mskaccess
+            $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_ACCESS_DATA_HOME/data_clinical_mskaccess_data_clinical.txt -m $MSK_ACCESS_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_access.json -i mskaccess -e $MSK_DMP_TMPDIR/cvr_consent_status_cache.json
         fi
 
         # Upload ACCESS sample list to S3 for CDM use

--- a/import-scripts/fetch-dmp-data-for-import.sh
+++ b/import-scripts/fetch-dmp-data-for-import.sh
@@ -262,7 +262,7 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                     upload_to_s3 "$MSK_IMPACT_DATA_HOME" "mskimpact" "mskimpact-databricks"
                 fi
                 # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
-                $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt -m $MSK_IMPACT_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD
+                $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_IMPACT_DATA_HOME/data_clinical_mskimpact_data_clinical_cvr.txt -m $MSK_IMPACT_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_impact.json -i mskimpact
             fi
         fi
 
@@ -334,6 +334,8 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                 echo "pushing cvr data for heme to s3"
                 upload_to_s3 "$MSK_HEMEPACT_DATA_HOME" "mskimpact_heme" "mskimpact-databricks"
             fi
+            # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
+            $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_HEMEPACT_DATA_HOME/data_clinical_hemepact_data_clinical.txt -m $MSK_HEMEPACT_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_heme.json -i mskimpact_heme
         fi
         # fetch new/updated HEMEPACT germline samples using CVR Web service   (must come after normal cvr fetching)
         drop_dead_instant_step=$(date --date="+6hours" -Iseconds) # nearly 6 hours from now
@@ -403,6 +405,8 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                 echo "pushing archer unfiltered data to s3"
                 upload_to_s3 "$MSK_ARCHER_UNFILTERED_DATA_HOME" "mskarcher_unfiltered" "mskimpact-databricks"
             fi
+            # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
+            $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_ARCHER_UNFILTERED_DATA_HOME/data_clinical_mskarcher_data_clinical.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_archer.json -i mskarcher
         fi
 
         # Upload ARCHER sample list to S3 for CDM use
@@ -446,6 +450,8 @@ MY_FLOCK_FILEPATH="/data/portal-cron/cron-lock/fetch-dmp-data-for-import.lock"
                 echo "pushing access data to s3"
                 upload_to_s3 "$MSK_ACCESS_DATA_HOME" "mskaccess" "mskimpact-databricks"
             fi
+            # identify samples that need to be requeued or removed from data set due to CVR Part A or Part C consent status changes
+            $PYTHON_BINARY $PORTAL_HOME/scripts/cvr_consent_status_checker.py -c $MSK_ACCESS_DATA_HOME/data_clinical_mskaccess_data_clinical.txt -m $MSK_ACCESS_DATA_HOME/data_mutations_extended.txt -u $GMAIL_USERNAME -p $GMAIL_PASSWORD -f $PIPELINES_CONFIG_HOME/properties/fetch-cvr/application.properties -s $MSK_DMP_TMPDIR/cvr_consent_checker_session_access.json -i mskaccess
         fi
 
         # Upload ACCESS sample list to S3 for CDM use


### PR DESCRIPTION
Bug in `cvr_consent_status_checker.py`: Consent granted samples (where PARTA or PARTC consent status changes from 'NO' to 'YES') were never being requeued. The script now contains a function to run the `cvr_dmp_endpoint_utility.py` script as a subprocess to requeue the consent granted patients.

Bug in `fetch-dmp-data-for-import.sh`: The `cvr_consent_status_checker.py` script (which checks for consent granting and consent revocation) was only being run after the impact fetch, and was ignoring consent status changes in heme, access, and archer. Each cohort is now evaluated for consent status changes after the CVR fetch. Note that for impact and heme, the `cvr_consent_status_checker.py` occurs **after** the germline fetch so that freshly-written germline records are also caught and removed for any patient whose Part C consent was revoked.