### PR TITLE
Derive tables in standby database, not fixed secret database

### DIFF
--- a/dags/import_public_hackathon.py
+++ b/dags/import_public_hackathon.py
@@ -124,6 +124,29 @@ CLICKHOUSE_CONFIG_FILE = f"{CREDS_DIR}/manage_public_clickhouse_database_update_
 S3_MOUNT_PATH = "/mnt/s3-data"
 S3_PVC_CLAIM_NAME = "databricks-s3-pvc"
 
+# Task IDs that may be listed in the skip_tasks param (dry-run support).
+SKIPPABLE_TASK_IDS = (
+    "clone_live_database_into_standby",
+    "import_into_standby_database",
+    "create_derived_tables_in_standby_database",
+    "transfer_deployment_color",
+)
+
+
+def _bash_skip_guard(task_id: str) -> str:
+    """Jinja prefix for a BashOperator command: exit 99 (BashOperator's skip exit
+    code) when the task is listed in params.skip_tasks."""
+    return (
+        f"{{% if '{task_id}' in params.skip_tasks %}}"
+        f"echo '{task_id} listed in skip_tasks - skipping'; exit 99"
+        f"{{% endif %}}\n"
+    )
+
+
+def _skip_if_requested(task_id: str, params: dict | None) -> None:
+    if task_id in ((params or {}).get("skip_tasks") or []):
+        raise AirflowSkipException(f"{task_id} listed in skip_tasks - skipping")
+
 
 def _study_data_path(study_id: str) -> str | None:
     """Resolve a study on the S3 mount; extract tarballs to a temp dir. None if absent."""
@@ -394,13 +417,31 @@ def _activate_standby_properties() -> str:
             description="Select one or more cancer study IDs to import. Run refresh_study_list to update the list.",
             title="Cancer Study IDs",
         ),
+        "skip_tasks": Param(
+            [],
+            type="array",
+            examples=list(SKIPPABLE_TASK_IDS),
+            description=(
+                "Task IDs to skip this run (dry-run support). Skipping "
+                "transfer_deployment_color imports into the standby database without "
+                "swapping production traffic; the run then finishes in the 'abandoned' "
+                "management state so the next run re-clones the standby database."
+            ),
+            title="Skip Tasks",
+        ),
     },
 )
 def import_public_hackathon():
     @task(executor_config=_POD_OVERRIDE)
-    def verify_studies_exist(study_ids: list[str]) -> list[str]:
+    def verify_studies_exist(study_ids: list[str], params: dict | None = None) -> list[str]:
         """All-or-nothing: every requested study must exist on the S3 mount, else fail the DAG."""
         import pathlib
+
+        # Fail fast on typos: a misspelled skip_tasks entry would silently NOT skip
+        # its task, which for transfer_deployment_color means an unintended traffic swap.
+        unknown = set((params or {}).get("skip_tasks") or []) - set(SKIPPABLE_TASK_IDS)
+        if unknown:
+            raise AirflowException(f"skip_tasks contains unknown task ids: {sorted(unknown)}")
 
         # render_template_as_native_obj may render the array Param as its string repr
         if isinstance(study_ids, str):
@@ -436,7 +477,7 @@ def import_public_hackathon():
 
     t_clone_live_database = BashOperator(
         task_id="clone_live_database_into_standby",
-        bash_command=_script(
+        bash_command=_bash_skip_guard("clone_live_database_into_standby") + _script(
             "airflow-clone-db.sh",
             IMPORTER,
             SCRIPTS_DIR,
@@ -473,12 +514,16 @@ def import_public_hackathon():
     def collect_valid_studies(results: list) -> list[str]:
         valid = [sid for sid in (results or []) if sid is not None]
         if not valid:
-            raise AirflowSkipException("No studies passed validation — skipping import")
+            # Fail (not skip): downstream tasks use NONE_FAILED so that explicit
+            # skip_tasks skips flow through them — a skip here would let
+            # transfer_deployment_color swap traffic onto an unmodified clone.
+            raise AirflowException("No studies passed validation")
         logging.info("Studies passing validation: %s", valid)
         return valid
 
-    @task(executor_config=_POD_OVERRIDE_IMPORT)
-    def import_into_standby_database(valid_studies: list[str]):
+    @task(executor_config=_POD_OVERRIDE_IMPORT, trigger_rule=TriggerRule.NONE_FAILED)
+    def import_into_standby_database(valid_studies: list[str], params: dict | None = None):
+        _skip_if_requested("import_into_standby_database", params)
         _activate_standby_properties()
         if not valid_studies:
             logging.info("No valid studies to import — exiting.")
@@ -505,8 +550,9 @@ def import_public_hackathon():
         if failed:
             raise Exception(f"Import failed for {len(failed)} study/studies: {failed}")
 
-    @task(executor_config=_POD_OVERRIDE_IMPORT)
-    def create_derived_tables_in_standby_database():
+    @task(executor_config=_POD_OVERRIDE_IMPORT, trigger_rule=TriggerRule.NONE_FAILED)
+    def create_derived_tables_in_standby_database(params: dict | None = None):
+        _skip_if_requested("create_derived_tables_in_standby_database", params)
         _activate_standby_properties()
         rebuild = _run_and_stream(
             [sys.executable, IMPORT_SCRIPT_PATH, "derive-tables",
@@ -517,25 +563,36 @@ def import_public_hackathon():
 
     t_transfer_deployment_color = BashOperator(
         task_id="transfer_deployment_color",
-        bash_command="unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE; " + _script(
+        bash_command=_bash_skip_guard("transfer_deployment_color")
+        + "unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE; " + _script(
             "airflow-transfer-deployment.sh",
             SCRIPTS_DIR,
             CLICKHOUSE_CONFIG_FILE,
             COLOR_SWAP_CONFIG_FILE,
         ),
         executor_config=_POD_OVERRIDE,
+        trigger_rule=TriggerRule.NONE_FAILED,
     )
 
-    t_set_import_complete = BashOperator(
-        task_id="set_import_complete",
-        bash_command=_script(
-            "set_update_process_state.sh",
-            CLICKHOUSE_CONFIG_FILE,
-            "complete",
-            source_automation_env=True,
-        ),
-        executor_config=_POD_OVERRIDE,
-    )
+    @task(executor_config=_POD_OVERRIDE, trigger_rule=TriggerRule.NONE_FAILED)
+    def finalize_import_state(ti=None):
+        """Set the management DB end state: 'complete' only if production traffic was
+        actually swapped, otherwise 'abandoned' so the next run re-clones standby."""
+        transfer_state = ti.get_dagrun().get_task_instance("transfer_deployment_color").state
+        state = "complete" if transfer_state == "success" else "abandoned"
+        logging.info(
+            "transfer_deployment_color finished in state %r -> setting update process state %r",
+            transfer_state, state,
+        )
+        _run_and_stream(
+            ["bash", "-c", _script(
+                "set_update_process_state.sh",
+                CLICKHOUSE_CONFIG_FILE,
+                state,
+                source_automation_env=True,
+            )],
+            check=True,
+        )
 
     t_set_import_abandoned = BashOperator(
         task_id="set_import_abandoned",
@@ -554,6 +611,7 @@ def import_public_hackathon():
     t_collect_valid  = collect_valid_studies(t_pull_and_validate)
     t_import         = import_into_standby_database(t_collect_valid)
     t_create_derived_tables = create_derived_tables_in_standby_database()
+    t_finalize       = finalize_import_state()
 
     t_found_studies >> t_verify_cluster_state >> [t_clone_live_database, t_pull_and_validate]
     t_clone_live_database >> t_import
@@ -561,7 +619,7 @@ def import_public_hackathon():
         t_import
         >> t_create_derived_tables
         >> t_transfer_deployment_color
-        >> t_set_import_complete
+        >> t_finalize
     )
 
     [
@@ -573,7 +631,7 @@ def import_public_hackathon():
         t_import,
         t_create_derived_tables,
         t_transfer_deployment_color,
-        t_set_import_complete,
+        t_finalize,
     ] >> t_set_import_abandoned
 
 

--- a/dags/import_public_hackathon.py
+++ b/dags/import_public_hackathon.py
@@ -183,13 +183,17 @@ def _script(script_name: str, *args: object, source_automation_env: bool = False
 _SAML2AWS_ENV = k8s.V1EnvVar(name="SAML2AWS_CONFIGFILE", value=f"{CREDS_DIR}/.saml2aws")
 
 
-def _clickhouse_secret_env(name: str, key: str) -> k8s.V1EnvVar:
-    return k8s.V1EnvVar(
-        name=name,
-        value_from=k8s.V1EnvVarSource(
-            secret_key_ref=k8s.V1SecretKeySelector(name="hackathon-clickhouse-secret", key=key)
-        ),
-    )
+def _load_properties(path: str) -> dict[str, str]:
+    """Parse a simple key=value properties file (comments and blank lines ignored)."""
+    props: dict[str, str] = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            props[key.strip()] = value.strip()
+    return props
 
 
 def _pod_override(
@@ -265,11 +269,6 @@ _POD_OVERRIDE = _pod_override(
 def _make_cbioportal_pod_override(java_opts: str | None = None, memory_request: str = "2Gi", memory_limit: str = "3Gi") -> dict:
     env = [
         k8s.V1EnvVar(name="PORTAL_HOME", value="/"),
-        _clickhouse_secret_env("CLICKHOUSE_HOST", "host"),
-        _clickhouse_secret_env("CLICKHOUSE_NATIVE_PORT", "native_port"),
-        _clickhouse_secret_env("CLICKHOUSE_USER", "user"),
-        _clickhouse_secret_env("CLICKHOUSE_PASSWORD", "password"),
-        _clickhouse_secret_env("CLICKHOUSE_DB", "database"),
         _SAML2AWS_ENV,
     ]
     if java_opts:
@@ -356,6 +355,18 @@ def _activate_standby_properties() -> str:
     shutil.copy(src_path, dest_path)
     shutil.copy("/clickhouse.sql", "/tmp/clickhouse.sql")
     os.environ["PORTAL_HOME"] = "/tmp"
+
+    # Point the derive-tables clickhouse client at the standby database.
+    # rebuild_derived_tables.py reads CLICKHOUSE_* env vars; these previously came
+    # from a fixed k8s secret (hackathon-clickhouse-secret) whose single database
+    # value ignored the blue/green color, so derived tables could be built in the
+    # live database instead of the standby one.
+    ch_props = _load_properties(CLICKHOUSE_CONFIG_FILE)
+    os.environ["CLICKHOUSE_HOST"] = ch_props["clickhouse_server_host_name"]
+    os.environ["CLICKHOUSE_NATIVE_PORT"] = ch_props["clickhouse_server_port"]
+    os.environ["CLICKHOUSE_USER"] = ch_props["clickhouse_server_username"]
+    os.environ["CLICKHOUSE_PASSWORD"] = ch_props["clickhouse_server_password"]
+    os.environ["CLICKHOUSE_DB"] = ch_props[f"clickhouse_{standby_color}_database_name"]
     logging.info("Activated %s application.properties (live=%s, standby=%s) -> %s", standby_color, live_color, standby_color, dest_path)
     return standby_color
 
@@ -498,7 +509,8 @@ def import_public_hackathon():
     def create_derived_tables_in_standby_database():
         _activate_standby_properties()
         rebuild = _run_and_stream(
-            [sys.executable, IMPORT_SCRIPT_PATH, "derive-tables"],
+            [sys.executable, IMPORT_SCRIPT_PATH, "derive-tables",
+             "--derived-table-sql", "/tmp/clickhouse.sql"],
         )
         if rebuild.returncode != 0:
             raise Exception(f"Derived table rebuild failed (exit {rebuild.returncode})")

--- a/dags/import_public_hackathon.py
+++ b/dags/import_public_hackathon.py
@@ -114,12 +114,16 @@ IMPORTER = "public"
 CREDS_DIR = "/data/portal-cron/pipelines-credentials"
 CREDS_SECRET_NAME = "pipelines-credentials"
 CREDS_VOLUME_NAME = "pipelines-credentials"
-APP_PROPERTIES_SECRET_BLUE  = "containerized-properties-blue"
-APP_PROPERTIES_SECRET_GREEN = "containerized-properties-green"
-APP_PROPERTIES_PATH         = "/application.properties"
 GET_DB_IN_PROD_SCRIPT       = f"{SCRIPTS_DIR}/get_database_currently_in_production.sh"
-COLOR_SWAP_CONFIG_FILE = f"{CREDS_DIR}/public-db-color-swap-config.yaml"
-CLICKHOUSE_CONFIG_FILE = f"{CREDS_DIR}/manage_public_clickhouse_database_update_tools.properties"
+
+# Both environments' config files live in the pipelines-credentials secret under
+# env-prefixed keys; params.database ('containerized' or 'public') selects the set.
+MANAGE_PROPS_TEMPLATE = f"{CREDS_DIR}/{{{{ params.database }}}}.manage.properties"
+COLOR_SWAP_TEMPLATE   = f"{CREDS_DIR}/{{{{ params.database }}}}.color-swap.yaml"
+
+
+def _manage_props_path(env: str) -> str:
+    return f"{CREDS_DIR}/{env}.manage.properties"
 
 S3_MOUNT_PATH = "/mnt/s3-data"
 S3_PVC_CLAIM_NAME = "databricks-s3-pvc"
@@ -297,6 +301,9 @@ def _make_cbioportal_pod_override(java_opts: str | None = None, memory_request: 
     if java_opts:
         env.append(k8s.V1EnvVar(name="JAVA_OPTS", value=java_opts))
 
+    # application.properties, clickhouse.sql and manage properties for both
+    # environments come from the pipelines-credentials secret (mounted at
+    # CREDS_DIR) under env-prefixed keys — no extra per-environment mounts.
     return _pod_override(
         image=K8S_IMAGE_VALIDATE,
         env=env,
@@ -304,40 +311,6 @@ def _make_cbioportal_pod_override(java_opts: str | None = None, memory_request: 
             requests={"memory": memory_request, "cpu": "1"},
             limits={"memory": memory_limit},
         ),
-        extra_volumes=[
-            k8s.V1Volume(
-                name="app-properties-blue",
-                secret=k8s.V1SecretVolumeSource(secret_name=APP_PROPERTIES_SECRET_BLUE),
-            ),
-            k8s.V1Volume(
-                name="app-properties-green",
-                secret=k8s.V1SecretVolumeSource(secret_name=APP_PROPERTIES_SECRET_GREEN),
-            ),
-            k8s.V1Volume(
-                name="clickhouse-sql",
-                secret=k8s.V1SecretVolumeSource(secret_name="hackathon-clickhouse-sql"),
-            ),
-        ],
-        extra_mounts=[
-            k8s.V1VolumeMount(
-                name="app-properties-blue",
-                mount_path=f"{APP_PROPERTIES_PATH}.blue",
-                sub_path="application.properties",
-                read_only=True,
-            ),
-            k8s.V1VolumeMount(
-                name="app-properties-green",
-                mount_path=f"{APP_PROPERTIES_PATH}.green",
-                sub_path="application.properties",
-                read_only=True,
-            ),
-            k8s.V1VolumeMount(
-                name="clickhouse-sql",
-                mount_path="/clickhouse.sql",
-                sub_path="clickhouse.sql",
-                read_only=True,
-            ),
-        ],
     )
 
 
@@ -354,8 +327,10 @@ _DEFAULT_ARGS = {
 }
 
 
-def _activate_standby_properties() -> str:
-    """Determine the standby color and copy the matching application.properties into place.
+def _activate_standby_properties(env: str) -> str:
+    """Determine the standby color for the given environment ('containerized' or
+    'public') and copy the matching application.properties + derived-table SQL into
+    /tmp, pointing PORTAL_HOME and the CLICKHOUSE_* env vars at the standby database.
 
     Calls get_database_currently_in_production.sh from the cbioportal-core scripts
     (available at /scripts/clickhouse_import_support/ in the core image).
@@ -363,34 +338,37 @@ def _activate_standby_properties() -> str:
     Returns the standby color string ('blue' or 'green').
     """
     import shutil
+    manage_props_path = _manage_props_path(env)
     # The core image has cbioportal-core scripts at /scripts/clickhouse_import_support/
     result = _run_and_stream([
         "/scripts/clickhouse_import_support/get_database_currently_in_production.sh",
-        CLICKHOUSE_CONFIG_FILE,
+        manage_props_path,
     ])
     if result.returncode != 0:
         raise Exception(f"get_database_currently_in_production failed (exit {result.returncode})")
     live_db       = result.stdout.strip()  # e.g. "cbioportal_public_blue : current production database"
     live_color    = "blue" if "blue" in live_db else "green"
     standby_color = "green" if live_color == "blue" else "blue"
-    src_path = f"{APP_PROPERTIES_PATH}.{standby_color}"
+    src_path = f"{CREDS_DIR}/{env}.application.properties.{standby_color}"
     dest_path = "/tmp/application.properties"
     shutil.copy(src_path, dest_path)
-    shutil.copy("/clickhouse.sql", "/tmp/clickhouse.sql")
+    shutil.copy(f"{CREDS_DIR}/{env}.clickhouse.sql", "/tmp/clickhouse.sql")
     os.environ["PORTAL_HOME"] = "/tmp"
 
     # Point the derive-tables clickhouse client at the standby database.
-    # rebuild_derived_tables.py reads CLICKHOUSE_* env vars; these previously came
-    # from a fixed k8s secret (hackathon-clickhouse-secret) whose single database
-    # value ignored the blue/green color, so derived tables could be built in the
-    # live database instead of the standby one.
-    ch_props = _load_properties(CLICKHOUSE_CONFIG_FILE)
+    # rebuild_derived_tables.py reads CLICKHOUSE_* env vars; a fixed value would
+    # ignore the blue/green color, so derive them from the manage properties here.
+    ch_props = _load_properties(manage_props_path)
+    standby_db = ch_props[f"clickhouse_{standby_color}_database_name"]
     os.environ["CLICKHOUSE_HOST"] = ch_props["clickhouse_server_host_name"]
     os.environ["CLICKHOUSE_NATIVE_PORT"] = ch_props["clickhouse_server_port"]
     os.environ["CLICKHOUSE_USER"] = ch_props["clickhouse_server_username"]
     os.environ["CLICKHOUSE_PASSWORD"] = ch_props["clickhouse_server_password"]
-    os.environ["CLICKHOUSE_DB"] = ch_props[f"clickhouse_{standby_color}_database_name"]
-    logging.info("Activated %s application.properties (live=%s, standby=%s) -> %s", standby_color, live_color, standby_color, dest_path)
+    os.environ["CLICKHOUSE_DB"] = standby_db
+    logging.info(
+        "=== TARGET ENVIRONMENT: %s | live=%s standby=%s | standby db=%s ===",
+        env, live_color, standby_color, standby_db,
+    )
     return standby_color
 
 
@@ -404,10 +382,15 @@ def _activate_standby_properties() -> str:
     render_template_as_native_obj=True,
     params={
         "database": Param(
-            "public",
+            "containerized",
             type="string",
             enum=["containerized", "public"],
-            description="Which database environment to import into.",
+            description=(
+                "Which database environment to import into. 'containerized' targets the "
+                "test databases and containerized.cbioportal.org; 'public' targets the "
+                "REAL public databases — its traffic swap moves www.cbioportal.org. "
+                "Defaults to the safe environment; select 'public' deliberately."
+            ),
             title="Database",
         ),
         "cancer_study_ids": Param(
@@ -469,8 +452,8 @@ def import_public_hackathon():
         bash_command="unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE; " + _script(
             "airflow-verify-management.sh",
             SCRIPTS_DIR,
-            CLICKHOUSE_CONFIG_FILE,
-            COLOR_SWAP_CONFIG_FILE,
+            MANAGE_PROPS_TEMPLATE,
+            COLOR_SWAP_TEMPLATE,
         ),
         executor_config=_POD_OVERRIDE,
     )
@@ -481,7 +464,7 @@ def import_public_hackathon():
             "airflow-clone-db.sh",
             IMPORTER,
             SCRIPTS_DIR,
-            CLICKHOUSE_CONFIG_FILE,
+            MANAGE_PROPS_TEMPLATE,
         ),
         executor_config=_POD_OVERRIDE,
     )
@@ -524,7 +507,7 @@ def import_public_hackathon():
     @task(executor_config=_POD_OVERRIDE_IMPORT, trigger_rule=TriggerRule.NONE_FAILED)
     def import_into_standby_database(valid_studies: list[str], params: dict | None = None):
         _skip_if_requested("import_into_standby_database", params)
-        _activate_standby_properties()
+        _activate_standby_properties(params["database"])
         if not valid_studies:
             logging.info("No valid studies to import — exiting.")
             return
@@ -553,7 +536,7 @@ def import_public_hackathon():
     @task(executor_config=_POD_OVERRIDE_IMPORT, trigger_rule=TriggerRule.NONE_FAILED)
     def create_derived_tables_in_standby_database(params: dict | None = None):
         _skip_if_requested("create_derived_tables_in_standby_database", params)
-        _activate_standby_properties()
+        _activate_standby_properties(params["database"])
         rebuild = _run_and_stream(
             [sys.executable, IMPORT_SCRIPT_PATH, "derive-tables",
              "--derived-table-sql", "/tmp/clickhouse.sql"],
@@ -567,15 +550,15 @@ def import_public_hackathon():
         + "unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE; " + _script(
             "airflow-transfer-deployment.sh",
             SCRIPTS_DIR,
-            CLICKHOUSE_CONFIG_FILE,
-            COLOR_SWAP_CONFIG_FILE,
+            MANAGE_PROPS_TEMPLATE,
+            COLOR_SWAP_TEMPLATE,
         ),
         executor_config=_POD_OVERRIDE,
         trigger_rule=TriggerRule.NONE_FAILED,
     )
 
     @task(executor_config=_POD_OVERRIDE, trigger_rule=TriggerRule.NONE_FAILED)
-    def finalize_import_state(ti=None):
+    def finalize_import_state(ti=None, params: dict | None = None):
         """Set the management DB end state: 'complete' only if production traffic was
         actually swapped, otherwise 'abandoned' so the next run re-clones standby."""
         transfer_state = ti.get_dagrun().get_task_instance("transfer_deployment_color").state
@@ -587,7 +570,7 @@ def import_public_hackathon():
         _run_and_stream(
             ["bash", "-c", _script(
                 "set_update_process_state.sh",
-                CLICKHOUSE_CONFIG_FILE,
+                _manage_props_path(params["database"]),
                 state,
                 source_automation_env=True,
             )],
@@ -598,7 +581,7 @@ def import_public_hackathon():
         task_id="set_import_abandoned",
         bash_command=_script(
             "set_update_process_state.sh",
-            CLICKHOUSE_CONFIG_FILE,
+            MANAGE_PROPS_TEMPLATE,
             "abandoned",
             source_automation_env=True,
         ),


### PR DESCRIPTION
Two fixes to the `import_public_hackathon` DAG's `create_derived_tables_in_standby_database` task, needed before pointing the DAG at a real blue/green public database:

**1. Color-aware derive-tables target.** `rebuild_derived_tables.py` connects via `CLICKHOUSE_*` env vars, which were injected from the `hackathon-clickhouse-secret` k8s secret — a single fixed `database` value that ignores the blue/green standby color. Import writes the standby database (via `application.properties.{color}`), but derived tables were rebuilt in whatever database the secret named — wrong target half the time under real blue/green alternation. Now `_activate_standby_properties()` sets the `CLICKHOUSE_*` env vars from `manage_public_clickhouse_database_update_tools.properties` (`clickhouse_{blue,green}_database_name` selected by standby color) — the same config file the verify/clone/transfer tasks already use, so there is one source of truth. The `hackathon-clickhouse-secret` env injection is removed; the secret is no longer referenced by the DAG.

**2. Explicit derived-table SQL path.** The DAG stages the SQL at `/tmp/clickhouse.sql`, but `rebuild_derived_tables.py` falls back to `$PORTAL_HOME/populate_derived_tables.sql` when no path is given. Pass `--derived-table-sql /tmp/clickhouse.sql` explicitly to remove the filename coupling.

Known remaining caveat (unchanged by this PR): `clickhouse_server_additional_args` (`?secure=true...`) is not forwarded to the `clickhouse client` invocation; TLS behavior on native port 9440 is the same as before.